### PR TITLE
Derive declaration_version_id as its own unit (evaluation prerequisite)

### DIFF
--- a/build/declaration_version.py
+++ b/build/declaration_version.py
@@ -1,0 +1,228 @@
+"""Derive the ``declaration_version_id`` — the identity of a set of declarations.
+
+Three identities run through the release model (data-architecture.md §4.6), and they are
+deliberately distinct:
+
+    declaration_version_id = source_git_sha + source_content_digest + evaluator_version
+    observation_snapshot_id = digest of the normalized observation content, and nothing else
+    release_id             = declaration_version_id + observation_snapshot_id
+                             + reconciliation_policy_version
+
+This module owns the first. It answers "which declarations, evaluated by which evaluator" —
+the identity that ``registry.axis_assessments``, ``evaluation.product_adoption_measurements``
+and ``evaluation.adoption_reconciliation`` all key on. It says nothing about measurements
+(that is the observation snapshot) and nothing about a published release (that is the release
+id, which only exists once a declaration/observation pair has passed reconciliation).
+
+## What the digest covers, and what it must not
+
+``source_content_digest`` is a canonical hash over the DECLARATION tree alone — the
+curator-authored records that ``build.validate.load_sources`` parses: products,
+organizations, categories, scores, rubrics, the taxonomy, and the long-tail registry seeds.
+Those are exactly the inputs a reconciliation adjudicates a measurement against.
+
+Three exclusions are deliberate, because including any of them would make the id move for a
+reason that is not a change in the declarations:
+
+  * The frozen ``sources/snapshots/long_tail.json`` warehouse sample. It is a hand-synced
+    point-in-time count, not a scoring declaration; a re-sync must not mint a new declaration
+    version. ``load_sources`` exposes it under ``long_tail``; ``DECLARATION_KEYS`` omits it.
+  * The derived score projections (``overall_score``, ``tier``, ``maturity``, ``mature``).
+    Those are computed by the evaluator from the declared axis values, so folding them in
+    would double-count the evaluator — whose contribution is already named separately by
+    ``evaluator_version`` — and would make ``source_content_digest`` change when the scoring
+    formula changes, breaking the clean three-way split. ``load_sources`` carries only the
+    RECORDED axis values under ``scores``; the derived numbers live downstream in
+    ``build.serialize`` and never enter this digest.
+  * The routing policy (``sources/signal_routing.yaml``). It publishes under its own
+    ``routing_policy_version`` (see ``test_serialize_routing``) and is applied in the
+    evaluation layer, not declared per product; it is not a scoring declaration.
+
+## No frozen receipt, on purpose
+
+Unlike ``warehouse/audits/source_runs.json``, this module writes no committed receipt. A
+``declaration_version_id`` embeds ``source_git_sha``, and no commit can record its own SHA —
+a receipt committed alongside the value would forever name its own parent. §12.1 resolves
+this by DERIVING the id at release time from the resolved SHA, which is what this module does:
+it is a pure computation the release builder (and any consumer keying a candidate table) calls,
+not a stored constant. ``source_content_digest`` alone is git-SHA-independent and reproducible,
+but freezing it would demand a regenerate-and-gate step on every score edit; the tests pin the
+canonicalization's PROPERTIES (determinism, order-invariance, the digested key-set) instead of
+a brittle golden value.
+
+Usage:
+    uv run python -m build.declaration_version            # print the components at HEAD
+    uv run python -m build.declaration_version --json     # same, machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+from build.validate import load_sources
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Bumped when the digested key-set, the serialization, or the id composition changes, so a
+# value computed under an older rule cannot silently pass for a current one.
+CANONICALIZATION_VERSION = 1
+
+# The repository-owned evaluator is Phase 6 (docs/architecture/migration-status.md); it does
+# not exist yet. Until it lands, the evaluator component is a declared sentinel rather than a
+# real version, so a ``declaration_version_id`` is well-formed and forward-compatible today and
+# only its evaluator component moves when Phase 6 ships. It is NOT the empty string: an absent
+# evaluator is a deliberate state ("scores are curator-recorded, not machine-derived"), and the
+# sentinel records that rather than leaving a field that reads as "unset".
+EVALUATOR_VERSION = "v0-no-repo-evaluator"
+
+# The declaration subtrees of ``load_sources`` that the digest covers. This is the whole of
+# ``load_sources`` EXCEPT ``long_tail`` (the frozen warehouse sample). Kept explicit, and gated
+# by ``test_declaration_keys_cover_every_declaration_subtree``, so a newly added declaration
+# directory cannot slip out of the identity unnoticed.
+DECLARATION_KEYS: tuple[str, ...] = (
+    "organizations",
+    "categories",
+    "rubrics",
+    "products",
+    "scores",
+    "taxonomy",
+    "registry",
+)
+
+# Everything ``load_sources`` may return that is deliberately NOT a declaration.
+NON_DECLARATION_KEYS: frozenset[str] = frozenset({"long_tail"})
+
+
+def canonical_json(obj: object) -> str:
+    """The one canonical serialization every digest here is taken over.
+
+    Canonicalization rule (data-architecture.md §4.7), version ``CANONICALIZATION_VERSION``:
+
+      * format: JSON, UTF-8, no insignificant whitespace (``separators=(",", ":")``);
+      * key ordering: every mapping sorted by key (``sort_keys=True``), so a curator
+        reordering a YAML file produces no change;
+      * strings: preserved verbatim, not ASCII-escaped (``ensure_ascii=False``);
+      * dates/other scalars: rendered by ``str`` (``default=str``), so a YAML ``date`` becomes
+        its ISO ``YYYY-MM-DD`` text deterministically rather than a Python object;
+      * null: JSON ``null``.
+    """
+    return json.dumps(
+        obj, sort_keys=True, ensure_ascii=False, separators=(",", ":"), default=str
+    )
+
+
+def declaration_content(root: Path | None = None) -> dict:
+    """The declaration tree the digest is taken over: ``load_sources`` minus non-declarations.
+
+    Raises if ``load_sources`` stops exposing a declared key, so the digest can never quietly
+    narrow to a subset of the declarations.
+    """
+    sources = load_sources(root or ROOT)
+    missing = [k for k in DECLARATION_KEYS if k not in sources]
+    if missing:
+        raise KeyError(f"load_sources is missing declaration keys: {sorted(missing)}")
+    return {k: sources[k] for k in DECLARATION_KEYS}
+
+
+def source_content_digest(root: Path | None = None) -> str:
+    """sha256 over the canonicalized declaration tree. Git-SHA-independent and reproducible."""
+    payload = canonical_json(declaration_content(root))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def resolve_git_sha(root: Path | None = None) -> str:
+    """The exact commit the declarations are read from (§12.1 step 1)."""
+    result = subprocess.run(
+        ["git", "-C", str(root or ROOT), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def declaration_paths_are_clean(root: Path | None = None) -> bool:
+    """True when no declaration file has uncommitted changes.
+
+    A ``declaration_version_id`` pairs the working-tree digest with ``HEAD``'s SHA. When a
+    declaration file is dirty the two describe different states, so the derived id is not
+    reproducible from the SHA alone. The CLI surfaces this rather than emitting a misleading id.
+    """
+    base = root or ROOT
+    result = subprocess.run(
+        ["git", "-C", str(base), "status", "--porcelain", "--", "sources/"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip() == ""
+
+
+def declaration_version_id(
+    source_git_sha: str,
+    content_digest: str,
+    evaluator_version: str = EVALUATOR_VERSION,
+) -> str:
+    """Compose the three components into one opaque, reproducible identity.
+
+    A hash rather than a concatenation so the id is fixed-width and unambiguous; the human-
+    readable ``source_git_sha`` is carried alongside it on the tables that key on this
+    (``registry.axis_assessments``), never parsed back out of the id. The canonicalization
+    version is folded in so a rule change cannot collide with a value minted under the old rule.
+    """
+    payload = canonical_json(
+        {
+            "canonicalization_version": CANONICALIZATION_VERSION,
+            "evaluator_version": evaluator_version,
+            "source_content_digest": content_digest,
+            "source_git_sha": source_git_sha,
+        }
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def resolve(root: Path | None = None) -> dict:
+    """Derive every component and the id at ``HEAD`` over the working-tree declarations."""
+    base = root or ROOT
+    digest = source_content_digest(base)
+    git_sha = resolve_git_sha(base)
+    return {
+        "canonicalization_version": CANONICALIZATION_VERSION,
+        "evaluator_version": EVALUATOR_VERSION,
+        "source_git_sha": git_sha,
+        "source_content_digest": digest,
+        "declaration_version_id": declaration_version_id(git_sha, digest),
+        "declarations_clean": declaration_paths_are_clean(base),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit the components as JSON")
+    args = parser.parse_args()
+
+    info = resolve()
+    if args.json:
+        print(json.dumps(info, indent=2))
+        return 0
+
+    print(f"canonicalization_version  {info['canonicalization_version']}")
+    print(f"evaluator_version         {info['evaluator_version']}")
+    print(f"source_git_sha            {info['source_git_sha']}")
+    print(f"source_content_digest     {info['source_content_digest']}")
+    print(f"declaration_version_id    {info['declaration_version_id']}")
+    if not info["declarations_clean"]:
+        print(
+            "\nWARNING: sources/ has uncommitted changes. The digest is taken over the working\n"
+            "tree but source_git_sha is HEAD, so this declaration_version_id is not reproducible\n"
+            "from that SHA. Commit the declarations first."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/declaration_version.py
+++ b/build/declaration_version.py
@@ -1,6 +1,6 @@
 """Derive the ``declaration_version_id`` — the identity of a set of declarations.
 
-Three identities run through the release model (data-architecture.md §4.6), and they are
+Three identities run through the release model (data-architecture.md §4.5), and they are
 deliberately distinct:
 
     declaration_version_id = source_git_sha + source_content_digest + evaluator_version
@@ -14,29 +14,32 @@ and ``evaluation.adoption_reconciliation`` all key on. It says nothing about mea
 (that is the observation snapshot) and nothing about a published release (that is the release
 id, which only exists once a declaration/observation pair has passed reconciliation).
 
-## What the digest covers, and what it must not
+## What the digest covers: every authoritative declaration input, gated
 
-``source_content_digest`` is a canonical hash over the DECLARATION tree alone — the
-curator-authored records that ``build.validate.load_sources`` parses: products,
-organizations, categories, scores, rubrics, the taxonomy, and the long-tail registry seeds.
-Those are exactly the inputs a reconciliation adjudicates a measurement against.
+``source_content_digest`` is a canonical hash over the DECLARATION inputs of ``sources/`` — the
+curator-authored records whose change should mint a new declaration version. Every top-level
+entry of ``sources/`` is classified into exactly one of three buckets below, and
+``test_source_inventory_is_fully_classified`` walks the directory and fails if a new entry is
+unclassified. The gate protects the whole ``sources/`` inventory, not just what
+``build.validate.load_sources`` happens to parse — ``evidence_policy.yaml`` and
+``verification_queue.yaml`` are authoritative declaration inputs that ``load_sources`` does not
+return, and both are folded in here.
 
-Three exclusions are deliberate, because including any of them would make the id move for a
-reason that is not a change in the declarations:
+  * ``DECLARATION_INPUTS`` — content IS the declaration; folded into the digest.
+  * ``POLICY_INPUTS`` — excluded from ``declaration_version_id`` because the input carries its
+    OWN version and is applied in a downstream layer, not in the declaration compile. The
+    exclusion is a redirection, not a gap: each names the downstream identity its policy version
+    must bind into. ``signal_routing.yaml`` is the case — it publishes under
+    ``routing_policy_version`` (see ``test_serialize_routing``) and is applied in evaluation, so
+    its version binds into ``evaluation.adoption_reconciliation`` / ``release_id`` when those are
+    built, never into this identity.
+  * ``NON_DECLARATION_INPUTS`` — not a scoring declaration at all (the frozen long-tail
+    warehouse sample); excluded with a reason.
 
-  * The frozen ``sources/snapshots/long_tail.json`` warehouse sample. It is a hand-synced
-    point-in-time count, not a scoring declaration; a re-sync must not mint a new declaration
-    version. ``load_sources`` exposes it under ``long_tail``; ``DECLARATION_KEYS`` omits it.
-  * The derived score projections (``overall_score``, ``tier``, ``maturity``, ``mature``).
-    Those are computed by the evaluator from the declared axis values, so folding them in
-    would double-count the evaluator — whose contribution is already named separately by
-    ``evaluator_version`` — and would make ``source_content_digest`` change when the scoring
-    formula changes, breaking the clean three-way split. ``load_sources`` carries only the
-    RECORDED axis values under ``scores``; the derived numbers live downstream in
-    ``build.serialize`` and never enter this digest.
-  * The routing policy (``sources/signal_routing.yaml``). It publishes under its own
-    ``routing_policy_version`` (see ``test_serialize_routing``) and is applied in the
-    evaluation layer, not declared per product; it is not a scoring declaration.
+The derived score projections (``overall_score``, ``tier``, ``maturity``, ``mature``) are also
+excluded, by construction rather than by name: they are computed by ``build.serialize`` from the
+declared axis values and never live in ``sources/``. Folding them in would double-count the
+evaluator, whose contribution is already named by ``evaluator_version``.
 
 ## No frozen receipt, on purpose
 
@@ -47,27 +50,35 @@ this by DERIVING the id at release time from the resolved SHA, which is what thi
 it is a pure computation the release builder (and any consumer keying a candidate table) calls,
 not a stored constant. ``source_content_digest`` alone is git-SHA-independent and reproducible,
 but freezing it would demand a regenerate-and-gate step on every score edit; the tests pin the
-canonicalization's PROPERTIES (determinism, order-invariance, the digested key-set) instead of
-a brittle golden value.
+canonicalization's PROPERTIES (determinism, order-invariance, the digested inventory, type
+rejection) instead of a brittle golden value.
+
+Because the digest is taken over the working tree while ``source_git_sha`` is ``HEAD``, a dirty
+``sources/`` tree yields an id that no SHA can reproduce. ``resolve`` therefore FAILS CLOSED on
+uncommitted declarations; a diagnostic value over a dirty tree requires an explicit opt-in
+(``allow_dirty`` / CLI ``--allow-dirty``).
 
 Usage:
-    uv run python -m build.declaration_version            # print the components at HEAD
-    uv run python -m build.declaration_version --json     # same, machine-readable
+    uv run python -m build.declaration_version                # print the components at HEAD
+    uv run python -m build.declaration_version --json         # same, machine-readable
+    uv run python -m build.declaration_version --allow-dirty  # diagnostic over a dirty tree
 """
 
 from __future__ import annotations
 
 import argparse
+import datetime
 import hashlib
 import json
 import subprocess
+import sys
 from pathlib import Path
 
-from build.validate import load_sources
+import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 
-# Bumped when the digested key-set, the serialization, or the id composition changes, so a
+# Bumped when the classified inventory, the serialization, or the id composition changes, so a
 # value computed under an older rule cannot silently pass for a current one.
 CANONICALIZATION_VERSION = 1
 
@@ -79,57 +90,138 @@ CANONICALIZATION_VERSION = 1
 # sentinel records that rather than leaving a field that reads as "unset".
 EVALUATOR_VERSION = "v0-no-repo-evaluator"
 
-# The declaration subtrees of ``load_sources`` that the digest covers. This is the whole of
-# ``load_sources`` EXCEPT ``long_tail`` (the frozen warehouse sample). Kept explicit, and gated
-# by ``test_declaration_keys_cover_every_declaration_subtree``, so a newly added declaration
-# directory cannot slip out of the identity unnoticed.
-DECLARATION_KEYS: tuple[str, ...] = (
-    "organizations",
+# --- the classified sources/ inventory -------------------------------------------
+# Every top-level entry of sources/ is in exactly one of the three collections below;
+# test_source_inventory_is_fully_classified fails if that stops being true.
+
+# Declaration inputs — their content IS the declaration; a change mints a new
+# declaration_version_id. Directories are read file-by-file; a .txt allowlist is reduced to its
+# semantic set of entries (matching the repo's own parse in tests/test_digest_ratchet.py).
+DECLARATION_INPUTS: tuple[str, ...] = (
+    "allowlists",
     "categories",
-    "rubrics",
+    "evidence_policy.yaml",
+    "organizations",
     "products",
-    "scores",
-    "taxonomy",
     "registry",
+    "rubrics",
+    "scores",
+    "taxonomy.yaml",
+    "verification_queue.yaml",
 )
 
-# Everything ``load_sources`` may return that is deliberately NOT a declaration.
-NON_DECLARATION_KEYS: frozenset[str] = frozenset({"long_tail"})
+# Policy inputs — excluded from declaration_version_id because they carry their OWN version and
+# are applied in a downstream layer, not in the declaration compile. Each MUST have its policy
+# version bound into the downstream identity named here when that identity is built.
+POLICY_INPUTS: dict[str, dict[str, str]] = {
+    "signal_routing.yaml": {
+        "policy_version": "routing_policy_version",
+        "bound_into": "evaluation.adoption_reconciliation / release_id",
+        "reason": (
+            "routing is applied in the evaluation layer, not declared per product; it "
+            "publishes under routing_policy_version (see test_serialize_routing)."
+        ),
+    },
+}
+
+# Non-declaration inputs — authored nowhere as a scoring declaration.
+NON_DECLARATION_INPUTS: dict[str, str] = {
+    "snapshots": (
+        "frozen point-in-time warehouse sample (long_tail.json), hand-synced; a re-sync is "
+        "not a change in the declarations."
+    ),
+}
+
+
+def _canonical_default(value: object) -> str:
+    """Serialize the one non-JSON-native type the declarations use (dates); reject the rest.
+
+    ``json.dumps`` calls this only for values it cannot serialize itself. A YAML ``!!set`` or an
+    unexpected object would otherwise slip through a permissive ``str`` fallback and become an
+    implementation-dependent string — a silently non-reproducible identity. Only dates are
+    accepted (rendered ISO); everything else raises.
+    """
+    if isinstance(value, (datetime.date, datetime.datetime)):
+        return value.isoformat()
+    raise TypeError(
+        f"canonical_json cannot serialize a value of type {type(value).__name__!r}; "
+        "only JSON scalars, lists, dicts, and dates are supported."
+    )
 
 
 def canonical_json(obj: object) -> str:
     """The one canonical serialization every digest here is taken over.
 
-    Canonicalization rule (data-architecture.md §4.7), version ``CANONICALIZATION_VERSION``:
+    Canonicalization rule (data-architecture.md §4.5), version ``CANONICALIZATION_VERSION``:
 
       * format: JSON, UTF-8, no insignificant whitespace (``separators=(",", ":")``);
       * key ordering: every mapping sorted by key (``sort_keys=True``), so a curator
         reordering a YAML file produces no change;
       * strings: preserved verbatim, not ASCII-escaped (``ensure_ascii=False``);
-      * dates/other scalars: rendered by ``str`` (``default=str``), so a YAML ``date`` becomes
-        its ISO ``YYYY-MM-DD`` text deterministically rather than a Python object;
-      * null: JSON ``null``.
+      * dates: rendered as ISO text; null as JSON ``null``;
+      * numbers: finite only — ``allow_nan=False`` rejects ``NaN``/``Infinity``, which are not
+        valid JSON and do not round-trip reproducibly;
+      * types: only JSON scalars, lists, dicts, and dates; any other type is rejected rather
+        than coerced (``_canonical_default``).
     """
     return json.dumps(
-        obj, sort_keys=True, ensure_ascii=False, separators=(",", ":"), default=str
+        obj,
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        default=_canonical_default,
+        allow_nan=False,
     )
 
 
-def declaration_content(root: Path | None = None) -> dict:
-    """The declaration tree the digest is taken over: ``load_sources`` minus non-declarations.
+def _read_declaration_input(path: Path) -> object:
+    """Read one declaration input into its canonical, format-invariant content.
 
-    Raises if ``load_sources`` stops exposing a declared key, so the digest can never quietly
-    narrow to a subset of the declarations.
+    YAML is parsed (dropping comments and key order); a ``.txt`` allowlist is reduced to the
+    sorted set of its non-comment, non-blank lines, exactly as the repo's own gate reads it, so
+    a comment edit does not mint a new version but an added or removed entry does.
     """
-    sources = load_sources(root or ROOT)
-    missing = [k for k in DECLARATION_KEYS if k not in sources]
-    if missing:
-        raise KeyError(f"load_sources is missing declaration keys: {sorted(missing)}")
-    return {k: sources[k] for k in DECLARATION_KEYS}
+    if path.is_dir():
+        out: dict[str, object] = {}
+        for child in sorted(path.iterdir()):
+            if not child.is_file():
+                raise ValueError(f"unexpected non-file in declaration input: {child}")
+            if child.suffix in (".yaml", ".yml"):
+                out[child.name] = yaml.safe_load(child.read_text(encoding="utf-8"))
+            elif child.suffix == ".txt":
+                out[child.name] = sorted(
+                    {
+                        line.strip()
+                        for line in child.read_text(encoding="utf-8").splitlines()
+                        if line.strip() and not line.startswith("#")
+                    }
+                )
+            else:
+                raise ValueError(f"unclassified file type in declaration input: {child}")
+        return out
+    if path.suffix in (".yaml", ".yml"):
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
+    raise ValueError(f"unsupported declaration input file: {path}")
+
+
+def declaration_content(root: Path | None = None) -> dict:
+    """The declaration tree the digest is taken over: every ``DECLARATION_INPUTS`` entry.
+
+    Raises if a declared input is missing from disk, so the digest can never quietly narrow to a
+    subset of the declarations.
+    """
+    base = (root or ROOT) / "sources"
+    content: dict[str, object] = {}
+    for name in DECLARATION_INPUTS:
+        path = base / name
+        if not path.exists():
+            raise FileNotFoundError(f"declaration input missing: sources/{name}")
+        content[name] = _read_declaration_input(path)
+    return content
 
 
 def source_content_digest(root: Path | None = None) -> str:
-    """sha256 over the canonicalized declaration tree. Git-SHA-independent and reproducible."""
+    """sha256 over the canonicalized declaration inputs. Git-SHA-independent and reproducible."""
     payload = canonical_json(declaration_content(root))
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
@@ -150,11 +242,10 @@ def declaration_paths_are_clean(root: Path | None = None) -> bool:
 
     A ``declaration_version_id`` pairs the working-tree digest with ``HEAD``'s SHA. When a
     declaration file is dirty the two describe different states, so the derived id is not
-    reproducible from the SHA alone. The CLI surfaces this rather than emitting a misleading id.
+    reproducible from the SHA alone.
     """
-    base = root or ROOT
     result = subprocess.run(
-        ["git", "-C", str(base), "status", "--porcelain", "--", "sources/"],
+        ["git", "-C", str(root or ROOT), "status", "--porcelain", "--", "sources/"],
         capture_output=True,
         text=True,
         check=True,
@@ -185,9 +276,25 @@ def declaration_version_id(
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
-def resolve(root: Path | None = None) -> dict:
-    """Derive every component and the id at ``HEAD`` over the working-tree declarations."""
+class DirtyDeclarationsError(RuntimeError):
+    """Raised when an id is requested over a working tree with uncommitted declarations."""
+
+
+def resolve(root: Path | None = None, allow_dirty: bool = False) -> dict:
+    """Derive every component and the id at ``HEAD`` over the working-tree declarations.
+
+    Fails closed when ``sources/`` is dirty: the digest is over the working tree but the SHA is
+    ``HEAD``, so the pair is not reproducible. ``allow_dirty`` returns a diagnostic value anyway,
+    with ``declarations_clean`` recording the state.
+    """
     base = root or ROOT
+    clean = declaration_paths_are_clean(base)
+    if not clean and not allow_dirty:
+        raise DirtyDeclarationsError(
+            "sources/ has uncommitted changes: the working-tree digest would pair with HEAD's "
+            "SHA and would not be reproducible from it. Commit the declarations first, or pass "
+            "allow_dirty=True (CLI --allow-dirty) for a diagnostic-only value."
+        )
     digest = source_content_digest(base)
     git_sha = resolve_git_sha(base)
     return {
@@ -196,16 +303,26 @@ def resolve(root: Path | None = None) -> dict:
         "source_git_sha": git_sha,
         "source_content_digest": digest,
         "declaration_version_id": declaration_version_id(git_sha, digest),
-        "declarations_clean": declaration_paths_are_clean(base),
+        "declarations_clean": clean,
     }
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="emit the components as JSON")
+    parser.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="emit a diagnostic id over an uncommitted sources/ tree (not reproducible)",
+    )
     args = parser.parse_args()
 
-    info = resolve()
+    try:
+        info = resolve(allow_dirty=args.allow_dirty)
+    except DirtyDeclarationsError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
     if args.json:
         print(json.dumps(info, indent=2))
         return 0
@@ -217,9 +334,9 @@ def main() -> int:
     print(f"declaration_version_id    {info['declaration_version_id']}")
     if not info["declarations_clean"]:
         print(
-            "\nWARNING: sources/ has uncommitted changes. The digest is taken over the working\n"
-            "tree but source_git_sha is HEAD, so this declaration_version_id is not reproducible\n"
-            "from that SHA. Commit the declarations first."
+            "\nWARNING: sources/ has uncommitted changes. This is a diagnostic value only — the\n"
+            "digest is over the working tree but source_git_sha is HEAD, so it is not\n"
+            "reproducible from that SHA."
         )
     return 0
 

--- a/build/declaration_version.py
+++ b/build/declaration_version.py
@@ -66,10 +66,13 @@ canonicalization's PROPERTIES (determinism, order-invariance, the digested inven
 rejection) instead of a brittle golden value.
 
 Because the digest and this identity code are both read from the working tree while
-``source_git_sha`` is ``HEAD``, a dirty TRACKED worktree — dirty declarations, or a dirty
-``build/declaration_version.py`` / future evaluator — yields an id that no commit can reproduce.
-``resolve`` therefore FAILS CLOSED unless the whole tracked worktree is clean; a diagnostic value
-over a dirty tree requires an explicit opt-in (``allow_dirty`` / CLI ``--allow-dirty``).
+``source_git_sha`` is ``HEAD``, a worktree that disagrees with ``HEAD`` yields an id no commit can
+reproduce. ``resolve`` therefore FAILS CLOSED on either kind of disagreement: a dirty TRACKED file
+anywhere (dirty declarations, or a dirty ``build/declaration_version.py`` / future evaluator), or
+an UNTRACKED file under ``sources/`` (a declaration the commit does not carry). The digest itself
+reads only tracked files, so an untracked file cannot enter it silently; the guard additionally
+refuses it so the mismatch surfaces rather than passing. A diagnostic value over a dirty tree
+requires an explicit opt-in (``allow_dirty`` / CLI ``--allow-dirty``).
 
 Usage:
     uv run python -m build.declaration_version                # print the components at HEAD
@@ -233,49 +236,64 @@ def canonical_json(obj: object) -> str:
     )
 
 
-def _read_declaration_input(path: Path) -> object:
-    """Read one declaration input into its canonical, format-invariant content.
+def _tracked_paths(root: Path, rel: str) -> list[str]:
+    """Repo-relative paths of the files git TRACKS at ``rel`` (a file or a directory).
+
+    The digest is taken over what git tracks, never over ``Path.iterdir()``: an untracked file
+    dropped into ``sources/`` must not be able to enter the digest while ``source_git_sha`` names
+    a commit that does not contain it. ``git ls-files`` lists tracked paths only, so an untracked
+    file is simply absent from the set.
+    """
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z", "--", rel],
+        capture_output=True,
+        check=True,
+    )
+    return [p for p in result.stdout.decode("utf-8").split("\0") if p]
+
+
+def _parse_declaration_file(path: Path) -> object:
+    """Parse one declaration file into its canonical, format-invariant content.
 
     YAML is parsed (dropping comments and key order); a ``.txt`` allowlist is reduced to the
     sorted set of its non-comment, non-blank lines, exactly as the repo's own gate reads it, so
     a comment edit does not mint a new version but an added or removed entry does.
     """
-    if path.is_dir():
-        out: dict[str, object] = {}
-        for child in sorted(path.iterdir()):
-            if not child.is_file():
-                raise ValueError(f"unexpected non-file in declaration input: {child}")
-            if child.suffix in (".yaml", ".yml"):
-                out[child.name] = yaml.safe_load(child.read_text(encoding="utf-8"))
-            elif child.suffix == ".txt":
-                out[child.name] = sorted(
-                    {
-                        line.strip()
-                        for line in child.read_text(encoding="utf-8").splitlines()
-                        if line.strip() and not line.startswith("#")
-                    }
-                )
-            else:
-                raise ValueError(f"unclassified file type in declaration input: {child}")
-        return out
     if path.suffix in (".yaml", ".yml"):
         return yaml.safe_load(path.read_text(encoding="utf-8"))
-    raise ValueError(f"unsupported declaration input file: {path}")
+    if path.suffix == ".txt":
+        return sorted(
+            {
+                line.strip()
+                for line in path.read_text(encoding="utf-8").splitlines()
+                if line.strip() and not line.startswith("#")
+            }
+        )
+    raise ValueError(f"unclassified file type in declaration input: {path}")
 
 
 def declaration_content(root: Path | None = None) -> dict:
     """The declaration tree the digest is taken over: every ``DECLARATION_INPUTS`` entry.
 
-    Raises if a declared input is missing from disk, so the digest can never quietly narrow to a
-    subset of the declarations.
+    The file set is derived from ``git ls-files``, not the filesystem, so an untracked file
+    cannot enter the digest. Raises if a declared input tracks no files, so the digest can never
+    quietly narrow to a subset of the declarations.
     """
-    base = (root or ROOT) / "sources"
+    base = root or ROOT
     content: dict[str, object] = {}
     for name in DECLARATION_INPUTS:
-        path = base / name
-        if not path.exists():
-            raise FileNotFoundError(f"declaration input missing: sources/{name}")
-        content[name] = _read_declaration_input(path)
+        rel = f"sources/{name}"
+        tracked = _tracked_paths(base, rel)
+        if not tracked:
+            raise FileNotFoundError(f"declaration input tracks no files: {rel}")
+        if tracked == [rel]:
+            # A single tracked file at exactly this path — a file input (taxonomy.yaml, etc.).
+            content[name] = _parse_declaration_file(base / rel)
+        else:
+            # A directory input — map each tracked file's basename to its parsed content.
+            content[name] = {
+                (base / tp).name: _parse_declaration_file(base / tp) for tp in tracked
+            }
     return content
 
 
@@ -296,26 +314,41 @@ def resolve_git_sha(root: Path | None = None) -> str:
     return result.stdout.strip()
 
 
-def tracked_worktree_is_clean(root: Path | None = None) -> bool:
-    """True when no TRACKED file has uncommitted changes.
+def worktree_is_clean_for_identity(root: Path | None = None) -> bool:
+    """True when the worktree state the identity depends on matches ``HEAD``.
 
-    The identity is commit-scoped: ``source_git_sha`` names ``HEAD``, and the digest is computed
-    over the working tree by code that is itself tracked. So it is not enough for ``sources/`` to
-    be clean — a dirty ``build/declaration_version.py`` (or, later, dirty evaluator code) would
-    change the computed identity while ``source_git_sha`` still named ``HEAD``, producing a value
-    no commit can reproduce. Requiring the whole tracked worktree to match ``HEAD`` is the
-    simplest guarantee that the derived id names exactly this commit's state.
+    Two kinds of dirtiness both make the derived id unreproducible from ``source_git_sha``, and
+    both are refused:
 
-    Untracked files are ignored (``--untracked-files=no``): they are not read by this computation
-    and do not affect the identity.
+      * any TRACKED file modified/staged/deleted/renamed, ANYWHERE — the digest and this identity
+        code are read from the working tree, so dirty declarations OR dirty identity/evaluator
+        code change the computed id while ``source_git_sha`` still names ``HEAD``;
+      * any UNTRACKED file under ``sources/`` — ``declaration_content`` reads only tracked files,
+        so such a file cannot silently enter the digest, but its presence means the working tree
+        carries a declaration the commit does not, so the id is refused rather than emitted
+        against a tree that disagrees with ``HEAD``.
+
+    Untracked files OUTSIDE ``sources/`` (scratch, build artifacts, new modules not yet added)
+    are not read by this computation and are ignored.
     """
     result = subprocess.run(
-        ["git", "-C", str(root or ROOT), "status", "--porcelain", "--untracked-files=no"],
+        ["git", "-C", str(root or ROOT), "status", "--porcelain"],
         capture_output=True,
         text=True,
         check=True,
     )
-    return result.stdout.strip() == ""
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        status, path = line[:2], line[3:]
+        if status == "??":
+            # Untracked: dirty only when it sits under sources/ (a declaration the commit lacks).
+            if path.startswith("sources/"):
+                return False
+        else:
+            # Any tracked change, anywhere in the worktree.
+            return False
+    return True
 
 
 def declaration_version_id(
@@ -354,13 +387,14 @@ def resolve(root: Path | None = None, allow_dirty: bool = False) -> dict:
     ``worktree_clean`` recording the state.
     """
     base = root or ROOT
-    clean = tracked_worktree_is_clean(base)
+    clean = worktree_is_clean_for_identity(base)
     if not clean and not allow_dirty:
         raise DirtyWorktreeError(
-            "the tracked worktree has uncommitted changes: the digest and the identity code are "
-            "read from the working tree while source_git_sha is HEAD, so the id would not be "
-            "reproducible from that commit. Commit first, or pass allow_dirty=True "
-            "(CLI --allow-dirty) for a diagnostic-only value."
+            "the worktree has uncommitted changes affecting the identity — a tracked file "
+            "(declarations or identity/evaluator code), or an untracked file under sources/. "
+            "The digest and identity code are read from the working tree while source_git_sha is "
+            "HEAD, so the id would not be reproducible from that commit. Commit first, or pass "
+            "allow_dirty=True (CLI --allow-dirty) for a diagnostic-only value."
         )
     digest = source_content_digest(base)
     git_sha = resolve_git_sha(base)

--- a/build/declaration_version.py
+++ b/build/declaration_version.py
@@ -26,20 +26,32 @@ unclassified. The gate protects the whole ``sources/`` inventory, not just what
 return, and both are folded in here.
 
   * ``DECLARATION_INPUTS`` — content IS the declaration; folded into the digest.
-  * ``POLICY_INPUTS`` — excluded from ``declaration_version_id`` because the input carries its
-    OWN version and is applied in a downstream layer, not in the declaration compile. The
-    exclusion is a redirection, not a gap: each names the downstream identity its policy version
-    must bind into. ``signal_routing.yaml`` is the case — it publishes under
-    ``routing_policy_version`` (see ``test_serialize_routing``) and is applied in evaluation, so
-    its version binds into ``evaluation.adoption_reconciliation`` / ``release_id`` when those are
-    built, never into this identity.
+  * ``POLICY_INPUTS`` — excluded from the ``source_content_digest`` (NOT from
+    ``declaration_version_id`` — see "commit-scoped" below) because the input carries its OWN
+    version and is applied in a downstream layer, not in the declaration compile.
+    ``signal_routing.yaml`` is the case — it publishes under ``routing_policy_version`` (see
+    ``test_serialize_routing``) and is applied in evaluation. Its version is a PENDING binding
+    obligation: ``evaluation.adoption_reconciliation`` and ``release_id`` do not exist yet, so no
+    binding exists to prove; the entry records where the version MUST bind, and the obligation is
+    ratcheted into a real assertion when those tables land.
   * ``NON_DECLARATION_INPUTS`` — not a scoring declaration at all (the frozen long-tail
-    warehouse sample); excluded with a reason.
+    warehouse sample); excluded from the digest with a reason.
 
 The derived score projections (``overall_score``, ``tier``, ``maturity``, ``mature``) are also
-excluded, by construction rather than by name: they are computed by ``build.serialize`` from the
-declared axis values and never live in ``sources/``. Folding them in would double-count the
-evaluator, whose contribution is already named by ``evaluator_version``.
+excluded from the digest, by construction rather than by name: they are computed by
+``build.serialize`` from the declared axis values and never live in ``sources/``. Folding them in
+would double-count the evaluator, whose contribution is already named by ``evaluator_version``.
+
+## The id is commit-scoped
+
+The exclusions above are exclusions from the CONTENT DIGEST, not from the identity. The identity
+also carries ``source_git_sha``, so any commit that changes ``signal_routing.yaml``, the frozen
+snapshot, or the derived projections changes the SHA and therefore the final
+``declaration_version_id`` — the digest simply does not itself vary with them, so a routing-only
+change reshuffles the id via the SHA rather than via the declaration content. What the digest
+buys is a content-addressed cross-check: two commits with identical declaration content share a
+digest even though their SHAs differ, which is how a reconciliation can tell a real declaration
+change from an unrelated one.
 
 ## No frozen receipt, on purpose
 
@@ -53,10 +65,11 @@ but freezing it would demand a regenerate-and-gate step on every score edit; the
 canonicalization's PROPERTIES (determinism, order-invariance, the digested inventory, type
 rejection) instead of a brittle golden value.
 
-Because the digest is taken over the working tree while ``source_git_sha`` is ``HEAD``, a dirty
-``sources/`` tree yields an id that no SHA can reproduce. ``resolve`` therefore FAILS CLOSED on
-uncommitted declarations; a diagnostic value over a dirty tree requires an explicit opt-in
-(``allow_dirty`` / CLI ``--allow-dirty``).
+Because the digest and this identity code are both read from the working tree while
+``source_git_sha`` is ``HEAD``, a dirty TRACKED worktree — dirty declarations, or a dirty
+``build/declaration_version.py`` / future evaluator — yields an id that no commit can reproduce.
+``resolve`` therefore FAILS CLOSED unless the whole tracked worktree is clean; a diagnostic value
+over a dirty tree requires an explicit opt-in (``allow_dirty`` / CLI ``--allow-dirty``).
 
 Usage:
     uv run python -m build.declaration_version                # print the components at HEAD
@@ -70,6 +83,7 @@ import argparse
 import datetime
 import hashlib
 import json
+import math
 import subprocess
 import sys
 from pathlib import Path
@@ -110,13 +124,18 @@ DECLARATION_INPUTS: tuple[str, ...] = (
     "verification_queue.yaml",
 )
 
-# Policy inputs — excluded from declaration_version_id because they carry their OWN version and
-# are applied in a downstream layer, not in the declaration compile. Each MUST have its policy
-# version bound into the downstream identity named here when that identity is built.
+# Policy inputs — excluded from source_content_digest because they carry their OWN version and
+# are applied in a downstream layer, not in the declaration compile. The version is a PENDING
+# binding obligation, not an existing binding: the downstream identity does not exist yet, so
+# `binding` is "pending" and names where the version MUST bind. When that table lands, the
+# binding is implemented and this flips to "bound" (test_policy_inputs_record_a_binding_obligation
+# ratchets on it). Excluding an input here never excludes it from declaration_version_id itself,
+# which is commit-scoped via source_git_sha.
 POLICY_INPUTS: dict[str, dict[str, str]] = {
     "signal_routing.yaml": {
         "policy_version": "routing_policy_version",
-        "bound_into": "evaluation.adoption_reconciliation / release_id",
+        "binding": "pending",
+        "binds_into": "evaluation.adoption_reconciliation / release_id",
         "reason": (
             "routing is applied in the evaluation layer, not declared per product; it "
             "publishes under routing_policy_version (see test_serialize_routing)."
@@ -133,20 +152,59 @@ NON_DECLARATION_INPUTS: dict[str, str] = {
 }
 
 
-def _canonical_default(value: object) -> str:
-    """Serialize the one non-JSON-native type the declarations use (dates); reject the rest.
+# The exact scalar types the digest accepts. Checked by identity (`type(x) is …`), not
+# isinstance, so a subclass cannot smuggle in surprising serialization. `bool` is listed
+# separately from `int` deliberately: it is an int subclass, but the two serialize to distinct
+# JSON tokens (`true` vs `1`) and are both wanted.
+_ALLOWED_SCALARS = (str, bool, int, float)
 
-    ``json.dumps`` calls this only for values it cannot serialize itself. A YAML ``!!set`` or an
-    unexpected object would otherwise slip through a permissive ``str`` fallback and become an
-    implementation-dependent string — a silently non-reproducible identity. Only dates are
-    accepted (rendered ISO); everything else raises.
+
+def _assert_canonicalizable(obj: object, path: str = "<root>") -> None:
+    """Reject, before serialization, every shape that would make two distinct inputs collide.
+
+    ``json.dumps`` is too permissive to trust as the sole gate: it coerces a non-string mapping
+    key to a string (``{1: "x"}`` and ``{"1": "x"}`` serialize identically) and renders a tuple
+    as an array (``(1, 2)`` and ``[1, 2]`` collide). Either would let two different declaration
+    states share one identity. So the structure is validated first:
+
+      * mappings: keys must be exactly ``str``; values recurse;
+      * sequences: must be exactly ``list`` (a tuple or other sequence is rejected); items recurse;
+      * scalars: only ``str``/``bool``/``int``/``float`` by exact type, plus ``date``/``datetime``;
+        floats must be finite;
+      * everything else (sets, bytes, custom objects, tuples-as-keys) raises.
     """
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if type(key) is not str:
+                raise TypeError(
+                    f"canonical_json: mapping key at {path} must be a str, got "
+                    f"{type(key).__name__!r} ({key!r})"
+                )
+            _assert_canonicalizable(value, f"{path}.{key}")
+        return
+    if type(obj) is list:
+        for index, value in enumerate(obj):
+            _assert_canonicalizable(value, f"{path}[{index}]")
+        return
+    if isinstance(obj, (datetime.date, datetime.datetime)):
+        return
+    if obj is None:
+        return
+    if type(obj) in _ALLOWED_SCALARS:
+        if type(obj) is float and not math.isfinite(obj):
+            raise ValueError(f"canonical_json: non-finite number at {path} ({obj!r})")
+        return
+    raise TypeError(
+        f"canonical_json: unsupported type {type(obj).__name__!r} at {path}; only str/bool/"
+        "int/finite-float/None scalars, dates, lists, and str-keyed dicts are supported."
+    )
+
+
+def _date_default(value: object) -> str:
+    """Serialize a date once the structure has been validated; anything else is a bug here."""
     if isinstance(value, (datetime.date, datetime.datetime)):
         return value.isoformat()
-    raise TypeError(
-        f"canonical_json cannot serialize a value of type {type(value).__name__!r}; "
-        "only JSON scalars, lists, dicts, and dates are supported."
-    )
+    raise TypeError(f"canonical_json: unexpected type past validation: {type(value).__name__!r}")
 
 
 def canonical_json(obj: object) -> str:
@@ -154,22 +212,23 @@ def canonical_json(obj: object) -> str:
 
     Canonicalization rule (data-architecture.md §4.5), version ``CANONICALIZATION_VERSION``:
 
+      * structure: validated first (``_assert_canonicalizable``) so non-string keys and tuples
+        are rejected rather than silently coerced into a colliding form;
       * format: JSON, UTF-8, no insignificant whitespace (``separators=(",", ":")``);
       * key ordering: every mapping sorted by key (``sort_keys=True``), so a curator
         reordering a YAML file produces no change;
       * strings: preserved verbatim, not ASCII-escaped (``ensure_ascii=False``);
       * dates: rendered as ISO text; null as JSON ``null``;
-      * numbers: finite only — ``allow_nan=False`` rejects ``NaN``/``Infinity``, which are not
-        valid JSON and do not round-trip reproducibly;
-      * types: only JSON scalars, lists, dicts, and dates; any other type is rejected rather
-        than coerced (``_canonical_default``).
+      * numbers: finite only (rejected in validation; ``allow_nan=False`` is a backstop);
+      * types: only JSON scalars, lists, dates, and str-keyed dicts.
     """
+    _assert_canonicalizable(obj)
     return json.dumps(
         obj,
         sort_keys=True,
         ensure_ascii=False,
         separators=(",", ":"),
-        default=_canonical_default,
+        default=_date_default,
         allow_nan=False,
     )
 
@@ -237,15 +296,21 @@ def resolve_git_sha(root: Path | None = None) -> str:
     return result.stdout.strip()
 
 
-def declaration_paths_are_clean(root: Path | None = None) -> bool:
-    """True when no declaration file has uncommitted changes.
+def tracked_worktree_is_clean(root: Path | None = None) -> bool:
+    """True when no TRACKED file has uncommitted changes.
 
-    A ``declaration_version_id`` pairs the working-tree digest with ``HEAD``'s SHA. When a
-    declaration file is dirty the two describe different states, so the derived id is not
-    reproducible from the SHA alone.
+    The identity is commit-scoped: ``source_git_sha`` names ``HEAD``, and the digest is computed
+    over the working tree by code that is itself tracked. So it is not enough for ``sources/`` to
+    be clean — a dirty ``build/declaration_version.py`` (or, later, dirty evaluator code) would
+    change the computed identity while ``source_git_sha`` still named ``HEAD``, producing a value
+    no commit can reproduce. Requiring the whole tracked worktree to match ``HEAD`` is the
+    simplest guarantee that the derived id names exactly this commit's state.
+
+    Untracked files are ignored (``--untracked-files=no``): they are not read by this computation
+    and do not affect the identity.
     """
     result = subprocess.run(
-        ["git", "-C", str(root or ROOT), "status", "--porcelain", "--", "sources/"],
+        ["git", "-C", str(root or ROOT), "status", "--porcelain", "--untracked-files=no"],
         capture_output=True,
         text=True,
         check=True,
@@ -276,24 +341,26 @@ def declaration_version_id(
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
-class DirtyDeclarationsError(RuntimeError):
-    """Raised when an id is requested over a working tree with uncommitted declarations."""
+class DirtyWorktreeError(RuntimeError):
+    """Raised when an id is requested over a tracked worktree with uncommitted changes."""
 
 
 def resolve(root: Path | None = None, allow_dirty: bool = False) -> dict:
     """Derive every component and the id at ``HEAD`` over the working-tree declarations.
 
-    Fails closed when ``sources/`` is dirty: the digest is over the working tree but the SHA is
-    ``HEAD``, so the pair is not reproducible. ``allow_dirty`` returns a diagnostic value anyway,
-    with ``declarations_clean`` recording the state.
+    Fails closed when any tracked file is dirty: the digest and the identity implementation are
+    read from the working tree but ``source_git_sha`` is ``HEAD``, so a dirty tree yields a value
+    no commit can reproduce. ``allow_dirty`` returns a diagnostic value anyway, with
+    ``worktree_clean`` recording the state.
     """
     base = root or ROOT
-    clean = declaration_paths_are_clean(base)
+    clean = tracked_worktree_is_clean(base)
     if not clean and not allow_dirty:
-        raise DirtyDeclarationsError(
-            "sources/ has uncommitted changes: the working-tree digest would pair with HEAD's "
-            "SHA and would not be reproducible from it. Commit the declarations first, or pass "
-            "allow_dirty=True (CLI --allow-dirty) for a diagnostic-only value."
+        raise DirtyWorktreeError(
+            "the tracked worktree has uncommitted changes: the digest and the identity code are "
+            "read from the working tree while source_git_sha is HEAD, so the id would not be "
+            "reproducible from that commit. Commit first, or pass allow_dirty=True "
+            "(CLI --allow-dirty) for a diagnostic-only value."
         )
     digest = source_content_digest(base)
     git_sha = resolve_git_sha(base)
@@ -303,7 +370,7 @@ def resolve(root: Path | None = None, allow_dirty: bool = False) -> dict:
         "source_git_sha": git_sha,
         "source_content_digest": digest,
         "declaration_version_id": declaration_version_id(git_sha, digest),
-        "declarations_clean": clean,
+        "worktree_clean": clean,
     }
 
 
@@ -313,13 +380,13 @@ def main() -> int:
     parser.add_argument(
         "--allow-dirty",
         action="store_true",
-        help="emit a diagnostic id over an uncommitted sources/ tree (not reproducible)",
+        help="emit a diagnostic id over an uncommitted tracked worktree (not reproducible)",
     )
     args = parser.parse_args()
 
     try:
         info = resolve(allow_dirty=args.allow_dirty)
-    except DirtyDeclarationsError as exc:
+    except DirtyWorktreeError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
@@ -332,11 +399,11 @@ def main() -> int:
     print(f"source_git_sha            {info['source_git_sha']}")
     print(f"source_content_digest     {info['source_content_digest']}")
     print(f"declaration_version_id    {info['declaration_version_id']}")
-    if not info["declarations_clean"]:
+    if not info["worktree_clean"]:
         print(
-            "\nWARNING: sources/ has uncommitted changes. This is a diagnostic value only — the\n"
-            "digest is over the working tree but source_git_sha is HEAD, so it is not\n"
-            "reproducible from that SHA."
+            "\nWARNING: the tracked worktree has uncommitted changes. This is a diagnostic value\n"
+            "only — the digest and identity code are read from the working tree but\n"
+            "source_git_sha is HEAD, so it is not reproducible from that commit."
         )
     return 0
 

--- a/docs/architecture/data-architecture.md
+++ b/docs/architecture/data-architecture.md
@@ -862,9 +862,12 @@ is **commit-scoped**: it also carries `source_git_sha`, so any commit that touch
 therefore the id. What the digest buys is a content-addressed cross-check — two commits with
 identical declaration content share a digest even though their SHAs differ, so a reconciliation
 can distinguish a real declaration change from an unrelated one. Because the id is commit-scoped
-and computed by tracked code over the working tree, it is derived only over a **clean tracked
-worktree**: a dirty tree (dirty declarations, or dirty identity/evaluator code) pairs a
-working-tree value with `HEAD`'s SHA and is refused unless an explicit diagnostic opt-in is given.
+and computed by tracked code over the working tree, it is derived only over a worktree that
+agrees with `HEAD`: a dirty tracked file anywhere (dirty declarations, or dirty identity/evaluator
+code), or an untracked file under `sources/` (a declaration the commit does not carry), is
+refused unless an explicit diagnostic opt-in is given. The digest reads only git-tracked files, so
+an untracked file cannot enter it silently; the guard additionally refuses it so the mismatch
+surfaces.
 
 Until the repository-owned evaluator lands (Phase 6), `evaluator_version` is a declared sentinel
 `v0-no-repo-evaluator` — well-formed and forward-compatible, and deliberately not the empty

--- a/docs/architecture/data-architecture.md
+++ b/docs/architecture/data-architecture.md
@@ -833,6 +833,19 @@ release_id
   = declaration_version_id + observation_snapshot_id + reconciliation_policy_version
 ```
 
+`declaration_version_id` is derived by `build/declaration_version.py`, not stored: it embeds
+`source_git_sha`, and no commit can record its own SHA, so the release builder (and any
+consumer keying a candidate table) computes it from the resolved SHA at run time. Its
+`source_content_digest` covers the declaration tree `build.validate.load_sources` parses
+(products, organizations, categories, scores, rubrics, taxonomy, long-tail registry seeds) and
+deliberately excludes three things whose change is not a change in the declarations: the frozen
+`sources/snapshots/long_tail.json` warehouse sample, the derived score projections (those are
+the evaluator's contribution, already named by `evaluator_version`), and the routing policy
+(which carries its own `routing_policy_version`). Until the repository-owned evaluator lands
+(Phase 6), `evaluator_version` is a declared sentinel `v0-no-repo-evaluator` — well-formed and
+forward-compatible, and deliberately not the empty string, so the day a real evaluator version
+replaces it is a reviewed change that moves every id with it.
+
 Use them consistently:
 
 - `registry.axis_assessments` belongs to `declaration_version_id`. It does not depend on
@@ -872,6 +885,19 @@ this specification — `source_content_digest`, `observation_content_digest`,
 
 Two implementations that disagree on any of these produce different digests from identical
 data, which is indistinguishable from real drift.
+
+Declared, for `source_content_digest` (owned by `build/declaration_version.py`,
+`canonicalization_version` 1):
+
+- serialization format: JSON, UTF-8, with no insignificant whitespace;
+- key ordering: every mapping sorted by key, so reordering a YAML file changes nothing;
+- string normalization: preserved verbatim, not ASCII-escaped;
+- date and null representation: a date scalar renders as its ISO `YYYY-MM-DD` text (Python
+  `str`), null as JSON `null`;
+- hash algorithm: SHA-256, lowercase hex;
+- input set: the declaration subtrees of `load_sources` (an explicit key-list gated so a new
+  declaration directory cannot silently leave the digest), excluding the frozen long-tail
+  sample.
 
 Future release tables may include:
 

--- a/docs/architecture/data-architecture.md
+++ b/docs/architecture/data-architecture.md
@@ -836,15 +836,28 @@ release_id
 `declaration_version_id` is derived by `build/declaration_version.py`, not stored: it embeds
 `source_git_sha`, and no commit can record its own SHA, so the release builder (and any
 consumer keying a candidate table) computes it from the resolved SHA at run time. Its
-`source_content_digest` covers the declaration tree `build.validate.load_sources` parses
-(products, organizations, categories, scores, rubrics, taxonomy, long-tail registry seeds) and
-deliberately excludes three things whose change is not a change in the declarations: the frozen
-`sources/snapshots/long_tail.json` warehouse sample, the derived score projections (those are
-the evaluator's contribution, already named by `evaluator_version`), and the routing policy
-(which carries its own `routing_policy_version`). Until the repository-owned evaluator lands
-(Phase 6), `evaluator_version` is a declared sentinel `v0-no-repo-evaluator` — well-formed and
+`source_content_digest` covers every authoritative declaration input under `sources/` — every
+top-level entry is classified into exactly one of three buckets, gated so a new input cannot
+escape the identity unnoticed:
+
+- **declaration** (folded into the digest): `products`, `organizations`, `categories`,
+  `scores`, `rubrics`, `taxonomy.yaml`, the long-tail `registry` seeds, and — beyond what
+  `load_sources` returns — `evidence_policy.yaml` (which shapes serialized registry output) and
+  `verification_queue.yaml` (which governs release eligibility), plus the `allowlists`;
+- **policy** (excluded here, its own version bound downstream): `signal_routing.yaml`, which
+  publishes under `routing_policy_version` and is applied in the evaluation layer, so its version
+  binds into `evaluation.adoption_reconciliation` / `release_id`, never into this identity;
+- **non-declaration** (excluded with a reason): the frozen `sources/snapshots/long_tail.json`
+  warehouse sample.
+
+The derived score projections (`overall_score`, `tier`, `maturity`, `mature`) are excluded by
+construction — they never live in `sources/`; they are the evaluator's contribution, already
+named by `evaluator_version`. Until the repository-owned evaluator lands (Phase 6),
+`evaluator_version` is a declared sentinel `v0-no-repo-evaluator` — well-formed and
 forward-compatible, and deliberately not the empty string, so the day a real evaluator version
-replaces it is a reviewed change that moves every id with it.
+replaces it is a reviewed change that moves every id with it. The id is also derived only over
+a committed `sources/` tree: a dirty working tree pairs a working-tree digest with `HEAD`'s SHA
+and is refused unless an explicit diagnostic opt-in is given.
 
 Use them consistently:
 
@@ -892,12 +905,15 @@ Declared, for `source_content_digest` (owned by `build/declaration_version.py`,
 - serialization format: JSON, UTF-8, with no insignificant whitespace;
 - key ordering: every mapping sorted by key, so reordering a YAML file changes nothing;
 - string normalization: preserved verbatim, not ASCII-escaped;
-- date and null representation: a date scalar renders as its ISO `YYYY-MM-DD` text (Python
-  `str`), null as JSON `null`;
+- date and null representation: a date scalar renders as its ISO text, null as JSON `null`;
+- number representation: finite only — `NaN`/`Infinity` are rejected, not emitted;
+- type handling: only JSON scalars, lists, dicts, and dates are accepted; any other type
+  (a YAML `!!set`, an unexpected object) is rejected rather than coerced to a string, which
+  would make the digest implementation-dependent;
 - hash algorithm: SHA-256, lowercase hex;
-- input set: the declaration subtrees of `load_sources` (an explicit key-list gated so a new
-  declaration directory cannot silently leave the digest), excluding the frozen long-tail
-  sample.
+- input set: the classified declaration inputs of `sources/` (the full top-level inventory is
+  gated, so a new authoritative input cannot silently leave the digest), excluding the
+  separately-versioned routing policy and the frozen long-tail sample.
 
 Future release tables may include:
 

--- a/docs/architecture/data-architecture.md
+++ b/docs/architecture/data-architecture.md
@@ -838,26 +838,38 @@ release_id
 consumer keying a candidate table) computes it from the resolved SHA at run time. Its
 `source_content_digest` covers every authoritative declaration input under `sources/` — every
 top-level entry is classified into exactly one of three buckets, gated so a new input cannot
-escape the identity unnoticed:
+escape the digest unnoticed:
 
 - **declaration** (folded into the digest): `products`, `organizations`, `categories`,
   `scores`, `rubrics`, `taxonomy.yaml`, the long-tail `registry` seeds, and — beyond what
   `load_sources` returns — `evidence_policy.yaml` (which shapes serialized registry output) and
   `verification_queue.yaml` (which governs release eligibility), plus the `allowlists`;
-- **policy** (excluded here, its own version bound downstream): `signal_routing.yaml`, which
-  publishes under `routing_policy_version` and is applied in the evaluation layer, so its version
-  binds into `evaluation.adoption_reconciliation` / `release_id`, never into this identity;
-- **non-declaration** (excluded with a reason): the frozen `sources/snapshots/long_tail.json`
-  warehouse sample.
+- **policy** (excluded from the digest, its own version a pending downstream obligation):
+  `signal_routing.yaml`, which publishes under `routing_policy_version` and is applied in the
+  evaluation layer. That version must bind into `evaluation.adoption_reconciliation` /
+  `release_id`; those tables do not exist yet, so the binding is recorded as an obligation and
+  ratcheted into a real assertion when they land;
+- **non-declaration** (excluded from the digest, with a reason): the frozen
+  `sources/snapshots/long_tail.json` warehouse sample.
 
-The derived score projections (`overall_score`, `tier`, `maturity`, `mature`) are excluded by
-construction — they never live in `sources/`; they are the evaluator's contribution, already
-named by `evaluator_version`. Until the repository-owned evaluator lands (Phase 6),
-`evaluator_version` is a declared sentinel `v0-no-repo-evaluator` — well-formed and
-forward-compatible, and deliberately not the empty string, so the day a real evaluator version
-replaces it is a reviewed change that moves every id with it. The id is also derived only over
-a committed `sources/` tree: a dirty working tree pairs a working-tree digest with `HEAD`'s SHA
-and is refused unless an explicit diagnostic opt-in is given.
+The derived score projections (`overall_score`, `tier`, `maturity`, `mature`) are excluded from
+the digest by construction — they never live in `sources/`; they are the evaluator's
+contribution, already named by `evaluator_version`.
+
+These are exclusions from the **content digest**, not from the identity. `declaration_version_id`
+is **commit-scoped**: it also carries `source_git_sha`, so any commit that touches
+`signal_routing.yaml`, the frozen snapshot, or the derived projections changes the SHA and
+therefore the id. What the digest buys is a content-addressed cross-check — two commits with
+identical declaration content share a digest even though their SHAs differ, so a reconciliation
+can distinguish a real declaration change from an unrelated one. Because the id is commit-scoped
+and computed by tracked code over the working tree, it is derived only over a **clean tracked
+worktree**: a dirty tree (dirty declarations, or dirty identity/evaluator code) pairs a
+working-tree value with `HEAD`'s SHA and is refused unless an explicit diagnostic opt-in is given.
+
+Until the repository-owned evaluator lands (Phase 6), `evaluator_version` is a declared sentinel
+`v0-no-repo-evaluator` — well-formed and forward-compatible, and deliberately not the empty
+string, so the day a real evaluator version replaces it is a reviewed change that moves every id
+with it.
 
 Use them consistently:
 

--- a/docs/architecture/migration-status.md
+++ b/docs/architecture/migration-status.md
@@ -29,10 +29,14 @@ did not yet exist in code. Laid ahead of those tables so each is defined once, o
 than improvised inside the first consumer.
 
 - **`declaration_version_id` — implemented** (`build/declaration_version.py`, `data-architecture.md`
-  §4.6/§4.7). Derived at run time, not stored, because it embeds `source_git_sha`. Its
-  `source_content_digest` covers the declaration tree `load_sources` parses, excluding the frozen
-  long-tail sample, the derived score projections, and the routing policy. `evaluator_version` is
-  pinned to the sentinel `v0-no-repo-evaluator` until the repository-owned evaluator lands (Phase 6).
+  §4.5). Derived at run time, not stored, because it embeds `source_git_sha`, and refused over a
+  dirty `sources/` tree without an explicit diagnostic opt-in. Its `source_content_digest` covers
+  every authoritative declaration input under `sources/` — the full top-level inventory is
+  classified and gated, so `evidence_policy.yaml` and `verification_queue.yaml` (which
+  `load_sources` does not return) are folded in, `signal_routing.yaml` is excluded as a policy
+  whose `routing_policy_version` binds downstream, and the frozen long-tail sample and derived
+  score projections are excluded. `evaluator_version` is pinned to the sentinel
+  `v0-no-repo-evaluator` until the repository-owned evaluator lands (Phase 6).
 - **`observation_snapshot_id` — pending**, to be emitted by the observations layer over
   `observations.product_adoption_current` (a build receipt, like `source_runs.json`). Gated on
   `observations.product_adoption_current` reaching `main`.

--- a/docs/architecture/migration-status.md
+++ b/docs/architecture/migration-status.md
@@ -21,6 +21,22 @@ file records only where the work has got to. Delete a row when it stops being te
 | 7 — retire duplicate openness computation | not started | |
 | 8 — release manifests | not started | |
 
+## Versioning identities
+
+Prerequisites for the fully-keyed evaluation tables (`evaluation.product_adoption_measurements`,
+`evaluation.adoption_reconciliation`, `registry.axis_assessments`), which key on identities that
+did not yet exist in code. Laid ahead of those tables so each is defined once, on its own, rather
+than improvised inside the first consumer.
+
+- **`declaration_version_id` — implemented** (`build/declaration_version.py`, `data-architecture.md`
+  §4.6/§4.7). Derived at run time, not stored, because it embeds `source_git_sha`. Its
+  `source_content_digest` covers the declaration tree `load_sources` parses, excluding the frozen
+  long-tail sample, the derived score projections, and the routing policy. `evaluator_version` is
+  pinned to the sentinel `v0-no-repo-evaluator` until the repository-owned evaluator lands (Phase 6).
+- **`observation_snapshot_id` — pending**, to be emitted by the observations layer over
+  `observations.product_adoption_current` (a build receipt, like `source_runs.json`). Gated on
+  `observations.product_adoption_current` reaching `main`.
+
 ## Atomicity: which state is in force
 
 **Transitional.** Verified 2026-08-20: static models carry no version or revision list, and

--- a/docs/architecture/migration-status.md
+++ b/docs/architecture/migration-status.md
@@ -29,14 +29,16 @@ did not yet exist in code. Laid ahead of those tables so each is defined once, o
 than improvised inside the first consumer.
 
 - **`declaration_version_id` — implemented** (`build/declaration_version.py`, `data-architecture.md`
-  §4.5). Derived at run time, not stored, because it embeds `source_git_sha`, and refused over a
-  dirty `sources/` tree without an explicit diagnostic opt-in. Its `source_content_digest` covers
-  every authoritative declaration input under `sources/` — the full top-level inventory is
-  classified and gated, so `evidence_policy.yaml` and `verification_queue.yaml` (which
-  `load_sources` does not return) are folded in, `signal_routing.yaml` is excluded as a policy
-  whose `routing_policy_version` binds downstream, and the frozen long-tail sample and derived
-  score projections are excluded. `evaluator_version` is pinned to the sentinel
-  `v0-no-repo-evaluator` until the repository-owned evaluator lands (Phase 6).
+  §4.5). Commit-scoped (it embeds `source_git_sha`), derived at run time rather than stored, and
+  refused over a dirty **tracked worktree** — dirty declarations or dirty identity/evaluator code —
+  without an explicit diagnostic opt-in. Its `source_content_digest` covers every authoritative
+  declaration input under `sources/` — the full top-level inventory is classified and gated, so
+  `evidence_policy.yaml` and `verification_queue.yaml` (which `load_sources` does not return) are
+  folded in, while `signal_routing.yaml` (its `routing_policy_version` a **pending** binding
+  obligation for reconciliation/releases), the frozen long-tail sample, and the derived score
+  projections are excluded from the **digest** — not from the id, which changes with any commit
+  that touches them. `evaluator_version` is pinned to the sentinel `v0-no-repo-evaluator` until
+  the repository-owned evaluator lands (Phase 6).
 - **`observation_snapshot_id` — pending**, to be emitted by the observations layer over
   `observations.product_adoption_current` (a build receipt, like `source_runs.json`). Gated on
   `observations.product_adoption_current` reaching `main`.

--- a/docs/architecture/migration-status.md
+++ b/docs/architecture/migration-status.md
@@ -30,8 +30,9 @@ than improvised inside the first consumer.
 
 - **`declaration_version_id` — implemented** (`build/declaration_version.py`, `data-architecture.md`
   §4.5). Commit-scoped (it embeds `source_git_sha`), derived at run time rather than stored, and
-  refused over a dirty **tracked worktree** — dirty declarations or dirty identity/evaluator code —
-  without an explicit diagnostic opt-in. Its `source_content_digest` covers every authoritative
+  refused over a worktree that disagrees with `HEAD` — a dirty tracked file (declarations or
+  identity/evaluator code) or an untracked file under `sources/` — without an explicit diagnostic
+  opt-in; the digest itself reads only git-tracked files. Its `source_content_digest` covers every authoritative
   declaration input under `sources/` — the full top-level inventory is classified and gated, so
   `evidence_policy.yaml` and `verification_queue.yaml` (which `load_sources` does not return) are
   folded in, while `signal_routing.yaml` (its `routing_policy_version` a **pending** binding

--- a/tests/test_declaration_version.py
+++ b/tests/test_declaration_version.py
@@ -1,6 +1,6 @@
 """The declaration-version identity, and the properties that keep it honest.
 
-`build/declaration_version.py` derives `declaration_version_id` (data-architecture.md §4.6):
+`build/declaration_version.py` derives `declaration_version_id` (data-architecture.md §4.5):
 the identity of a set of declarations, evaluated by a named evaluator, that
 `registry.axis_assessments`, `evaluation.product_adoption_measurements` and
 `evaluation.adoption_reconciliation` all key on.
@@ -8,55 +8,95 @@ the identity of a set of declarations, evaluated by a named evaluator, that
 There is no committed golden value to pin — the id embeds `source_git_sha`, and freezing a
 receipt would either name its own parent commit or force a regenerate step on every score edit
 (see the module docstring). So these tests pin the canonicalization's PROPERTIES instead:
-determinism, order-invariance, the exact digested key-set, the exclusions, the sentinel, and
-that the id responds to each component.
+the classified `sources/` inventory, determinism, order-invariance, type rejection, the
+fail-closed behavior on a dirty tree, and that the id responds to each component.
 """
 
 import copy
 import hashlib
 from pathlib import Path
 
+import pytest
+
 import build.declaration_version as dv
 from build.declaration_version import (
     CANONICALIZATION_VERSION,
-    DECLARATION_KEYS,
+    DECLARATION_INPUTS,
     EVALUATOR_VERSION,
-    NON_DECLARATION_KEYS,
+    NON_DECLARATION_INPUTS,
+    POLICY_INPUTS,
+    DirtyDeclarationsError,
     canonical_json,
     declaration_content,
     declaration_version_id,
+    resolve,
     source_content_digest,
 )
-from build.validate import load_sources
 
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_declaration_keys_cover_every_declaration_subtree():
-    """The digested key-set must be load_sources MINUS the declared non-declarations, exactly.
+# --- the classified inventory (finding 1) ----------------------------------------
 
-    This is the 'declared state matches reality' gate for the identity: add a new declaration
-    directory to sources/ (so load_sources grows a key) and this fails until the key is either
-    folded into the digest or explicitly classified a non-declaration. A declaration cannot
-    slip out of the version unnoticed.
+
+def test_source_inventory_is_fully_classified():
+    """Every top-level sources/ entry is classified into exactly one bucket.
+
+    This is the 'declared state matches reality' gate for the identity, and it protects the
+    WHOLE sources/ inventory rather than only what load_sources parses: add a new authoritative
+    input to sources/ and this fails until it is folded into the digest, bound downstream as a
+    policy input, or explicitly declared a non-declaration. An input cannot silently escape the
+    identity.
     """
-    exposed = set(load_sources(ROOT))
-    classified = set(DECLARATION_KEYS) | set(NON_DECLARATION_KEYS)
-    assert exposed == classified, (
-        f"load_sources exposes {sorted(exposed)}, but the identity classifies "
-        f"{sorted(classified)}; every key must be a declaration or a declared exclusion."
+    entries = {p.name for p in (ROOT / "sources").iterdir()}
+    declaration = set(DECLARATION_INPUTS)
+    policy = set(POLICY_INPUTS)
+    non_declaration = set(NON_DECLARATION_INPUTS)
+
+    classified = declaration | policy | non_declaration
+    assert entries == classified, (
+        f"sources/ holds {sorted(entries)}, but the identity classifies {sorted(classified)}; "
+        "every entry must be a declaration, a downstream-bound policy, or a declared exclusion."
     )
-    # The two partitions must not overlap: a key is a declaration xor an exclusion.
-    assert not (set(DECLARATION_KEYS) & set(NON_DECLARATION_KEYS))
+    # The three buckets are disjoint: an entry is exactly one kind.
+    assert declaration.isdisjoint(policy)
+    assert declaration.isdisjoint(non_declaration)
+    assert policy.isdisjoint(non_declaration)
 
 
-def test_long_tail_is_excluded_from_the_declaration_content():
-    """The frozen warehouse sample is a non-declaration and never enters the digest."""
-    assert "long_tail" in NON_DECLARATION_KEYS
-    assert "long_tail" not in DECLARATION_KEYS
+def test_uncovered_declaration_inputs_are_included():
+    """The two authoritative inputs load_sources does NOT return are in the digest.
+
+    evidence_policy.yaml shapes serialized registry output and verification_queue.yaml governs
+    release eligibility; both are declarations and must move the id when they change.
+    """
+    assert "evidence_policy.yaml" in DECLARATION_INPUTS
+    assert "verification_queue.yaml" in DECLARATION_INPUTS
     content = declaration_content(ROOT)
-    assert set(content) == set(DECLARATION_KEYS)
-    assert "long_tail" not in content
+    assert "evidence_policy.yaml" in content
+    assert "verification_queue.yaml" in content
+
+
+def test_policy_inputs_name_a_downstream_binding():
+    """A policy input is excluded from THIS identity only by naming where its version binds.
+
+    The exclusion is a redirection, not a gap: signal_routing.yaml carries routing_policy_version
+    and must bind into a downstream identity, so its record names both.
+    """
+    assert "signal_routing.yaml" in POLICY_INPUTS
+    for name, spec in POLICY_INPUTS.items():
+        assert spec.get("policy_version"), f"{name} names no policy version"
+        assert spec.get("bound_into"), f"{name} names no downstream identity to bind into"
+
+
+def test_frozen_snapshot_is_a_non_declaration():
+    """The frozen warehouse sample is excluded, with a reason, and never enters the digest."""
+    assert "snapshots" in NON_DECLARATION_INPUTS
+    assert NON_DECLARATION_INPUTS["snapshots"]
+    assert "snapshots" not in declaration_content(ROOT)
+
+
+# --- canonicalization properties --------------------------------------------------
 
 
 def test_digest_is_deterministic():
@@ -96,17 +136,66 @@ def test_reordering_a_loaded_declaration_does_not_change_the_digest():
     content = declaration_content(ROOT)
     baseline = hashlib.sha256(canonical_json(content).encode("utf-8")).hexdigest()
     shuffled = copy.deepcopy(content)
-    # Rebuild the top-level mapping in reverse key order.
     shuffled = {k: shuffled[k] for k in reversed(list(shuffled))}
     assert hashlib.sha256(canonical_json(shuffled).encode("utf-8")).hexdigest() == baseline
 
 
-def test_evaluator_version_is_the_declared_sentinel():
-    """The Phase-6 evaluator does not exist yet; the component is a deliberate sentinel, not ''.
+# --- strict type handling (finding 3) --------------------------------------------
 
-    Pinned so that the day a real evaluator version replaces it is a deliberate, reviewed change
-    (every historical declaration_version_id moves with it) rather than an accident.
+
+def test_canonical_json_rejects_unsupported_types():
+    """A YAML set (or any non-JSON-native object) is rejected, never coerced to a string."""
+    with pytest.raises(TypeError):
+        canonical_json({"x": {1, 2, 3}})
+
+    class Weird:
+        pass
+
+    with pytest.raises(TypeError):
+        canonical_json({"x": Weird()})
+
+
+def test_canonical_json_rejects_non_finite_numbers():
+    """NaN and Infinity are not valid JSON and do not round-trip; reject rather than emit."""
+    for bad in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(ValueError):
+            canonical_json({"x": bad})
+
+
+# --- fail-closed on a dirty tree (finding 2) -------------------------------------
+
+
+def test_resolve_fails_closed_on_dirty_declarations(monkeypatch):
+    """With uncommitted declarations, resolve() raises rather than emit an unreproducible id.
+
+    Synthetic: the cleanliness probe is forced to report dirty, so the fail-closed branch is
+    exercised without dirtying the real tree.
     """
+    monkeypatch.setattr(dv, "declaration_paths_are_clean", lambda *a, **k: False)
+    with pytest.raises(DirtyDeclarationsError):
+        resolve()
+
+
+def test_resolve_allow_dirty_opt_in_returns_a_diagnostic_value(monkeypatch):
+    """The explicit opt-in returns a value and records that the tree was dirty."""
+    monkeypatch.setattr(dv, "declaration_paths_are_clean", lambda *a, **k: False)
+    info = resolve(allow_dirty=True)
+    assert info["declarations_clean"] is False
+    assert len(info["declaration_version_id"]) == 64
+
+
+def test_resolve_clean_tree_succeeds():
+    """On a clean tree resolve() returns the full component set without opt-in."""
+    info = resolve()
+    assert info["declarations_clean"] is True
+    assert len(info["declaration_version_id"]) == 64
+
+
+# --- the id itself ----------------------------------------------------------------
+
+
+def test_evaluator_version_is_the_declared_sentinel():
+    """The Phase-6 evaluator does not exist yet; the component is a deliberate sentinel, not ''."""
     assert EVALUATOR_VERSION == "v0-no-repo-evaluator"
     assert EVALUATOR_VERSION != ""
 

--- a/tests/test_declaration_version.py
+++ b/tests/test_declaration_version.py
@@ -1,0 +1,137 @@
+"""The declaration-version identity, and the properties that keep it honest.
+
+`build/declaration_version.py` derives `declaration_version_id` (data-architecture.md §4.6):
+the identity of a set of declarations, evaluated by a named evaluator, that
+`registry.axis_assessments`, `evaluation.product_adoption_measurements` and
+`evaluation.adoption_reconciliation` all key on.
+
+There is no committed golden value to pin — the id embeds `source_git_sha`, and freezing a
+receipt would either name its own parent commit or force a regenerate step on every score edit
+(see the module docstring). So these tests pin the canonicalization's PROPERTIES instead:
+determinism, order-invariance, the exact digested key-set, the exclusions, the sentinel, and
+that the id responds to each component.
+"""
+
+import copy
+import hashlib
+from pathlib import Path
+
+import build.declaration_version as dv
+from build.declaration_version import (
+    CANONICALIZATION_VERSION,
+    DECLARATION_KEYS,
+    EVALUATOR_VERSION,
+    NON_DECLARATION_KEYS,
+    canonical_json,
+    declaration_content,
+    declaration_version_id,
+    source_content_digest,
+)
+from build.validate import load_sources
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_declaration_keys_cover_every_declaration_subtree():
+    """The digested key-set must be load_sources MINUS the declared non-declarations, exactly.
+
+    This is the 'declared state matches reality' gate for the identity: add a new declaration
+    directory to sources/ (so load_sources grows a key) and this fails until the key is either
+    folded into the digest or explicitly classified a non-declaration. A declaration cannot
+    slip out of the version unnoticed.
+    """
+    exposed = set(load_sources(ROOT))
+    classified = set(DECLARATION_KEYS) | set(NON_DECLARATION_KEYS)
+    assert exposed == classified, (
+        f"load_sources exposes {sorted(exposed)}, but the identity classifies "
+        f"{sorted(classified)}; every key must be a declaration or a declared exclusion."
+    )
+    # The two partitions must not overlap: a key is a declaration xor an exclusion.
+    assert not (set(DECLARATION_KEYS) & set(NON_DECLARATION_KEYS))
+
+
+def test_long_tail_is_excluded_from_the_declaration_content():
+    """The frozen warehouse sample is a non-declaration and never enters the digest."""
+    assert "long_tail" in NON_DECLARATION_KEYS
+    assert "long_tail" not in DECLARATION_KEYS
+    content = declaration_content(ROOT)
+    assert set(content) == set(DECLARATION_KEYS)
+    assert "long_tail" not in content
+
+
+def test_digest_is_deterministic():
+    assert source_content_digest(ROOT) == source_content_digest(ROOT)
+
+
+def test_digest_matches_the_documented_rule():
+    """The public digest is exactly sha256 of canonical_json(declaration_content)."""
+    expected = hashlib.sha256(
+        canonical_json(declaration_content(ROOT)).encode("utf-8")
+    ).hexdigest()
+    assert source_content_digest(ROOT) == expected
+
+
+def test_canonical_json_is_key_order_invariant():
+    """A curator reordering keys in a YAML file must produce no change in the serialization."""
+    a = {"z": 1, "a": {"y": 2, "x": 3}, "m": [1, 2, 3]}
+    b = {"a": {"x": 3, "y": 2}, "m": [1, 2, 3], "z": 1}
+    assert canonical_json(a) == canonical_json(b)
+
+
+def test_canonical_json_preserves_list_order():
+    """Key order is normalized; list order is content and must be preserved."""
+    assert canonical_json({"k": [1, 2, 3]}) != canonical_json({"k": [3, 2, 1]})
+
+
+def test_canonical_json_renders_dates_deterministically():
+    """A YAML `date` scalar serializes to its ISO text, not a Python repr."""
+    import datetime
+
+    out = canonical_json({"last_verified": datetime.date(2026, 8, 13)})
+    assert "2026-08-13" in out
+
+
+def test_reordering_a_loaded_declaration_does_not_change_the_digest():
+    """End-to-end order-invariance over the real declaration content."""
+    content = declaration_content(ROOT)
+    baseline = hashlib.sha256(canonical_json(content).encode("utf-8")).hexdigest()
+    shuffled = copy.deepcopy(content)
+    # Rebuild the top-level mapping in reverse key order.
+    shuffled = {k: shuffled[k] for k in reversed(list(shuffled))}
+    assert hashlib.sha256(canonical_json(shuffled).encode("utf-8")).hexdigest() == baseline
+
+
+def test_evaluator_version_is_the_declared_sentinel():
+    """The Phase-6 evaluator does not exist yet; the component is a deliberate sentinel, not ''.
+
+    Pinned so that the day a real evaluator version replaces it is a deliberate, reviewed change
+    (every historical declaration_version_id moves with it) rather than an accident.
+    """
+    assert EVALUATOR_VERSION == "v0-no-repo-evaluator"
+    assert EVALUATOR_VERSION != ""
+
+
+def test_declaration_version_id_shape():
+    """A lowercase 64-hex sha256 — an opaque id, never a readable concatenation."""
+    vid = declaration_version_id("a" * 40, "b" * 64)
+    assert len(vid) == 64
+    assert vid == vid.lower()
+    int(vid, 16)  # hex
+
+
+def test_declaration_version_id_is_sensitive_to_each_component():
+    sha, digest = "a" * 40, "b" * 64
+    base = declaration_version_id(sha, digest)
+    assert declaration_version_id(sha, digest) == base  # stable
+    assert declaration_version_id("c" * 40, digest) != base  # git sha
+    assert declaration_version_id(sha, "d" * 64) != base  # content digest
+    assert declaration_version_id(sha, digest, "v1-real-evaluator") != base  # evaluator
+
+
+def test_canonicalization_version_participates_in_the_id(monkeypatch):
+    """Bumping the canonicalization version changes every id, so a value minted under the old
+    rule cannot collide with one minted under the new rule."""
+    sha, digest = "a" * 40, "b" * 64
+    before = declaration_version_id(sha, digest)
+    monkeypatch.setattr(dv, "CANONICALIZATION_VERSION", CANONICALIZATION_VERSION + 1)
+    assert dv.declaration_version_id(sha, digest) != before

--- a/tests/test_declaration_version.py
+++ b/tests/test_declaration_version.py
@@ -33,7 +33,7 @@ from build.declaration_version import (
     declaration_version_id,
     resolve,
     source_content_digest,
-    tracked_worktree_is_clean,
+    worktree_is_clean_for_identity,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -200,9 +200,9 @@ def test_canonical_json_rejects_non_finite_numbers():
 def test_dirty_declaration_file_is_detected(tmp_path):
     """A dirty declaration file makes the worktree unclean."""
     repo = _tiny_repo(tmp_path)
-    assert tracked_worktree_is_clean(repo) is True
+    assert worktree_is_clean_for_identity(repo) is True
     (repo / "sources" / "x.yaml").write_text("a: 2\n", encoding="utf-8")
-    assert tracked_worktree_is_clean(repo) is False
+    assert worktree_is_clean_for_identity(repo) is False
 
 
 def test_dirty_identity_implementation_is_detected(tmp_path):
@@ -212,28 +212,61 @@ def test_dirty_identity_implementation_is_detected(tmp_path):
     while source_git_sha still names HEAD. The cleanliness probe must cover it.
     """
     repo = _tiny_repo(tmp_path)
-    assert tracked_worktree_is_clean(repo) is True
+    assert worktree_is_clean_for_identity(repo) is True
     (repo / "impl.py").write_text("# identity implementation CHANGED\n", encoding="utf-8")
-    assert tracked_worktree_is_clean(repo) is False
+    assert worktree_is_clean_for_identity(repo) is False
 
 
-def test_untracked_files_do_not_make_the_worktree_dirty(tmp_path):
-    """An untracked file is not read by the computation and must not block a reproducible id."""
+def test_untracked_file_under_sources_makes_the_worktree_dirty(tmp_path):
+    """An UNTRACKED file under sources/ is a declaration the commit lacks — refused.
+
+    This is the gap the --untracked-files=no check missed: the digest read the filesystem, so an
+    untracked declaration entered the digest while source_git_sha named a commit without it.
+    """
+    repo = _tiny_repo(tmp_path)
+    assert worktree_is_clean_for_identity(repo) is True
+    (repo / "sources" / "review_probe.yaml").write_text("display_name: probe\n", encoding="utf-8")
+    assert worktree_is_clean_for_identity(repo) is False
+
+
+def test_untracked_files_outside_sources_are_ignored(tmp_path):
+    """An untracked scratch file elsewhere is not read by the computation and must not block."""
     repo = _tiny_repo(tmp_path)
     (repo / "scratch.txt").write_text("ignore me\n", encoding="utf-8")
-    assert tracked_worktree_is_clean(repo) is True
+    (repo / "build_artifact.log").write_text("noise\n", encoding="utf-8")
+    assert worktree_is_clean_for_identity(repo) is True
+
+
+def test_untracked_declaration_is_excluded_from_the_digest_and_refused():
+    """The reproduction on the real repo: an untracked YAML in sources/categories/.
+
+    Two guarantees at once — the digest reads only tracked files, so the untracked probe does NOT
+    change it (closing `probe_digested=True`); and resolve() REFUSES rather than emit an id over a
+    tree that carries a declaration the commit does not (closing `clean_probe=True`).
+    """
+    probe = ROOT / "sources" / "categories" / "_declaration_version_untracked_probe.yaml"
+    assert not probe.exists()
+    baseline = source_content_digest(ROOT)
+    probe.write_text("display_name: probe\n", encoding="utf-8")
+    try:
+        assert source_content_digest(ROOT) == baseline  # digest reads tracked files only
+        assert worktree_is_clean_for_identity(ROOT) is False  # untracked-under-sources is dirty
+        with pytest.raises(DirtyWorktreeError):
+            resolve()
+    finally:
+        probe.unlink()
 
 
 def test_resolve_fails_closed_on_a_dirty_worktree(monkeypatch):
-    """With any tracked file dirty, resolve() raises rather than emit an unreproducible id."""
-    monkeypatch.setattr(dv, "tracked_worktree_is_clean", lambda *a, **k: False)
+    """With the worktree dirty, resolve() raises rather than emit an unreproducible id."""
+    monkeypatch.setattr(dv, "worktree_is_clean_for_identity", lambda *a, **k: False)
     with pytest.raises(DirtyWorktreeError):
         resolve()
 
 
 def test_resolve_allow_dirty_opt_in_returns_a_diagnostic_value(monkeypatch):
     """The explicit opt-in returns a value and records that the tree was dirty."""
-    monkeypatch.setattr(dv, "tracked_worktree_is_clean", lambda *a, **k: False)
+    monkeypatch.setattr(dv, "worktree_is_clean_for_identity", lambda *a, **k: False)
     info = resolve(allow_dirty=True)
     assert info["worktree_clean"] is False
     assert len(info["declaration_version_id"]) == 64
@@ -246,7 +279,7 @@ def test_resolve_clean_path_succeeds(monkeypatch):
     very changes under test, so asserting against live git state would be flaky. The digest and
     SHA are still computed over the real repo.
     """
-    monkeypatch.setattr(dv, "tracked_worktree_is_clean", lambda *a, **k: True)
+    monkeypatch.setattr(dv, "worktree_is_clean_for_identity", lambda *a, **k: True)
     info = resolve()
     assert info["worktree_clean"] is True
     assert len(info["declaration_version_id"]) == 64

--- a/tests/test_declaration_version.py
+++ b/tests/test_declaration_version.py
@@ -8,12 +8,14 @@ the identity of a set of declarations, evaluated by a named evaluator, that
 There is no committed golden value to pin — the id embeds `source_git_sha`, and freezing a
 receipt would either name its own parent commit or force a regenerate step on every score edit
 (see the module docstring). So these tests pin the canonicalization's PROPERTIES instead:
-the classified `sources/` inventory, determinism, order-invariance, type rejection, the
-fail-closed behavior on a dirty tree, and that the id responds to each component.
+the classified `sources/` inventory, determinism, order-invariance, collision-free encoding,
+type rejection, the fail-closed behavior on a dirty tracked worktree, and that the id responds
+to each component.
 """
 
 import copy
 import hashlib
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -25,29 +27,40 @@ from build.declaration_version import (
     EVALUATOR_VERSION,
     NON_DECLARATION_INPUTS,
     POLICY_INPUTS,
-    DirtyDeclarationsError,
+    DirtyWorktreeError,
     canonical_json,
     declaration_content,
     declaration_version_id,
     resolve,
     source_content_digest,
+    tracked_worktree_is_clean,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
 
 
-# --- the classified inventory (finding 1) ----------------------------------------
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True)
+
+
+def _tiny_repo(tmp_path: Path) -> Path:
+    """A throwaway git repo with a tracked declaration file and a tracked implementation file."""
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "t@t.test")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "sources").mkdir()
+    (tmp_path / "sources" / "x.yaml").write_text("a: 1\n", encoding="utf-8")
+    (tmp_path / "impl.py").write_text("# identity implementation\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "init")
+    return tmp_path
+
+
+# --- the classified inventory (finding 1, first pass) ----------------------------
 
 
 def test_source_inventory_is_fully_classified():
-    """Every top-level sources/ entry is classified into exactly one bucket.
-
-    This is the 'declared state matches reality' gate for the identity, and it protects the
-    WHOLE sources/ inventory rather than only what load_sources parses: add a new authoritative
-    input to sources/ and this fails until it is folded into the digest, bound downstream as a
-    policy input, or explicitly declared a non-declaration. An input cannot silently escape the
-    identity.
-    """
+    """Every top-level sources/ entry is classified into exactly one bucket."""
     entries = {p.name for p in (ROOT / "sources").iterdir()}
     declaration = set(DECLARATION_INPUTS)
     policy = set(POLICY_INPUTS)
@@ -58,18 +71,13 @@ def test_source_inventory_is_fully_classified():
         f"sources/ holds {sorted(entries)}, but the identity classifies {sorted(classified)}; "
         "every entry must be a declaration, a downstream-bound policy, or a declared exclusion."
     )
-    # The three buckets are disjoint: an entry is exactly one kind.
     assert declaration.isdisjoint(policy)
     assert declaration.isdisjoint(non_declaration)
     assert policy.isdisjoint(non_declaration)
 
 
 def test_uncovered_declaration_inputs_are_included():
-    """The two authoritative inputs load_sources does NOT return are in the digest.
-
-    evidence_policy.yaml shapes serialized registry output and verification_queue.yaml governs
-    release eligibility; both are declarations and must move the id when they change.
-    """
+    """The two authoritative inputs load_sources does NOT return are in the digest."""
     assert "evidence_policy.yaml" in DECLARATION_INPUTS
     assert "verification_queue.yaml" in DECLARATION_INPUTS
     content = declaration_content(ROOT)
@@ -77,16 +85,22 @@ def test_uncovered_declaration_inputs_are_included():
     assert "verification_queue.yaml" in content
 
 
-def test_policy_inputs_name_a_downstream_binding():
-    """A policy input is excluded from THIS identity only by naming where its version binds.
+def test_policy_inputs_record_a_binding_obligation():
+    """A policy input records a PENDING binding obligation, not a binding that already exists.
 
-    The exclusion is a redirection, not a gap: signal_routing.yaml carries routing_policy_version
-    and must bind into a downstream identity, so its record names both.
+    The downstream identities (evaluation.adoption_reconciliation, release_id) are not built yet,
+    so there is no binding to prove — only an obligation to record and later ratchet. This test
+    asserts the obligation is well-formed and marked pending; it deliberately does NOT assert a
+    binding exists. When those tables land, `binding` flips to `bound` and this test tightens.
     """
     assert "signal_routing.yaml" in POLICY_INPUTS
     for name, spec in POLICY_INPUTS.items():
         assert spec.get("policy_version"), f"{name} names no policy version"
-        assert spec.get("bound_into"), f"{name} names no downstream identity to bind into"
+        assert spec.get("binds_into"), f"{name} names no downstream identity to bind into"
+        assert spec.get("binding") == "pending", (
+            f"{name}: until reconciliation/releases land, the binding is an obligation, not a "
+            "fact. Ratchet this to 'bound' only when the downstream table is implemented."
+        )
 
 
 def test_frozen_snapshot_is_a_non_declaration():
@@ -140,7 +154,25 @@ def test_reordering_a_loaded_declaration_does_not_change_the_digest():
     assert hashlib.sha256(canonical_json(shuffled).encode("utf-8")).hexdigest() == baseline
 
 
-# --- strict type handling (finding 3) --------------------------------------------
+# --- collision-free encoding (finding 1, second pass) ----------------------------
+
+
+def test_non_string_mapping_keys_are_rejected():
+    """A non-string key would otherwise be coerced so `{1: x}` and `{"1": x}` collide."""
+    with pytest.raises(TypeError):
+        canonical_json({1: "x"})
+    # And the reproduction is genuinely closed: the string-keyed form still serializes.
+    assert canonical_json({"1": "x"})
+
+
+def test_tuples_are_rejected_so_they_cannot_collide_with_lists():
+    """A tuple would otherwise serialize as an array, colliding `(1, 2)` with `[1, 2]`."""
+    with pytest.raises(TypeError):
+        canonical_json((1, 2))
+    with pytest.raises(TypeError):
+        canonical_json({"k": (1, 2)})
+    # The list form is accepted; only the ambiguous tuple is refused.
+    assert canonical_json({"k": [1, 2]})
 
 
 def test_canonical_json_rejects_unsupported_types():
@@ -162,33 +194,63 @@ def test_canonical_json_rejects_non_finite_numbers():
             canonical_json({"x": bad})
 
 
-# --- fail-closed on a dirty tree (finding 2) -------------------------------------
+# --- fail-closed on a dirty tracked worktree (finding 2) -------------------------
 
 
-def test_resolve_fails_closed_on_dirty_declarations(monkeypatch):
-    """With uncommitted declarations, resolve() raises rather than emit an unreproducible id.
+def test_dirty_declaration_file_is_detected(tmp_path):
+    """A dirty declaration file makes the worktree unclean."""
+    repo = _tiny_repo(tmp_path)
+    assert tracked_worktree_is_clean(repo) is True
+    (repo / "sources" / "x.yaml").write_text("a: 2\n", encoding="utf-8")
+    assert tracked_worktree_is_clean(repo) is False
 
-    Synthetic: the cleanliness probe is forced to report dirty, so the fail-closed branch is
-    exercised without dirtying the real tree.
+
+def test_dirty_identity_implementation_is_detected(tmp_path):
+    """A dirty NON-sources tracked file (the identity implementation) is refused too.
+
+    This is the gap the sources/-only check missed: dirty identity code changes the computed id
+    while source_git_sha still names HEAD. The cleanliness probe must cover it.
     """
-    monkeypatch.setattr(dv, "declaration_paths_are_clean", lambda *a, **k: False)
-    with pytest.raises(DirtyDeclarationsError):
+    repo = _tiny_repo(tmp_path)
+    assert tracked_worktree_is_clean(repo) is True
+    (repo / "impl.py").write_text("# identity implementation CHANGED\n", encoding="utf-8")
+    assert tracked_worktree_is_clean(repo) is False
+
+
+def test_untracked_files_do_not_make_the_worktree_dirty(tmp_path):
+    """An untracked file is not read by the computation and must not block a reproducible id."""
+    repo = _tiny_repo(tmp_path)
+    (repo / "scratch.txt").write_text("ignore me\n", encoding="utf-8")
+    assert tracked_worktree_is_clean(repo) is True
+
+
+def test_resolve_fails_closed_on_a_dirty_worktree(monkeypatch):
+    """With any tracked file dirty, resolve() raises rather than emit an unreproducible id."""
+    monkeypatch.setattr(dv, "tracked_worktree_is_clean", lambda *a, **k: False)
+    with pytest.raises(DirtyWorktreeError):
         resolve()
 
 
 def test_resolve_allow_dirty_opt_in_returns_a_diagnostic_value(monkeypatch):
     """The explicit opt-in returns a value and records that the tree was dirty."""
-    monkeypatch.setattr(dv, "declaration_paths_are_clean", lambda *a, **k: False)
+    monkeypatch.setattr(dv, "tracked_worktree_is_clean", lambda *a, **k: False)
     info = resolve(allow_dirty=True)
-    assert info["declarations_clean"] is False
+    assert info["worktree_clean"] is False
     assert len(info["declaration_version_id"]) == 64
 
 
-def test_resolve_clean_tree_succeeds():
-    """On a clean tree resolve() returns the full component set without opt-in."""
+def test_resolve_clean_path_succeeds(monkeypatch):
+    """On a clean tree resolve() returns the full component set without opt-in.
+
+    Cleanliness is forced rather than assumed: during development the real worktree carries the
+    very changes under test, so asserting against live git state would be flaky. The digest and
+    SHA are still computed over the real repo.
+    """
+    monkeypatch.setattr(dv, "tracked_worktree_is_clean", lambda *a, **k: True)
     info = resolve()
-    assert info["declarations_clean"] is True
+    assert info["worktree_clean"] is True
     assert len(info["declaration_version_id"]) == 64
+    assert len(info["source_content_digest"]) == 64
 
 
 # --- the id itself ----------------------------------------------------------------


### PR DESCRIPTION
## What

Defines `declaration_version_id` (data-architecture.md §4.5) — the identity of *which declarations, evaluated by which evaluator* — as its own unit, ahead of the tables that key on it (`evaluation.product_adoption_measurements`, `evaluation.adoption_reconciliation`, `registry.axis_assessments`), so it is defined once rather than improvised inside the first consumer.

`build/declaration_version.py` derives `declaration_version_id = source_git_sha + source_content_digest + evaluator_version`:

- **`source_content_digest`** is a canonical SHA-256 over every authoritative declaration input under `sources/`. The full top-level inventory is classified into three buckets and gated (`test_source_inventory_is_fully_classified`), so a new input cannot escape the digest unnoticed:
  - **declaration** (in the digest): products, organizations, categories, scores, rubrics, taxonomy, the long-tail `registry` seeds, and — beyond what `load_sources` returns — `evidence_policy.yaml` and `verification_queue.yaml`, plus the `allowlists` (its `.txt` reduced to the same semantic set the repo's own `test_digest_ratchet` gate parses);
  - **policy** (excluded from the digest): `signal_routing.yaml`, whose `routing_policy_version` is a **pending** binding obligation for `evaluation.adoption_reconciliation` / `release_id` — recorded now, ratcheted to a real assertion when those tables land;
  - **non-declaration** (excluded from the digest): the frozen long-tail snapshot. The derived score projections are excluded by construction (they never live in `sources/`).
- **Commit-scoped.** Those are exclusions from the *content digest*, not from the id: `declaration_version_id` also carries `source_git_sha`, so any commit touching the excluded inputs changes the id. The digest is a content-addressed cross-check that distinguishes a real declaration change from an unrelated one.
- **Canonicalization is collision-free and strict.** `canonical_json` validates structure before serializing — non-string mapping keys and tuples are rejected (they would otherwise coerce to a colliding form), as are unsupported types and non-finite numbers.
- **Fail-closed derivation.** The id is derived at run time, not stored (it embeds `source_git_sha`, and no commit can record its own SHA). `resolve()` refuses to emit an id over a dirty **tracked worktree** — dirty declarations *or* dirty identity/evaluator code — unless an explicit `--allow-dirty` diagnostic opt-in is given.
- **`evaluator_version`** is a declared sentinel `v0-no-repo-evaluator` until the repository-owned evaluator lands (Phase 6) — forward-compatible, and deliberately not the empty string.

`tests/test_declaration_version.py` pins the canonicalization's *properties* (the classified inventory, determinism, order-invariance, collision rejection, type/finite rejection, fail-closed-on-dirty, per-component sensitivity) rather than a brittle golden value. Also concretizes the §4.5 canonicalization declaration for `source_content_digest`, and records the unit in `migration-status.md` alongside the still-pending `observation_snapshot_id` (which waits on `observations.product_adoption_current` reaching `main`).

No warehouse asset, model, or platform state changes — this is a build-side computation plus its tests and spec.

## Checklist

- [x] `uv run python -m build.validate` prints `0 error(s)`
- [ ] New/changed scores cite sources (`url`, `shows`, `accessed`) — N/A, no score changes
- [x] I did not edit `build/notebook_data.json` or `notebooks/ai-stack-map.py`
      (a bot regenerates them on merge)
- [ ] Product appears in exactly one category roster and one org roster — N/A, no product changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)