### PR TITLE
Derive observation_snapshot_id as its own unit (evaluation prerequisite)

### DIFF
--- a/build/observation_snapshot.py
+++ b/build/observation_snapshot.py
@@ -4,53 +4,59 @@ Two distinct things the release model (data-architecture.md §4.5) names separat
 `releases.manifest` carries both:
 
   * ``observation_content_digest`` — a pure SHA-256 of the canonical observation content, "and
-    nothing else". This is the raw content address: identical measurements digest identically,
-    forever, regardless of the canonicalization rule in force.
+    nothing else". Identical measurements digest identically, forever, regardless of the
+    canonicalization rule in force. Version-independent.
   * ``observation_snapshot_id`` — the *identity* that `evaluation.adoption_reconciliation` and
-    `releases.manifest` key on, and that binds into `release_id`. It is derived from BOTH the
-    ``canonicalization_version`` and the content digest, so a persisted snapshot id names the rule
-    that produced it. Without this a caller could store an id and be unable to tell which
-    serialization produced it; two rules could even collide on one id.
-
-The earlier revision of this module conflated the two — it exposed only the pure digest under the
-name ``observation_snapshot_id`` and left the version unbound. The split here is what §4.5 already
-requires.
+    `releases.manifest` key on, and that binds into `release_id`. It is a domain-separated hash of
+    the ``canonicalization_version`` and the content digest, so a persisted snapshot id names the
+    rule that produced it; two rules cannot collide on one id.
 
 ## What the content digest covers
 
 ``observation_content_digest`` is a SHA-256 over the measurement columns only — ``CONTENT_COLUMNS``:
 ``product_slug``, ``product_type``, ``artifact_kind``, ``artifact_id``, ``channel``,
 ``metric_type``, ``raw_value``, ``unit``, ``measurement_window_days``, ``observed_at`` — taken as an
-order-independent **multiset** (rows serialized, sorted, then hashed). Lineage (``source_run_id``,
-``source_record_id``, ``source_dataset``, ``source_table``), capture time (``ingested_at``), the
-derived ``observation_id``, ``is_valid``, and ``supersedes_observation_id`` are excluded, so an
-unchanged measurement keeps its digest across re-runs; the runs that produced it live in
-``observation_run_ids`` beside the id (§4.3), never in it.
+order-independent **multiset** (rows serialized, sorted, then hashed). Lineage, capture time
+(``ingested_at``), the derived ``observation_id``, ``is_valid``, and ``supersedes_observation_id``
+are excluded; the runs that produced the observations live in ``observation_run_ids`` beside the id
+(§4.3), never in it.
 
-## Timestamps are normalized to UTC
+## Strict per-column typing
 
-``observed_at`` is normalized before hashing: an aware timestamp is converted to UTC; a naive one
-is interpreted as UTC (the warehouse emits naive timestamps and the pipeline runs on UTC crons, so
-that is their real zone), and it is rendered at fixed microsecond precision with a ``Z`` suffix.
-Without this the same instant written ``…+00:00``, ``…-04:00``, or naive would produce three
-different digests (§4.5 requires timezone normalization).
+Every value is checked before serialization. ``observed_at`` must be an actual ``datetime`` — a
+string or other lookalike is rejected, never passed through (a string would bypass UTC
+normalization and produce a non-reproducible digest). Aware timestamps are converted to UTC; naive
+ones are interpreted as UTC (the warehouse emits naive UTC), rendered at fixed microsecond
+precision with a ``Z`` suffix. Every other column must be a JSON scalar (``str``/``bool``/``int``/
+finite ``float``/``None``); anything else raises.
 
-## Derived, not stored
+## The snapshot-id preimage (domain-separated, exact bytes)
 
-Like ``declaration_version_id``, these are run-time computations, not committed receipts — a
-full-refresh table's content changes every run, so a frozen value would go stale. Reconciliation
-and the release builder compute them over the live ``product_adoption_current`` rows. The tests
-exercise them against the one observation set that IS committed and immutable — the Phase-2
-baseline parquet — so both digests over it are pinned as fixed contracts.
+``observation_snapshot_id`` = ``SHA-256`` of the UTF-8 bytes:
+
+    "os-ai-map:observation-snapshot:v" + str(CANONICALIZATION_VERSION) + "\\0" + content_digest
+
+where ``content_digest`` is the 64-character lowercase-hex ``observation_content_digest``. The
+domain label separates this hash from any other SHA-256 in the system; the ``v<N>`` binds the
+version; the NUL byte unambiguously delimits the version prefix from the digest. This is a fixed,
+documented preimage, not an underspecified concatenation.
 
 ## The canonicalization ratchet
 
-``CANONICALIZATION_FINGERPRINT`` is the content digest over a fixed in-module fixture: any change to
-``CONTENT_COLUMNS`` or the serializer moves it. It is gated two ways — a test asserts it matches the
-current serializer, and a merge-base ratchet (``check_canonicalization_ratchet``) fails if the
-fingerprint changed against the merge base while ``CANONICALIZATION_VERSION`` did not advance. So a
-serialization change cannot land without a version bump, even if someone regenerates the pinned
-golden values.
+``CANONICALIZATION_FINGERPRINT`` is the digest of an explicit contract *descriptor*
+(``CANONICALIZATION_CONTRACT``) — the columns, ordering, allowed types, timestamp rule, null/number
+encoding, serialization format, and hash. Fingerprinting the descriptor rather than one sample's
+output means a declared-rule change is caught even where no fixture exercises it. A merge-base
+ratchet (``check_canonicalization_ratchet``) fails if the descriptor changed against the merge base
+while ``CANONICALIZATION_VERSION`` did not advance. Implementation *conformance* to the contract is
+tested separately (behavioral fixtures and the baseline goldens), so a serializer that drifts from
+its declared contract also fails.
+
+## Derived, not stored
+
+Like ``declaration_version_id``, these are run-time computations over the live
+``product_adoption_current`` rows; the tests exercise them against the committed, immutable Phase-2
+baseline, whose two digests are pinned as fixed contracts.
 
 Usage:
     uv run python -m build.observation_snapshot            # digests over the committed baseline
@@ -63,6 +69,7 @@ import argparse
 import datetime
 import hashlib
 import json
+import math
 import re
 import subprocess
 from collections.abc import Iterable
@@ -75,10 +82,8 @@ _UTC = datetime.timezone.utc
 # into observation_content_digest), and enforced by the ratchet below.
 CANONICALIZATION_VERSION = 1
 
-# The normalized observation content: the measurement itself, and nothing else. Lineage
-# (source_run_id / source_record_id / source_dataset / source_table), capture time (ingested_at),
-# the derived observation_id, is_valid, and supersedes_observation_id are deliberately excluded.
-# Order is fixed: it is the serialization's column order.
+# The measurement content: the measurement itself, and nothing else. Order is fixed — it is the
+# serialization's column order.
 CONTENT_COLUMNS: tuple[str, ...] = (
     "product_slug",
     "product_type",
@@ -92,104 +97,109 @@ CONTENT_COLUMNS: tuple[str, ...] = (
     "observed_at",
 )
 
+# Columns that MUST be a datetime and are UTC-normalized. A string or other lookalike is rejected.
+TIMESTAMP_COLUMNS: frozenset[str] = frozenset({"observed_at"})
+
+# Exact scalar types allowed in a non-timestamp content column, by identity (bool listed apart from
+# int: both are wanted and serialize to distinct JSON tokens).
+_ALLOWED_SCALARS = (str, bool, int, float)
+
 BASELINE_PARQUET = ROOT / "warehouse/data/observations/product_adoption_baseline.parquet"
+
+_SNAPSHOT_DOMAIN = "os-ai-map:observation-snapshot"
 
 
 def _canonical_timestamp(value: datetime.datetime) -> str:
-    """UTC-normalized, fixed-precision, ``Z``-suffixed ISO text.
-
-    Aware timestamps are converted to UTC; naive timestamps are interpreted as UTC (the warehouse
-    emits naive UTC). Always six fractional digits, so the same instant has exactly one rendering.
-    """
+    """UTC-normalized, fixed-precision, ``Z``-suffixed ISO text (six fractional digits)."""
     if value.tzinfo is None:
         value = value.replace(tzinfo=_UTC)
     value = value.astimezone(_UTC)
     return value.strftime("%Y-%m-%dT%H:%M:%S.") + f"{value.microsecond:06d}Z"
 
 
-def _canonical_value(value: object) -> object:
-    if isinstance(value, datetime.datetime):
-        return _canonical_timestamp(value)
-    if isinstance(value, datetime.date):
-        return value.isoformat()
-    return value
-
-
 def _canonical_row(row: dict) -> str:
-    """One observation's content as a compact JSON array over CONTENT_COLUMNS.
-
-    Timestamps are UTC-normalized; numbers must be finite; every other non-JSON-native type is
-    rejected (no permissive ``default``), so an unexpected value fails loudly rather than becoming
-    an implementation-dependent string and a non-reproducible digest.
-    """
+    """One observation's content as a compact JSON array over CONTENT_COLUMNS, strictly typed."""
     values = []
     for column in CONTENT_COLUMNS:
         if column not in row:
             raise KeyError(f"observation row is missing content column {column!r}")
-        values.append(_canonical_value(row[column]))
+        value = row[column]
+        if column in TIMESTAMP_COLUMNS:
+            if not isinstance(value, datetime.datetime):
+                raise TypeError(
+                    f"{column} must be a datetime, got {type(value).__name__!r} "
+                    f"({value!r}); a string or other lookalike would bypass UTC normalization"
+                )
+            values.append(_canonical_timestamp(value))
+            continue
+        if value is None:
+            values.append(None)
+        elif type(value) in _ALLOWED_SCALARS:
+            if type(value) is float and not math.isfinite(value):
+                raise ValueError(f"non-finite number in column {column!r}: {value!r}")
+            values.append(value)
+        else:
+            raise TypeError(
+                f"unsupported type {type(value).__name__!r} in content column {column!r}"
+            )
     return json.dumps(values, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
 
 
 def observation_content_digest(rows: Iterable[dict]) -> str:
-    """The pure content address of a set of observations — §4.5 "content and nothing else".
-
-    SHA-256 over the sorted, newline-joined canonical rows (an order-independent multiset). Does
-    NOT depend on the canonicalization version — that binding lives in observation_snapshot_id.
-    """
+    """The pure content address of a set of observations — §4.5 "content and nothing else"."""
     lines = sorted(_canonical_row(row) for row in rows)
     return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
 
 
-def observation_snapshot_id(rows: Iterable[dict]) -> str:
-    """The versioned identity reconciliation and releases key on.
+def snapshot_id_from_digest(content_digest: str, version: int | None = None) -> str:
+    """The versioned, domain-separated snapshot id for a content digest (exact bytes in module doc)."""
+    v = CANONICALIZATION_VERSION if version is None else version
+    preimage = f"{_SNAPSHOT_DOMAIN}:v{v}\0{content_digest}".encode("utf-8")
+    return hashlib.sha256(preimage).hexdigest()
 
-    Binds the canonicalization version to the content digest, so a stored id names the rule that
-    produced it and two rules cannot collide on one id.
-    """
+
+def observation_snapshot_id(rows: Iterable[dict]) -> str:
+    """The versioned identity reconciliation and releases key on."""
     return snapshot_id_from_digest(observation_content_digest(rows))
 
 
-def snapshot_id_from_digest(content_digest: str, version: int | None = None) -> str:
-    """Compose a snapshot id from a content digest and the canonicalization version."""
-    payload = json.dumps(
-        {
-            "canonicalization_version": CANONICALIZATION_VERSION if version is None else version,
-            "observation_content_digest": content_digest,
-        },
-        separators=(",", ":"),
-        sort_keys=True,
-    )
+# --- the canonicalization contract, its fingerprint, and the ratchet -------------
+
+# The explicit, declared canonicalization contract. The fingerprint is over THIS descriptor, so a
+# change to any declared rule — a new column, a changed type rule, the timestamp format — moves the
+# fingerprint whether or not a fixture happens to exercise it. Implementation conformance to the
+# contract is tested separately.
+CANONICALIZATION_CONTRACT: dict = {
+    "version": CANONICALIZATION_VERSION,
+    "content_columns": list(CONTENT_COLUMNS),
+    "timestamp_columns": sorted(TIMESTAMP_COLUMNS),
+    "row_ordering": "sorted-multiset-of-per-row-compact-json-arrays-newline-joined",
+    "serialization": "json-compact-array;separators=(',',':');utf-8;ensure_ascii=false",
+    "allowed_nontimestamp_scalars": ["str", "bool", "int", "finite-float", "NoneType"],
+    "timestamp_rule": "datetime-required;to-utc;naive-interpreted-utc;"
+    "strftime=%Y-%m-%dT%H:%M:%S.<6-digit-microseconds>Z",
+    "null_encoding": "json-null",
+    "number_rule": "finite-only;NaN-and-Infinity-rejected",
+    "hash": "sha256-lowercase-hex",
+    "snapshot_id_preimage": "sha256('os-ai-map:observation-snapshot:v'+version+'\\0'+content_digest)",
+}
+
+
+def canonicalization_fingerprint() -> str:
+    """SHA-256 over the canonical serialization of the contract descriptor."""
+    payload = json.dumps(CANONICALIZATION_CONTRACT, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
-# --- the canonicalization fingerprint and ratchet --------------------------------
-
-# A fixed fixture exercising the serializer: an aware timestamp, a naive one, a null window, and
-# unicode. CANONICALIZATION_FINGERPRINT is its content digest; any CONTENT_COLUMNS or serializer
-# change moves it, and the ratchet then requires CANONICALIZATION_VERSION to advance.
-_FINGERPRINT_FIXTURE: tuple[dict, ...] = (
-    {
-        "product_slug": "fixture-a", "product_type": "model", "artifact_kind": "github",
-        "artifact_id": "ówner/repo", "channel": "github", "metric_type": "stars",
-        "raw_value": 42, "unit": "stars", "measurement_window_days": None,
-        "observed_at": datetime.datetime(2026, 1, 2, 3, 4, 5, tzinfo=_UTC),
-    },
-    {
-        "product_slug": "fixture-b", "product_type": "dataset", "artifact_kind": "huggingface_dataset",
-        "artifact_id": "org/set", "channel": "huggingface", "metric_type": "downloads",
-        "raw_value": 1000, "unit": "downloads", "measurement_window_days": 30,
-        "observed_at": datetime.datetime(2026, 1, 2, 3, 4, 5),  # naive → interpreted UTC
-    },
-)
-CANONICALIZATION_FINGERPRINT = "e2e93998bdcf8fabe99fc2fb6d8e3870bf255785b153ba53138fd15ae578eb5c"
+CANONICALIZATION_FINGERPRINT = "cfe7fe9c1cdb30f72f079a2fe0b6437a82c8580ddec3ee2c09d70b08a2a91c86"
 
 
 class CanonicalizationRatchetError(RuntimeError):
-    """Raised when the canonicalization changed without a version bump."""
+    """Raised when the canonicalization contract changed without a version bump."""
 
 
 def check_canonicalization_ratchet(before: dict | None, now: dict) -> None:
-    """Fail if the fingerprint moved against the merge base while the version did not advance.
+    """Fail if the contract fingerprint moved against the merge base while the version did not.
 
     ``before`` / ``now`` are ``{"version": int, "fingerprint": str}``; ``before`` is None on the
     introducing PR (the module did not exist at the merge base), which is not a violation.
@@ -198,10 +208,9 @@ def check_canonicalization_ratchet(before: dict | None, now: dict) -> None:
         return
     if now["fingerprint"] != before["fingerprint"] and now["version"] <= before["version"]:
         raise CanonicalizationRatchetError(
-            "the observation canonicalization changed (CONTENT_COLUMNS or the serializer) but "
-            f"CANONICALIZATION_VERSION did not advance ({before['version']} -> {now['version']}). "
-            "Bump the version so a snapshot id minted under the old rule cannot be confused with "
-            "one minted under the new rule."
+            "the observation canonicalization contract changed but CANONICALIZATION_VERSION did "
+            f"not advance ({before['version']} -> {now['version']}). Bump the version so a "
+            "snapshot id minted under the old rule cannot be confused with one under the new rule."
         )
 
 
@@ -263,10 +272,6 @@ def main() -> int:
     print(f"observation_content_digest {info['observation_content_digest']}")
     print(f"observation_snapshot_id    {info['observation_snapshot_id']}")
     print(f"computed_over              {info['computed_over']}")
-    print(
-        "\n(Computed over the committed Phase-2 baseline. At reconciliation/release time the same\n"
-        "functions run over the live observations.product_adoption_current rows.)"
-    )
     return 0
 
 

--- a/build/observation_snapshot.py
+++ b/build/observation_snapshot.py
@@ -4,8 +4,10 @@ Two distinct things the release model (data-architecture.md §4.5) names separat
 `releases.manifest` carries both:
 
   * ``observation_content_digest`` — a pure SHA-256 of the canonical observation content, "and
-    nothing else". Identical measurements digest identically, forever, regardless of the
-    canonicalization rule in force. Version-independent.
+    nothing else": it does not fold in the ``canonicalization_version`` number, so bumping the
+    version alone does not move it. It is *not* invariant across canonicalization rules — the
+    canonical bytes themselves change if the contract changes — so two content digests are
+    comparable only under the same canonicalization contract.
   * ``observation_snapshot_id`` — the *identity* that `evaluation.adoption_reconciliation` and
     `releases.manifest` key on, and that binds into `release_id`. It is a domain-separated hash of
     the ``canonicalization_version`` and the content digest, so a persisted snapshot id names the
@@ -23,12 +25,23 @@ are excluded; the runs that produced the observations live in ``observation_run_
 
 ## Strict per-column typing
 
-Every value is checked before serialization. ``observed_at`` must be an actual ``datetime`` — a
-string or other lookalike is rejected, never passed through (a string would bypass UTC
-normalization and produce a non-reproducible digest). Aware timestamps are converted to UTC; naive
-ones are interpreted as UTC (the warehouse emits naive UTC), rendered at fixed microsecond
-precision with a ``Z`` suffix. Every other column must be a JSON scalar (``str``/``bool``/``int``/
-finite ``float``/``None``); anything else raises.
+Every value is checked against its column's declared type before serialization; a malformed row
+fails closed rather than minting an identity over garbage:
+
+  * the identity, vocabulary, and unit fields (``product_slug``, ``product_type``,
+    ``artifact_kind``, ``artifact_id``, ``channel``, ``metric_type``, ``unit``) must be **nonempty
+    strings** — an empty string, ``None``, or a non-string raises;
+  * ``raw_value`` must be a **finite ``int`` or ``float``, excluding ``bool``** (``True`` is not a
+    measurement); ``NaN``/``Infinity`` raise;
+  * ``measurement_window_days`` must be a **nonnegative ``int`` or ``None``, excluding ``bool``**;
+  * ``observed_at`` must be an actual ``datetime`` — a string, epoch ``int``, or bare ``date`` is
+    rejected, never passed through (a string would bypass UTC normalization and produce a
+    non-reproducible digest). Aware timestamps are converted to UTC; naive ones are interpreted as
+    UTC (the warehouse emits naive UTC), rendered at fixed microsecond precision with a ``Z``
+    suffix.
+
+Type checks use exact ``type(...) is`` identity, not ``isinstance``, so a ``bool`` never slips
+through where an ``int`` or ``str`` is required.
 
 ## The snapshot-id preimage (domain-separated, exact bytes)
 
@@ -100,13 +113,21 @@ CONTENT_COLUMNS: tuple[str, ...] = (
 # Columns that MUST be a datetime and are UTC-normalized. A string or other lookalike is rejected.
 TIMESTAMP_COLUMNS: frozenset[str] = frozenset({"observed_at"})
 
-# Exact scalar types allowed in a non-timestamp content column, by identity (bool listed apart from
-# int: both are wanted and serialize to distinct JSON tokens).
-_ALLOWED_SCALARS = (str, bool, int, float)
+# Identity, vocabulary, and unit fields: each must be a nonempty string.
+IDENTITY_COLUMNS: frozenset[str] = frozenset({
+    "product_slug",
+    "product_type",
+    "artifact_kind",
+    "artifact_id",
+    "channel",
+    "metric_type",
+    "unit",
+})
 
 BASELINE_PARQUET = ROOT / "warehouse/data/observations/product_adoption_baseline.parquet"
 
 _SNAPSHOT_DOMAIN = "os-ai-map:observation-snapshot"
+_HEX64 = re.compile(r"\A[0-9a-f]{64}\Z")
 
 
 def _canonical_timestamp(value: datetime.datetime) -> str:
@@ -115,6 +136,43 @@ def _canonical_timestamp(value: datetime.datetime) -> str:
         value = value.replace(tzinfo=_UTC)
     value = value.astimezone(_UTC)
     return value.strftime("%Y-%m-%dT%H:%M:%S.") + f"{value.microsecond:06d}Z"
+
+
+def _canonical_identity(column: str, value: object) -> str:
+    """An identity/vocabulary/unit field: a nonempty string, nothing else."""
+    if type(value) is not str:
+        raise TypeError(
+            f"{column} must be a nonempty str, got {type(value).__name__!r} ({value!r})"
+        )
+    if value == "":
+        raise ValueError(f"{column} must be a nonempty str, got an empty string")
+    return value
+
+
+def _canonical_raw_value(column: str, value: object) -> int | float:
+    """``raw_value``: a finite int or float, excluding bool."""
+    if type(value) not in (int, float):  # exact type: excludes bool, None, str
+        raise TypeError(
+            f"{column} must be a finite int or float (not bool), got "
+            f"{type(value).__name__!r} ({value!r})"
+        )
+    if type(value) is float and not math.isfinite(value):
+        raise ValueError(f"non-finite number in column {column!r}: {value!r}")
+    return value
+
+
+def _canonical_window(column: str, value: object) -> int | None:
+    """``measurement_window_days``: a nonnegative int or null, excluding bool."""
+    if value is None:
+        return None
+    if type(value) is not int:  # exact type: excludes bool and float
+        raise TypeError(
+            f"{column} must be a nonnegative int or None (not bool), got "
+            f"{type(value).__name__!r} ({value!r})"
+        )
+    if value < 0:
+        raise ValueError(f"{column} must be nonnegative, got {value!r}")
+    return value
 
 
 def _canonical_row(row: dict) -> str:
@@ -131,17 +189,14 @@ def _canonical_row(row: dict) -> str:
                     f"({value!r}); a string or other lookalike would bypass UTC normalization"
                 )
             values.append(_canonical_timestamp(value))
-            continue
-        if value is None:
-            values.append(None)
-        elif type(value) in _ALLOWED_SCALARS:
-            if type(value) is float and not math.isfinite(value):
-                raise ValueError(f"non-finite number in column {column!r}: {value!r}")
-            values.append(value)
-        else:
-            raise TypeError(
-                f"unsupported type {type(value).__name__!r} in content column {column!r}"
-            )
+        elif column in IDENTITY_COLUMNS:
+            values.append(_canonical_identity(column, value))
+        elif column == "raw_value":
+            values.append(_canonical_raw_value(column, value))
+        elif column == "measurement_window_days":
+            values.append(_canonical_window(column, value))
+        else:  # pragma: no cover - a new content column with no declared type
+            raise AssertionError(f"content column {column!r} has no declared type rule")
     return json.dumps(values, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
 
 
@@ -152,8 +207,20 @@ def observation_content_digest(rows: Iterable[dict]) -> str:
 
 
 def snapshot_id_from_digest(content_digest: str, version: int | None = None) -> str:
-    """The versioned, domain-separated snapshot id for a content digest (exact bytes in module doc)."""
+    """The versioned, domain-separated snapshot id for a content digest (exact bytes in module doc).
+
+    Fails closed on a malformed preimage: the version must be a positive int (not bool), and the
+    content digest must be exactly 64 lowercase hex characters — the shape ``observation_content_
+    digest`` produces. Minting an identity over ``"x"`` or an uppercase or truncated digest would
+    silently create an id that no content can reproduce.
+    """
     v = CANONICALIZATION_VERSION if version is None else version
+    if type(v) is not int or v <= 0:  # exact type: excludes bool
+        raise ValueError(f"canonicalization version must be a positive int, got {v!r}")
+    if type(content_digest) is not str or not _HEX64.match(content_digest):
+        raise ValueError(
+            f"content digest must be 64-character lowercase hex, got {content_digest!r}"
+        )
     preimage = f"{_SNAPSHOT_DOMAIN}:v{v}\0{content_digest}".encode("utf-8")
     return hashlib.sha256(preimage).hexdigest()
 
@@ -175,13 +242,26 @@ CANONICALIZATION_CONTRACT: dict = {
     "timestamp_columns": sorted(TIMESTAMP_COLUMNS),
     "row_ordering": "sorted-multiset-of-per-row-compact-json-arrays-newline-joined",
     "serialization": "json-compact-array;separators=(',',':');utf-8;ensure_ascii=false",
-    "allowed_nontimestamp_scalars": ["str", "bool", "int", "finite-float", "NoneType"],
+    "column_types": {
+        "product_slug": "nonempty-str",
+        "product_type": "nonempty-str",
+        "artifact_kind": "nonempty-str",
+        "artifact_id": "nonempty-str",
+        "channel": "nonempty-str",
+        "metric_type": "nonempty-str",
+        "unit": "nonempty-str",
+        "raw_value": "finite-int-or-float-excluding-bool",
+        "measurement_window_days": "nonnegative-int-or-null-excluding-bool",
+        "observed_at": "datetime-utc",
+    },
+    "type_check": "exact-type-identity-not-isinstance",
     "timestamp_rule": "datetime-required;to-utc;naive-interpreted-utc;"
     "strftime=%Y-%m-%dT%H:%M:%S.<6-digit-microseconds>Z",
     "null_encoding": "json-null",
     "number_rule": "finite-only;NaN-and-Infinity-rejected",
     "hash": "sha256-lowercase-hex",
-    "snapshot_id_preimage": "sha256('os-ai-map:observation-snapshot:v'+version+'\\0'+content_digest)",
+    "snapshot_id_preimage": "sha256('os-ai-map:observation-snapshot:v'+version+'\\0'+content_digest);"
+    "version-positive-int;content_digest-64-lowercase-hex",
 }
 
 
@@ -191,7 +271,7 @@ def canonicalization_fingerprint() -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
-CANONICALIZATION_FINGERPRINT = "cfe7fe9c1cdb30f72f079a2fe0b6437a82c8580ddec3ee2c09d70b08a2a91c86"
+CANONICALIZATION_FINGERPRINT = "f30c139bfb8a740589f34d9bd39cbee4f0dd4fe292788e2f0e4d43fc8bfaa150"
 
 
 class CanonicalizationRatchetError(RuntimeError):

--- a/build/observation_snapshot.py
+++ b/build/observation_snapshot.py
@@ -1,51 +1,59 @@
-"""Derive the ``observation_snapshot_id`` — the identity of a set of adoption observations.
+"""Identity of a set of adoption observations — the content digest and the versioned snapshot id.
 
-One of the three release identities (data-architecture.md §4.5). Where ``declaration_version_id``
-answers "which declarations", this answers "which measurements": it is the content address of the
-normalized adoption observations that a reconciliation adjudicated a declaration against. It is
-what ``evaluation.adoption_reconciliation`` and ``releases.manifest`` key on alongside the
-declaration version.
+Two distinct things the release model (data-architecture.md §4.5) names separately, and
+`releases.manifest` carries both:
 
-## Content alone — §4.5, strictly
+  * ``observation_content_digest`` — a pure SHA-256 of the canonical observation content, "and
+    nothing else". This is the raw content address: identical measurements digest identically,
+    forever, regardless of the canonicalization rule in force.
+  * ``observation_snapshot_id`` — the *identity* that `evaluation.adoption_reconciliation` and
+    `releases.manifest` key on, and that binds into `release_id`. It is derived from BOTH the
+    ``canonicalization_version`` and the content digest, so a persisted snapshot id names the rule
+    that produced it. Without this a caller could store an id and be unable to tell which
+    serialization produced it; two rules could even collide on one id.
 
-``observation_snapshot_id`` is "a canonical digest of the normalized observation content, and
-nothing else" (§4.5). Two materializations with identical measurements share an id; a re-run that
-changes nothing measured keeps the id (§4.3). Two consequences follow, and both are enforced here:
+The earlier revision of this module conflated the two — it exposed only the pure digest under the
+name ``observation_snapshot_id`` and left the version unbound. The split here is what §4.5 already
+requires.
 
-  * **Run identifiers are lineage, not inputs.** ``source_run_id`` and the ``observation_run_ids``
-    a snapshot was produced by are recorded *beside* the id, never folded into it (§4.3) —
-    otherwise every re-run would mint a new snapshot even when the measurements were identical,
-    which is the opposite of what the id is for.
-  * **Capture time and provenance are excluded.** ``ingested_at`` (when the row was written),
-    ``source_dataset`` / ``source_table`` (which physical table it sat in), ``source_record_id``,
-    the derived ``observation_id`` (a hash of the grain, redundant), ``is_valid`` (a constant on
-    the valid current-state slice), and ``supersedes_observation_id`` (history, absent pre-2B) are
-    all excluded. What remains — ``CONTENT_COLUMNS`` — is the measurement itself.
+## What the content digest covers
 
-The digest is over the observations as a **multiset**: the serialized rows are sorted before
-hashing, so the id does not depend on the order the rows were materialized or read in.
+``observation_content_digest`` is a SHA-256 over the measurement columns only — ``CONTENT_COLUMNS``:
+``product_slug``, ``product_type``, ``artifact_kind``, ``artifact_id``, ``channel``,
+``metric_type``, ``raw_value``, ``unit``, ``measurement_window_days``, ``observed_at`` — taken as an
+order-independent **multiset** (rows serialized, sorted, then hashed). Lineage (``source_run_id``,
+``source_record_id``, ``source_dataset``, ``source_table``), capture time (``ingested_at``), the
+derived ``observation_id``, ``is_valid``, and ``supersedes_observation_id`` are excluded, so an
+unchanged measurement keeps its digest across re-runs; the runs that produced it live in
+``observation_run_ids`` beside the id (§4.3), never in it.
 
-## Canonicalization version is recorded beside the id, not inside it
+## Timestamps are normalized to UTC
 
-§4.7 requires a canonicalization version so the rule can change without silently changing every
-digest. But §4.5 says the id is content "and nothing else" — folding the version into the digest
-bytes would break that. The two are reconciled by recording ``CANONICALIZATION_VERSION`` alongside
-the id (in the reconciliation row / manifest that carries it), never in the hashed input. A rule
-change is therefore a visible, declared version bump; the id itself stays a pure content address.
-This is the deliberate difference from ``declaration_version_id``, an opaque composite whose
-version *is* folded in.
+``observed_at`` is normalized before hashing: an aware timestamp is converted to UTC; a naive one
+is interpreted as UTC (the warehouse emits naive timestamps and the pipeline runs on UTC crons, so
+that is their real zone), and it is rendered at fixed microsecond precision with a ``Z`` suffix.
+Without this the same instant written ``…+00:00``, ``…-04:00``, or naive would produce three
+different digests (§4.5 requires timezone normalization).
 
 ## Derived, not stored
 
-Like ``declaration_version_id``, this is a computation the release builder and reconciliation call
-at run time over the live ``observations.product_adoption_current``; it is not a committed receipt.
-A full-refresh table's snapshot id must track current content, and a frozen value would go stale
-on every run. The tests exercise it against the one observation set that IS committed and
-immutable — the Phase-2 baseline parquet — which is why a golden value over the baseline is
-pinned: those bytes are ratchet-locked, so the digest over them is a fixed contract.
+Like ``declaration_version_id``, these are run-time computations, not committed receipts — a
+full-refresh table's content changes every run, so a frozen value would go stale. Reconciliation
+and the release builder compute them over the live ``product_adoption_current`` rows. The tests
+exercise them against the one observation set that IS committed and immutable — the Phase-2
+baseline parquet — so both digests over it are pinned as fixed contracts.
+
+## The canonicalization ratchet
+
+``CANONICALIZATION_FINGERPRINT`` is the content digest over a fixed in-module fixture: any change to
+``CONTENT_COLUMNS`` or the serializer moves it. It is gated two ways — a test asserts it matches the
+current serializer, and a merge-base ratchet (``check_canonicalization_ratchet``) fails if the
+fingerprint changed against the merge base while ``CANONICALIZATION_VERSION`` did not advance. So a
+serialization change cannot land without a version bump, even if someone regenerates the pinned
+golden values.
 
 Usage:
-    uv run python -m build.observation_snapshot            # id over the committed baseline
+    uv run python -m build.observation_snapshot            # digests over the committed baseline
     uv run python -m build.observation_snapshot --json     # same, machine-readable
 """
 
@@ -55,19 +63,22 @@ import argparse
 import datetime
 import hashlib
 import json
+import re
+import subprocess
 from collections.abc import Iterable
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+_UTC = datetime.timezone.utc
 
-# Bumped when CONTENT_COLUMNS or the serialization changes, so a value computed under an older
-# rule is known not to be comparable. Recorded BESIDE the id by callers, never folded into it.
+# Bumped when CONTENT_COLUMNS or the serialization changes. Bound INTO observation_snapshot_id (not
+# into observation_content_digest), and enforced by the ratchet below.
 CANONICALIZATION_VERSION = 1
 
 # The normalized observation content: the measurement itself, and nothing else. Lineage
 # (source_run_id / source_record_id / source_dataset / source_table), capture time (ingested_at),
-# the derived observation_id, is_valid, and supersedes_observation_id are deliberately excluded —
-# see the module docstring. Order is fixed: it is the serialization's column order.
+# the derived observation_id, is_valid, and supersedes_observation_id are deliberately excluded.
+# Order is fixed: it is the serialization's column order.
 CONTENT_COLUMNS: tuple[str, ...] = (
     "product_slug",
     "product_type",
@@ -81,53 +92,159 @@ CONTENT_COLUMNS: tuple[str, ...] = (
     "observed_at",
 )
 
-# The committed, immutable observation set the tests and CLI resolve against when no live rows are
-# supplied. Its digest is pinned in tests/test_observation_snapshot.py.
 BASELINE_PARQUET = ROOT / "warehouse/data/observations/product_adoption_baseline.parquet"
+
+
+def _canonical_timestamp(value: datetime.datetime) -> str:
+    """UTC-normalized, fixed-precision, ``Z``-suffixed ISO text.
+
+    Aware timestamps are converted to UTC; naive timestamps are interpreted as UTC (the warehouse
+    emits naive UTC). Always six fractional digits, so the same instant has exactly one rendering.
+    """
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=_UTC)
+    value = value.astimezone(_UTC)
+    return value.strftime("%Y-%m-%dT%H:%M:%S.") + f"{value.microsecond:06d}Z"
+
+
+def _canonical_value(value: object) -> object:
+    if isinstance(value, datetime.datetime):
+        return _canonical_timestamp(value)
+    if isinstance(value, datetime.date):
+        return value.isoformat()
+    return value
 
 
 def _canonical_row(row: dict) -> str:
     """One observation's content as a compact JSON array over CONTENT_COLUMNS.
 
-    Dates render as ISO-8601 text; numbers must be finite; every other non-JSON-native type is
+    Timestamps are UTC-normalized; numbers must be finite; every other non-JSON-native type is
     rejected (no permissive ``default``), so an unexpected value fails loudly rather than becoming
-    an implementation-dependent string and a non-reproducible id.
+    an implementation-dependent string and a non-reproducible digest.
     """
     values = []
     for column in CONTENT_COLUMNS:
         if column not in row:
             raise KeyError(f"observation row is missing content column {column!r}")
-        value = row[column]
-        if isinstance(value, (datetime.date, datetime.datetime)):
-            value = value.isoformat()
-        values.append(value)
+        values.append(_canonical_value(row[column]))
     return json.dumps(values, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
 
 
-def observation_snapshot_id(rows: Iterable[dict]) -> str:
-    """The content address of a set of normalized observations.
+def observation_content_digest(rows: Iterable[dict]) -> str:
+    """The pure content address of a set of observations — §4.5 "content and nothing else".
 
-    A SHA-256 over the sorted, newline-joined canonical rows — a multiset digest, independent of
-    row order and of everything outside CONTENT_COLUMNS.
+    SHA-256 over the sorted, newline-joined canonical rows (an order-independent multiset). Does
+    NOT depend on the canonicalization version — that binding lives in observation_snapshot_id.
     """
     lines = sorted(_canonical_row(row) for row in rows)
     return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
 
 
+def observation_snapshot_id(rows: Iterable[dict]) -> str:
+    """The versioned identity reconciliation and releases key on.
+
+    Binds the canonicalization version to the content digest, so a stored id names the rule that
+    produced it and two rules cannot collide on one id.
+    """
+    return snapshot_id_from_digest(observation_content_digest(rows))
+
+
+def snapshot_id_from_digest(content_digest: str, version: int | None = None) -> str:
+    """Compose a snapshot id from a content digest and the canonicalization version."""
+    payload = json.dumps(
+        {
+            "canonicalization_version": CANONICALIZATION_VERSION if version is None else version,
+            "observation_content_digest": content_digest,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+# --- the canonicalization fingerprint and ratchet --------------------------------
+
+# A fixed fixture exercising the serializer: an aware timestamp, a naive one, a null window, and
+# unicode. CANONICALIZATION_FINGERPRINT is its content digest; any CONTENT_COLUMNS or serializer
+# change moves it, and the ratchet then requires CANONICALIZATION_VERSION to advance.
+_FINGERPRINT_FIXTURE: tuple[dict, ...] = (
+    {
+        "product_slug": "fixture-a", "product_type": "model", "artifact_kind": "github",
+        "artifact_id": "ówner/repo", "channel": "github", "metric_type": "stars",
+        "raw_value": 42, "unit": "stars", "measurement_window_days": None,
+        "observed_at": datetime.datetime(2026, 1, 2, 3, 4, 5, tzinfo=_UTC),
+    },
+    {
+        "product_slug": "fixture-b", "product_type": "dataset", "artifact_kind": "huggingface_dataset",
+        "artifact_id": "org/set", "channel": "huggingface", "metric_type": "downloads",
+        "raw_value": 1000, "unit": "downloads", "measurement_window_days": 30,
+        "observed_at": datetime.datetime(2026, 1, 2, 3, 4, 5),  # naive → interpreted UTC
+    },
+)
+CANONICALIZATION_FINGERPRINT = "e2e93998bdcf8fabe99fc2fb6d8e3870bf255785b153ba53138fd15ae578eb5c"
+
+
+class CanonicalizationRatchetError(RuntimeError):
+    """Raised when the canonicalization changed without a version bump."""
+
+
+def check_canonicalization_ratchet(before: dict | None, now: dict) -> None:
+    """Fail if the fingerprint moved against the merge base while the version did not advance.
+
+    ``before`` / ``now`` are ``{"version": int, "fingerprint": str}``; ``before`` is None on the
+    introducing PR (the module did not exist at the merge base), which is not a violation.
+    """
+    if before is None:
+        return
+    if now["fingerprint"] != before["fingerprint"] and now["version"] <= before["version"]:
+        raise CanonicalizationRatchetError(
+            "the observation canonicalization changed (CONTENT_COLUMNS or the serializer) but "
+            f"CANONICALIZATION_VERSION did not advance ({before['version']} -> {now['version']}). "
+            "Bump the version so a snapshot id minted under the old rule cannot be confused with "
+            "one minted under the new rule."
+        )
+
+
+def _parse_canonicalization(source: str) -> dict | None:
+    """Extract {version, fingerprint} from a copy of this module's source, or None if absent."""
+    version = re.search(r"^CANONICALIZATION_VERSION\s*=\s*(\d+)", source, re.M)
+    fingerprint = re.search(r'^CANONICALIZATION_FINGERPRINT\s*=\s*"([0-9a-f]{64})"', source, re.M)
+    if not version or not fingerprint:
+        return None
+    return {"version": int(version.group(1)), "fingerprint": fingerprint.group(1)}
+
+
+def merge_base_canonicalization(base: str = "origin/main") -> dict | None:
+    """This module's {version, fingerprint} as of the merge base, or None if it did not exist."""
+    rel = "build/observation_snapshot.py"
+    try:
+        merge_base = subprocess.run(
+            ["git", "-C", str(ROOT), "merge-base", "HEAD", base],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        source = subprocess.run(
+            ["git", "-C", str(ROOT), "show", f"{merge_base}:{rel}"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        return None
+    return _parse_canonicalization(source)
+
+
 def rows_from_parquet(path: Path | None = None) -> list[dict]:
-    """Load observation rows from a parquet file (the baseline, or any frozen snapshot)."""
     import pyarrow.parquet as pq
 
     return pq.read_table(path or BASELINE_PARQUET).to_pylist()
 
 
 def resolve_baseline() -> dict:
-    """Compute the snapshot id over the committed baseline, with the version recorded beside it."""
     rows = rows_from_parquet(BASELINE_PARQUET)
+    digest = observation_content_digest(rows)
     return {
         "canonicalization_version": CANONICALIZATION_VERSION,
         "row_count": len(rows),
-        "observation_snapshot_id": observation_snapshot_id(rows),
+        "observation_content_digest": digest,
+        "observation_snapshot_id": snapshot_id_from_digest(digest),
         "computed_over": "warehouse/data/observations/product_adoption_baseline.parquet",
     }
 
@@ -141,13 +258,14 @@ def main() -> int:
     if args.json:
         print(json.dumps(info, indent=2))
         return 0
-    print(f"canonicalization_version  {info['canonicalization_version']}")
-    print(f"row_count                 {info['row_count']}")
-    print(f"observation_snapshot_id   {info['observation_snapshot_id']}")
-    print(f"computed_over             {info['computed_over']}")
+    print(f"canonicalization_version   {info['canonicalization_version']}")
+    print(f"row_count                  {info['row_count']}")
+    print(f"observation_content_digest {info['observation_content_digest']}")
+    print(f"observation_snapshot_id    {info['observation_snapshot_id']}")
+    print(f"computed_over              {info['computed_over']}")
     print(
         "\n(Computed over the committed Phase-2 baseline. At reconciliation/release time the same\n"
-        "function runs over the live observations.product_adoption_current rows.)"
+        "functions run over the live observations.product_adoption_current rows.)"
     )
     return 0
 

--- a/build/observation_snapshot.py
+++ b/build/observation_snapshot.py
@@ -1,0 +1,156 @@
+"""Derive the ``observation_snapshot_id`` — the identity of a set of adoption observations.
+
+One of the three release identities (data-architecture.md §4.5). Where ``declaration_version_id``
+answers "which declarations", this answers "which measurements": it is the content address of the
+normalized adoption observations that a reconciliation adjudicated a declaration against. It is
+what ``evaluation.adoption_reconciliation`` and ``releases.manifest`` key on alongside the
+declaration version.
+
+## Content alone — §4.5, strictly
+
+``observation_snapshot_id`` is "a canonical digest of the normalized observation content, and
+nothing else" (§4.5). Two materializations with identical measurements share an id; a re-run that
+changes nothing measured keeps the id (§4.3). Two consequences follow, and both are enforced here:
+
+  * **Run identifiers are lineage, not inputs.** ``source_run_id`` and the ``observation_run_ids``
+    a snapshot was produced by are recorded *beside* the id, never folded into it (§4.3) —
+    otherwise every re-run would mint a new snapshot even when the measurements were identical,
+    which is the opposite of what the id is for.
+  * **Capture time and provenance are excluded.** ``ingested_at`` (when the row was written),
+    ``source_dataset`` / ``source_table`` (which physical table it sat in), ``source_record_id``,
+    the derived ``observation_id`` (a hash of the grain, redundant), ``is_valid`` (a constant on
+    the valid current-state slice), and ``supersedes_observation_id`` (history, absent pre-2B) are
+    all excluded. What remains — ``CONTENT_COLUMNS`` — is the measurement itself.
+
+The digest is over the observations as a **multiset**: the serialized rows are sorted before
+hashing, so the id does not depend on the order the rows were materialized or read in.
+
+## Canonicalization version is recorded beside the id, not inside it
+
+§4.7 requires a canonicalization version so the rule can change without silently changing every
+digest. But §4.5 says the id is content "and nothing else" — folding the version into the digest
+bytes would break that. The two are reconciled by recording ``CANONICALIZATION_VERSION`` alongside
+the id (in the reconciliation row / manifest that carries it), never in the hashed input. A rule
+change is therefore a visible, declared version bump; the id itself stays a pure content address.
+This is the deliberate difference from ``declaration_version_id``, an opaque composite whose
+version *is* folded in.
+
+## Derived, not stored
+
+Like ``declaration_version_id``, this is a computation the release builder and reconciliation call
+at run time over the live ``observations.product_adoption_current``; it is not a committed receipt.
+A full-refresh table's snapshot id must track current content, and a frozen value would go stale
+on every run. The tests exercise it against the one observation set that IS committed and
+immutable — the Phase-2 baseline parquet — which is why a golden value over the baseline is
+pinned: those bytes are ratchet-locked, so the digest over them is a fixed contract.
+
+Usage:
+    uv run python -m build.observation_snapshot            # id over the committed baseline
+    uv run python -m build.observation_snapshot --json     # same, machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+from collections.abc import Iterable
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Bumped when CONTENT_COLUMNS or the serialization changes, so a value computed under an older
+# rule is known not to be comparable. Recorded BESIDE the id by callers, never folded into it.
+CANONICALIZATION_VERSION = 1
+
+# The normalized observation content: the measurement itself, and nothing else. Lineage
+# (source_run_id / source_record_id / source_dataset / source_table), capture time (ingested_at),
+# the derived observation_id, is_valid, and supersedes_observation_id are deliberately excluded —
+# see the module docstring. Order is fixed: it is the serialization's column order.
+CONTENT_COLUMNS: tuple[str, ...] = (
+    "product_slug",
+    "product_type",
+    "artifact_kind",
+    "artifact_id",
+    "channel",
+    "metric_type",
+    "raw_value",
+    "unit",
+    "measurement_window_days",
+    "observed_at",
+)
+
+# The committed, immutable observation set the tests and CLI resolve against when no live rows are
+# supplied. Its digest is pinned in tests/test_observation_snapshot.py.
+BASELINE_PARQUET = ROOT / "warehouse/data/observations/product_adoption_baseline.parquet"
+
+
+def _canonical_row(row: dict) -> str:
+    """One observation's content as a compact JSON array over CONTENT_COLUMNS.
+
+    Dates render as ISO-8601 text; numbers must be finite; every other non-JSON-native type is
+    rejected (no permissive ``default``), so an unexpected value fails loudly rather than becoming
+    an implementation-dependent string and a non-reproducible id.
+    """
+    values = []
+    for column in CONTENT_COLUMNS:
+        if column not in row:
+            raise KeyError(f"observation row is missing content column {column!r}")
+        value = row[column]
+        if isinstance(value, (datetime.date, datetime.datetime)):
+            value = value.isoformat()
+        values.append(value)
+    return json.dumps(values, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+
+
+def observation_snapshot_id(rows: Iterable[dict]) -> str:
+    """The content address of a set of normalized observations.
+
+    A SHA-256 over the sorted, newline-joined canonical rows — a multiset digest, independent of
+    row order and of everything outside CONTENT_COLUMNS.
+    """
+    lines = sorted(_canonical_row(row) for row in rows)
+    return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
+
+
+def rows_from_parquet(path: Path | None = None) -> list[dict]:
+    """Load observation rows from a parquet file (the baseline, or any frozen snapshot)."""
+    import pyarrow.parquet as pq
+
+    return pq.read_table(path or BASELINE_PARQUET).to_pylist()
+
+
+def resolve_baseline() -> dict:
+    """Compute the snapshot id over the committed baseline, with the version recorded beside it."""
+    rows = rows_from_parquet(BASELINE_PARQUET)
+    return {
+        "canonicalization_version": CANONICALIZATION_VERSION,
+        "row_count": len(rows),
+        "observation_snapshot_id": observation_snapshot_id(rows),
+        "computed_over": "warehouse/data/observations/product_adoption_baseline.parquet",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit the result as JSON")
+    args = parser.parse_args()
+
+    info = resolve_baseline()
+    if args.json:
+        print(json.dumps(info, indent=2))
+        return 0
+    print(f"canonicalization_version  {info['canonicalization_version']}")
+    print(f"row_count                 {info['row_count']}")
+    print(f"observation_snapshot_id   {info['observation_snapshot_id']}")
+    print(f"computed_over             {info['computed_over']}")
+    print(
+        "\n(Computed over the committed Phase-2 baseline. At reconciliation/release time the same\n"
+        "function runs over the live observations.product_adoption_current rows.)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/architecture/data-architecture.md
+++ b/docs/architecture/data-architecture.md
@@ -973,15 +973,21 @@ Declared, for `observation_content_digest` (owned by `build/observation_snapshot
   independent of the order rows were materialized or read in;
 - column set: the measurement columns only — lineage, capture time (`ingested_at`), the derived
   `observation_id`, `is_valid`, and `supersedes_observation_id` are excluded;
-- timezone/date normalization: `observed_at` is converted to UTC (a naive value interpreted as
-  UTC), rendered at fixed microsecond precision with a `Z` suffix, so one instant has one
-  rendering; null as JSON `null`;
-- number representation: finite only — `NaN`/`Infinity` are rejected; any non-JSON-native,
-  non-date type is rejected rather than coerced;
+- timezone/date normalization: `observed_at` MUST be a `datetime` (a string or lookalike is
+  rejected, not coerced); it is converted to UTC (a naive value interpreted as UTC), rendered at
+  fixed microsecond precision with a `Z` suffix, so one instant has one rendering; null as JSON
+  `null`;
+- number/type representation: finite numbers only (`NaN`/`Infinity` rejected); every
+  non-timestamp column must be a JSON scalar (`str`/`bool`/`int`/finite `float`/`None`), any other
+  type rejected;
 - hash algorithm: SHA-256, lowercase hex;
-- versioning: `observation_content_digest` is version-independent (pure content); the
-  `canonicalization_version` is bound into `observation_snapshot_id` instead, and a merge-base
-  ratchet forbids changing `CONTENT_COLUMNS` or the serializer without advancing the version.
+- versioning: `observation_content_digest` is version-independent (pure content). The
+  `canonicalization_version` is bound into `observation_snapshot_id`, whose preimage is the exact
+  UTF-8 bytes `"os-ai-map:observation-snapshot:v" + version + "\0" + content_digest`
+  (domain-separated, NUL-delimited). A merge-base ratchet forbids changing the canonicalization
+  **contract descriptor** — the columns, ordering, types, timestamp rule, null/number encoding,
+  serialization, and hash, fingerprinted as a whole rather than by one sample — without advancing
+  the version; implementation conformance to the descriptor is tested separately.
 
 Future release tables may include:
 

--- a/docs/architecture/data-architecture.md
+++ b/docs/architecture/data-architecture.md
@@ -883,20 +883,29 @@ Until the repository-owned evaluator lands (Phase 6), `evaluator_version` is a d
 string, so the day a real evaluator version replaces it is a reviewed change that moves every id
 with it.
 
-`observation_snapshot_id` is derived by `build/observation_snapshot.py`, and like the declaration
-version it is a run-time computation, not a stored receipt — a full-refresh table's snapshot must
-track current content, and a frozen value would go stale on every run. It is a SHA-256 over the
-normalized observation content **and nothing else**: the measurement columns only (`product_slug`,
-`product_type`, `artifact_kind`, `artifact_id`, `channel`, `metric_type`, `raw_value`, `unit`,
-`measurement_window_days`, `observed_at`), taken as an order-independent multiset. Lineage
-(`source_run_id`, `source_record_id`, `source_dataset`, `source_table`), capture time
-(`ingested_at`), the derived `observation_id`, `is_valid`, and `supersedes_observation_id` are
-excluded, so an unchanged measurement keeps its snapshot across re-runs and the runs that produced
-it stay visible only in `observation_run_ids` beside the id. The §4.7 `canonicalization_version` is
-likewise recorded **beside** the id, never folded into the digest — that is what keeps it "content
-and nothing else," and is the deliberate difference from the opaque composite `declaration_version_id`.
-The computation is exercised in-repo against the immutable Phase-2 baseline parquet, whose snapshot
-id is pinned as a fixed contract.
+`observation_content_digest` and `observation_snapshot_id` are both derived by
+`build/observation_snapshot.py`, and like the declaration version they are run-time computations,
+not stored receipts — a full-refresh table's content changes every run, so a frozen value would go
+stale. They are two distinct things, as the manifest columns above require:
+
+- **`observation_content_digest`** is a SHA-256 over the normalized observation content **and
+  nothing else**: the measurement columns only (`product_slug`, `product_type`, `artifact_kind`,
+  `artifact_id`, `channel`, `metric_type`, `raw_value`, `unit`, `measurement_window_days`,
+  `observed_at`), taken as an order-independent multiset. Lineage (`source_run_id`,
+  `source_record_id`, `source_dataset`, `source_table`), capture time (`ingested_at`), the derived
+  `observation_id`, `is_valid`, and `supersedes_observation_id` are excluded, so an unchanged
+  measurement keeps its digest across re-runs and the runs that produced it stay visible only in
+  `observation_run_ids` beside it. It does not depend on the canonicalization version.
+- **`observation_snapshot_id`** is the identity reconciliation and `release_id` key on. It binds
+  the `canonicalization_version` to the content digest, so a persisted id names the rule that
+  produced it and two rules cannot collide on one id — the version is bound INTO this id, not
+  merely recorded next to it.
+
+`observed_at` is normalized to UTC before hashing (an aware timestamp converted, a naive one
+interpreted as UTC — the warehouse emits naive UTC), at fixed microsecond precision with a `Z`
+suffix, so one instant has one digest. A merge-base ratchet fails if the serializer or
+`CONTENT_COLUMNS` change without `CANONICALIZATION_VERSION` advancing. Both digests are exercised
+in-repo against the immutable Phase-2 baseline parquet and pinned there as fixed contracts.
 
 Use them consistently:
 
@@ -953,6 +962,26 @@ Declared, for `source_content_digest` (owned by `build/declaration_version.py`,
 - input set: the classified declaration inputs of `sources/` (the full top-level inventory is
   gated, so a new authoritative input cannot silently leave the digest), excluding the
   separately-versioned routing policy and the frozen long-tail sample.
+
+Declared, for `observation_content_digest` (owned by `build/observation_snapshot.py`,
+`canonicalization_version` 1):
+
+- serialization format: each observation is a compact JSON array (UTF-8, no insignificant
+  whitespace) over the fixed column order `CONTENT_COLUMNS`; strings preserved verbatim, not
+  ASCII-escaped;
+- row/multiset ordering: the serialized rows are sorted and newline-joined, so the digest is
+  independent of the order rows were materialized or read in;
+- column set: the measurement columns only — lineage, capture time (`ingested_at`), the derived
+  `observation_id`, `is_valid`, and `supersedes_observation_id` are excluded;
+- timezone/date normalization: `observed_at` is converted to UTC (a naive value interpreted as
+  UTC), rendered at fixed microsecond precision with a `Z` suffix, so one instant has one
+  rendering; null as JSON `null`;
+- number representation: finite only — `NaN`/`Infinity` are rejected; any non-JSON-native,
+  non-date type is rejected rather than coerced;
+- hash algorithm: SHA-256, lowercase hex;
+- versioning: `observation_content_digest` is version-independent (pure content); the
+  `canonicalization_version` is bound into `observation_snapshot_id` instead, and a merge-base
+  ratchet forbids changing `CONTENT_COLUMNS` or the serializer without advancing the version.
 
 Future release tables may include:
 

--- a/docs/architecture/data-architecture.md
+++ b/docs/architecture/data-architecture.md
@@ -516,11 +516,15 @@ Rules:
   `source_unavailable` for reconciliation. After #355 provides authoritative row-to-run binding
   and scope, `product_adoption_current` may include only observations bound to
   `execution_status = "SUCCESS"` with matching scope.
-- `observation_snapshot_id` is content-addressed over the normalized observations alone. Run
-  identifiers are lineage, recorded in `observation_run_ids`, and are NOT inputs to the ID.
-  Including them would give every re-run a new snapshot ID even when nothing measured changed,
-  which is the opposite of what the ID is for. Identical content means an identical snapshot;
-  different content means a different one; the runs that produced it stay visible either way.
+- The observation identity is two things, not one. `observation_content_digest` is
+  content-addressed over the normalized observation content alone; `observation_snapshot_id` is
+  `SHA-256(domain + canonicalization_version + observation_content_digest)`, binding the
+  canonicalization rule so a persisted id names the rule that produced it. Run identifiers are
+  lineage, recorded in `observation_run_ids`, and are NOT inputs to either. Including them would
+  give every re-run a new content digest even when nothing measured changed, which is the opposite
+  of what the digest is for. Under one canonicalization contract, identical content means an
+  identical digest and different content means a different one; the runs that produced it stay
+  visible either way.
 
 Reconciliation may proceed against `product_adoption_current`; it does not need to wait for incremental support. Historical trend claims must wait.
 
@@ -835,8 +839,11 @@ and next week against different measurements produces different findings under t
 declaration_version_id
   = source_git_sha + source_content_digest + evaluator_version
 
+observation_content_digest
+  = canonical digest of the normalized observation content
+
 observation_snapshot_id
-  = canonical digest of the normalized observation content, and nothing else
+  = SHA-256(domain + canonicalization_version + observation_content_digest)
 
 release_id
   = declaration_version_id + observation_snapshot_id + reconciliation_policy_version
@@ -895,7 +902,10 @@ stale. They are two distinct things, as the manifest columns above require:
   `source_record_id`, `source_dataset`, `source_table`), capture time (`ingested_at`), the derived
   `observation_id`, `is_valid`, and `supersedes_observation_id` are excluded, so an unchanged
   measurement keeps its digest across re-runs and the runs that produced it stay visible only in
-  `observation_run_ids` beside it. It does not depend on the canonicalization version.
+  `observation_run_ids` beside it. It does not fold in the `canonicalization_version` number — a
+  version bump alone does not move it — but it is *not* invariant across canonicalization rules:
+  the canonical bytes change if the contract changes, so two content digests are comparable only
+  under the same contract.
 - **`observation_snapshot_id`** is the identity reconciliation and `release_id` key on. It binds
   the `canonicalization_version` to the content digest, so a persisted id names the rule that
   produced it and two rules cannot collide on one id — the version is bound INTO this id, not

--- a/docs/architecture/data-architecture.md
+++ b/docs/architecture/data-architecture.md
@@ -987,11 +987,16 @@ Declared, for `observation_content_digest` (owned by `build/observation_snapshot
   rejected, not coerced); it is converted to UTC (a naive value interpreted as UTC), rendered at
   fixed microsecond precision with a `Z` suffix, so one instant has one rendering; null as JSON
   `null`;
-- number/type representation: finite numbers only (`NaN`/`Infinity` rejected); every
-  non-timestamp column must be a JSON scalar (`str`/`bool`/`int`/finite `float`/`None`), any other
-  type rejected;
+- number/type representation: each column is checked against its declared type (by exact `type`
+  identity, so a `bool` never satisfies an `int`/`str` requirement), any other type rejected —
+  identity, vocabulary, and unit columns must be nonempty strings; `raw_value` a finite integer or
+  float, excluding boolean and null; `measurement_window_days` a nonnegative integer or null,
+  excluding boolean; `observed_at` a datetime normalized to UTC (as above);
 - hash algorithm: SHA-256, lowercase hex;
-- versioning: `observation_content_digest` is version-independent (pure content). The
+- versioning: the `canonicalization_version` number is excluded from the content-digest preimage
+  (bumping the version alone does not move `observation_content_digest`), but content digests are
+  comparable only under the same canonicalization contract, since the canonical bytes change if the
+  contract changes. The
   `canonicalization_version` is bound into `observation_snapshot_id`, whose preimage is the exact
   UTF-8 bytes `"os-ai-map:observation-snapshot:v" + version + "\0" + content_digest`
   (domain-separated, NUL-delimited). A merge-base ratchet forbids changing the canonicalization

--- a/docs/architecture/data-architecture.md
+++ b/docs/architecture/data-architecture.md
@@ -883,6 +883,21 @@ Until the repository-owned evaluator lands (Phase 6), `evaluator_version` is a d
 string, so the day a real evaluator version replaces it is a reviewed change that moves every id
 with it.
 
+`observation_snapshot_id` is derived by `build/observation_snapshot.py`, and like the declaration
+version it is a run-time computation, not a stored receipt — a full-refresh table's snapshot must
+track current content, and a frozen value would go stale on every run. It is a SHA-256 over the
+normalized observation content **and nothing else**: the measurement columns only (`product_slug`,
+`product_type`, `artifact_kind`, `artifact_id`, `channel`, `metric_type`, `raw_value`, `unit`,
+`measurement_window_days`, `observed_at`), taken as an order-independent multiset. Lineage
+(`source_run_id`, `source_record_id`, `source_dataset`, `source_table`), capture time
+(`ingested_at`), the derived `observation_id`, `is_valid`, and `supersedes_observation_id` are
+excluded, so an unchanged measurement keeps its snapshot across re-runs and the runs that produced
+it stay visible only in `observation_run_ids` beside the id. The §4.7 `canonicalization_version` is
+likewise recorded **beside** the id, never folded into the digest — that is what keeps it "content
+and nothing else," and is the deliberate difference from the opaque composite `declaration_version_id`.
+The computation is exercised in-repo against the immutable Phase-2 baseline parquet, whose snapshot
+id is pinned as a fixed contract.
+
 Use them consistently:
 
 - `registry.axis_assessments` belongs to `declaration_version_id`. It does not depend on

--- a/docs/architecture/migration-status.md
+++ b/docs/architecture/migration-status.md
@@ -41,13 +41,15 @@ than improvised inside the first consumer.
   that touches them. `evaluator_version` is pinned to the sentinel `v0-no-repo-evaluator` until
   the repository-owned evaluator lands (Phase 6).
 - **`observation_snapshot_id` — implemented** (`build/observation_snapshot.py`, `data-architecture.md`
-  §4.5). A SHA-256 over the normalized observation content and nothing else — the ten measurement
-  columns of `product_adoption_current` as an order-independent multiset, excluding lineage
-  (`source_run_id` et al.), capture time (`ingested_at`), the derived `observation_id`, `is_valid`,
-  and `supersedes_observation_id`, so an unchanged measurement keeps its id across re-runs. Derived
-  at run time, not stored (a full-refresh snapshot would go stale if frozen); the
-  `canonicalization_version` is recorded beside the id, not folded in, keeping it content-alone.
-  Exercised against the immutable Phase-2 baseline, whose snapshot id is pinned as a fixed contract.
+  §4.5), as the two distinct things §4.5 names. **`observation_content_digest`** is a SHA-256 over
+  the normalized observation content and nothing else — the ten measurement columns of
+  `product_adoption_current` as an order-independent multiset, excluding lineage, capture time, the
+  derived `observation_id`, `is_valid`, and `supersedes_observation_id`, with `observed_at`
+  normalized to UTC (naive interpreted as UTC) at fixed precision. **`observation_snapshot_id`** is
+  the identity reconciliation and `release_id` key on: it binds the `canonicalization_version` into
+  the content digest, so a persisted id names its rule. Derived at run time, not stored; a
+  merge-base ratchet forbids a serializer change without a version bump. Both digests are pinned
+  against the immutable Phase-2 baseline as fixed contracts.
 
 ## Atomicity: which state is in force
 

--- a/docs/architecture/migration-status.md
+++ b/docs/architecture/migration-status.md
@@ -40,9 +40,14 @@ than improvised inside the first consumer.
   projections are excluded from the **digest** — not from the id, which changes with any commit
   that touches them. `evaluator_version` is pinned to the sentinel `v0-no-repo-evaluator` until
   the repository-owned evaluator lands (Phase 6).
-- **`observation_snapshot_id` — pending**, to be emitted by the observations layer over
-  `observations.product_adoption_current` (a build receipt, like `source_runs.json`). Gated on
-  `observations.product_adoption_current` reaching `main`.
+- **`observation_snapshot_id` — implemented** (`build/observation_snapshot.py`, `data-architecture.md`
+  §4.5). A SHA-256 over the normalized observation content and nothing else — the ten measurement
+  columns of `product_adoption_current` as an order-independent multiset, excluding lineage
+  (`source_run_id` et al.), capture time (`ingested_at`), the derived `observation_id`, `is_valid`,
+  and `supersedes_observation_id`, so an unchanged measurement keeps its id across re-runs. Derived
+  at run time, not stored (a full-refresh snapshot would go stale if frozen); the
+  `canonicalization_version` is recorded beside the id, not folded in, keeping it content-alone.
+  Exercised against the immutable Phase-2 baseline, whose snapshot id is pinned as a fixed contract.
 
 ## Atomicity: which state is in force
 

--- a/tests/test_observation_snapshot.py
+++ b/tests/test_observation_snapshot.py
@@ -1,0 +1,138 @@
+"""The observation-snapshot identity, and the properties §4.5 requires of it.
+
+`build/observation_snapshot.py` derives `observation_snapshot_id` — the content address of a set
+of normalized adoption observations, which `evaluation.adoption_reconciliation` and
+`releases.manifest` key on. These tests pin the content-alone contract: it depends on the
+measurement and nothing else (not lineage, not capture time, not row order, not the
+canonicalization version), and it reproduces a fixed value over the immutable Phase-2 baseline.
+"""
+
+import copy
+import datetime
+
+import pytest
+
+import build.observation_snapshot as osnap
+from build.observation_snapshot import (
+    CONTENT_COLUMNS,
+    observation_snapshot_id,
+    rows_from_parquet,
+)
+
+# The snapshot id over the committed baseline parquet. The baseline bytes are ratchet-locked
+# (tests/test_baseline_contract.py), so this is a fixed contract; a change here means the
+# canonicalization drifted, and CANONICALIZATION_VERSION must move with it.
+BASELINE_SNAPSHOT_ID = "78922959233f1f83c72fb04d9877fbe67168a1e5517eaa3cb575c0886d1d1533"
+
+
+def _row(**overrides) -> dict:
+    """A minimal observation row carrying every column the id must ignore, plus the content."""
+    base = {
+        # content
+        "product_slug": "acme", "product_type": "model", "artifact_kind": "github",
+        "artifact_id": "acme/thing", "channel": "github", "metric_type": "stars",
+        "raw_value": 100, "unit": "stars", "measurement_window_days": None,
+        "observed_at": datetime.datetime(2026, 8, 20, 12, 0, 0),
+        # excluded: lineage / capture-time / derived / history
+        "observation_id": "deadbeef", "ingested_at": datetime.datetime(2026, 8, 25, 5, 0, 0),
+        "source_dataset": "signal_github", "source_table": "currentai.signal_github.artifact_state",
+        "source_run_id": None, "source_record_id": None, "is_valid": True,
+        "supersedes_observation_id": None,
+    }
+    base.update(overrides)
+    return base
+
+
+# --- the content column set -------------------------------------------------------
+
+
+def test_content_columns_exclude_lineage_and_capture_time():
+    """The digest covers the measurement, not how or when it was recorded."""
+    for excluded in (
+        "observation_id", "ingested_at", "source_run_id", "source_record_id",
+        "source_dataset", "source_table", "is_valid", "supersedes_observation_id",
+    ):
+        assert excluded not in CONTENT_COLUMNS
+    for included in ("product_slug", "artifact_id", "metric_type", "raw_value", "observed_at"):
+        assert included in CONTENT_COLUMNS
+
+
+# --- content-alone behavior -------------------------------------------------------
+
+
+def test_deterministic():
+    rows = [_row()]
+    assert observation_snapshot_id(rows) == observation_snapshot_id(rows)
+
+
+def test_order_independent_multiset():
+    a, b = _row(product_slug="a"), _row(product_slug="b")
+    assert observation_snapshot_id([a, b]) == observation_snapshot_id([b, a])
+
+
+def test_lineage_and_capture_time_do_not_change_the_id():
+    """Run identifiers, capture time, and provenance are lineage — a re-run that changes only
+    those keeps the same snapshot id (§4.3)."""
+    base = observation_snapshot_id([_row()])
+    for excluded, value in (
+        ("source_run_id", "run-xyz"),
+        ("ingested_at", datetime.datetime(2027, 1, 1, 0, 0, 0)),
+        ("observation_id", "cafebabe"),
+        ("source_table", "somewhere.else"),
+        ("is_valid", False),
+        ("supersedes_observation_id", "prior"),
+    ):
+        assert observation_snapshot_id([_row(**{excluded: value})]) == base, (
+            f"changing {excluded} changed the snapshot id; it must be content-alone"
+        )
+
+
+def test_measurement_changes_do_change_the_id():
+    base = observation_snapshot_id([_row()])
+    assert observation_snapshot_id([_row(raw_value=101)]) != base
+    assert observation_snapshot_id([_row(observed_at=datetime.datetime(2026, 8, 21, 12, 0, 0))]) != base
+    assert observation_snapshot_id([_row(metric_type="downloads")]) != base
+    assert observation_snapshot_id([_row(measurement_window_days=30)]) != base
+
+
+def test_canonicalization_version_is_not_folded_into_the_id(monkeypatch):
+    """§4.5 is strict: the id is content and nothing else. Bumping the canonicalization version
+    (recorded beside the id) must NOT change the id itself."""
+    before = observation_snapshot_id([_row()])
+    monkeypatch.setattr(osnap, "CANONICALIZATION_VERSION", osnap.CANONICALIZATION_VERSION + 1)
+    assert observation_snapshot_id([_row()]) == before
+
+
+def test_shape_is_64_hex():
+    vid = observation_snapshot_id([_row()])
+    assert len(vid) == 64 and vid == vid.lower()
+    int(vid, 16)
+
+
+def test_non_finite_numbers_are_rejected():
+    with pytest.raises(ValueError):
+        observation_snapshot_id([_row(raw_value=float("inf"))])
+
+
+def test_missing_content_column_is_loud():
+    bad = _row()
+    del bad["metric_type"]
+    with pytest.raises(KeyError):
+        observation_snapshot_id([bad])
+
+
+# --- the pinned contract over the immutable baseline ------------------------------
+
+
+def test_reproduces_the_baseline_snapshot_id():
+    """The id over the committed baseline is a fixed contract: the baseline bytes are immutable,
+    so this value only changes if the canonicalization changes — which requires a version bump."""
+    rows = rows_from_parquet()
+    assert len(rows) == 654
+    assert observation_snapshot_id(rows) == BASELINE_SNAPSHOT_ID
+
+
+def test_baseline_snapshot_ignores_the_row_order_it_is_read_in():
+    rows = rows_from_parquet()
+    shuffled = copy.deepcopy(rows)[::-1]
+    assert observation_snapshot_id(shuffled) == BASELINE_SNAPSHOT_ID

--- a/tests/test_observation_snapshot.py
+++ b/tests/test_observation_snapshot.py
@@ -19,6 +19,7 @@ from build.observation_snapshot import (
     CANONICALIZATION_FINGERPRINT,
     CANONICALIZATION_VERSION,
     CONTENT_COLUMNS,
+    IDENTITY_COLUMNS,
     CanonicalizationRatchetError,
     canonicalization_fingerprint,
     check_canonicalization_ratchet,
@@ -109,7 +110,7 @@ def test_content_digest_is_version_independent(monkeypatch):
     assert observation_content_digest([_row()]) == before
 
 
-# --- strict typing (refinement: observed_at must be a datetime) ------------------
+# --- strict per-column typing ----------------------------------------------------
 
 
 def test_observed_at_must_be_a_datetime():
@@ -119,9 +120,52 @@ def test_observed_at_must_be_a_datetime():
             observation_content_digest([_row(observed_at=bad)])
 
 
-def test_non_finite_numbers_are_rejected():
+def test_identity_columns_must_be_nonempty_strings():
+    """Every identity/vocabulary/unit field rejects a non-string and an empty string."""
+    assert IDENTITY_COLUMNS == {
+        "product_slug", "product_type", "artifact_kind", "artifact_id",
+        "channel", "metric_type", "unit",
+    }
+    for column in IDENTITY_COLUMNS:
+        with pytest.raises(TypeError):  # a bare int is not a slug
+            observation_content_digest([_row(**{column: 123})])
+        with pytest.raises(TypeError):  # bool is not a str (exact-type check)
+            observation_content_digest([_row(**{column: True})])
+        with pytest.raises(TypeError):  # None is not a nonempty str
+            observation_content_digest([_row(**{column: None})])
+        with pytest.raises(ValueError):  # empty string
+            observation_content_digest([_row(**{column: ""})])
+
+
+def test_raw_value_must_be_a_finite_number_and_not_a_bool():
+    with pytest.raises(TypeError):  # a numeric string is not a measurement
+        observation_content_digest([_row(raw_value="100")])
+    with pytest.raises(TypeError):  # bool is not a number (exact-type check)
+        observation_content_digest([_row(raw_value=True)])
+    with pytest.raises(TypeError):  # None is not a measurement
+        observation_content_digest([_row(raw_value=None)])
     with pytest.raises(ValueError):
         observation_content_digest([_row(raw_value=float("inf"))])
+    with pytest.raises(ValueError):
+        observation_content_digest([_row(raw_value=float("nan"))])
+    # a finite int and a finite float are both accepted, and 0 is a legitimate measurement.
+    observation_content_digest([_row(raw_value=0)])
+    observation_content_digest([_row(raw_value=3.5)])
+
+
+def test_measurement_window_days_must_be_a_nonnegative_int_or_null():
+    with pytest.raises(TypeError):  # bool is not an int here (exact-type check)
+        observation_content_digest([_row(measurement_window_days=True)])
+    with pytest.raises(TypeError):  # a float is not an int
+        observation_content_digest([_row(measurement_window_days=30.0)])
+    with pytest.raises(TypeError):  # a numeric string is not an int
+        observation_content_digest([_row(measurement_window_days="30")])
+    with pytest.raises(ValueError):  # negative
+        observation_content_digest([_row(measurement_window_days=-1)])
+    # None and a nonnegative int are both accepted.
+    observation_content_digest([_row(measurement_window_days=None)])
+    observation_content_digest([_row(measurement_window_days=0)])
+    observation_content_digest([_row(measurement_window_days=30)])
 
 
 def test_unexpected_type_in_a_content_column_is_rejected():
@@ -171,6 +215,20 @@ def test_snapshot_id_uses_the_documented_domain_separated_preimage():
         f"os-ai-map:observation-snapshot:v{CANONICALIZATION_VERSION}\0{digest}".encode("utf-8")
     ).hexdigest()
     assert snapshot_id_from_digest(digest) == expected
+
+
+def test_snapshot_id_from_digest_rejects_a_malformed_digest():
+    """Fail closed before minting: only a 64-char lowercase hex digest is a valid preimage."""
+    for bad in ("x", "b" * 63, "b" * 65, "B" * 64, "g" * 64, 123, None):
+        with pytest.raises((ValueError, TypeError)):
+            snapshot_id_from_digest(bad)
+
+
+def test_snapshot_id_from_digest_rejects_a_nonpositive_or_nonint_version():
+    good = "b" * 64
+    for bad_version in (0, -1, True, 1.0, "1"):
+        with pytest.raises((ValueError, TypeError)):
+            snapshot_id_from_digest(good, version=bad_version)
 
 
 def test_snapshot_id_is_not_the_bare_content_digest():

--- a/tests/test_observation_snapshot.py
+++ b/tests/test_observation_snapshot.py
@@ -1,34 +1,39 @@
-"""The observation-snapshot identity, and the properties §4.5 requires of it.
+"""The observation content digest, the versioned snapshot id, and the canonicalization ratchet.
 
-`build/observation_snapshot.py` derives `observation_snapshot_id` — the content address of a set
-of normalized adoption observations, which `evaluation.adoption_reconciliation` and
-`releases.manifest` key on. These tests pin the content-alone contract: it depends on the
-measurement and nothing else (not lineage, not capture time, not row order, not the
-canonicalization version), and it reproduces a fixed value over the immutable Phase-2 baseline.
+`build/observation_snapshot.py` derives two things §4.5 names separately:
+`observation_content_digest` (the pure content address) and `observation_snapshot_id` (the
+versioned identity reconciliation and releases key on). These tests pin the content-alone contract
+of the digest, the version binding of the id, UTC timestamp normalization, and a merge-base ratchet
+that forbids changing the serializer without a version bump.
 """
 
-import copy
 import datetime
 
 import pytest
 
 import build.observation_snapshot as osnap
 from build.observation_snapshot import (
+    CANONICALIZATION_FINGERPRINT,
     CONTENT_COLUMNS,
+    CanonicalizationRatchetError,
+    check_canonicalization_ratchet,
+    merge_base_canonicalization,
+    observation_content_digest,
     observation_snapshot_id,
     rows_from_parquet,
+    snapshot_id_from_digest,
+    _FINGERPRINT_FIXTURE,
 )
 
-# The snapshot id over the committed baseline parquet. The baseline bytes are ratchet-locked
-# (tests/test_baseline_contract.py), so this is a fixed contract; a change here means the
-# canonicalization drifted, and CANONICALIZATION_VERSION must move with it.
-BASELINE_SNAPSHOT_ID = "78922959233f1f83c72fb04d9877fbe67168a1e5517eaa3cb575c0886d1d1533"
+_UTC = datetime.timezone.utc
+
+# Fixed contracts over the immutable Phase-2 baseline parquet.
+BASELINE_CONTENT_DIGEST = "8a6c3e984776302ce116bc2f119a77eaf45dfc7b7aaffc734de74c63ae0d6eab"
+BASELINE_SNAPSHOT_ID = "ae1e9dfbc55c82c522edddc03c6286a6b57242a5fd104d2763ec2f966ef3e462"
 
 
 def _row(**overrides) -> dict:
-    """A minimal observation row carrying every column the id must ignore, plus the content."""
     base = {
-        # content
         "product_slug": "acme", "product_type": "model", "artifact_kind": "github",
         "artifact_id": "acme/thing", "channel": "github", "metric_type": "stars",
         "raw_value": 100, "unit": "stars", "measurement_window_days": None,
@@ -43,11 +48,10 @@ def _row(**overrides) -> dict:
     return base
 
 
-# --- the content column set -------------------------------------------------------
+# --- content columns -------------------------------------------------------------
 
 
 def test_content_columns_exclude_lineage_and_capture_time():
-    """The digest covers the measurement, not how or when it was recorded."""
     for excluded in (
         "observation_id", "ingested_at", "source_run_id", "source_record_id",
         "source_dataset", "source_table", "is_valid", "supersedes_observation_id",
@@ -57,82 +61,148 @@ def test_content_columns_exclude_lineage_and_capture_time():
         assert included in CONTENT_COLUMNS
 
 
-# --- content-alone behavior -------------------------------------------------------
+# --- the pure content digest -----------------------------------------------------
 
 
-def test_deterministic():
-    rows = [_row()]
-    assert observation_snapshot_id(rows) == observation_snapshot_id(rows)
-
-
-def test_order_independent_multiset():
+def test_content_digest_is_deterministic_and_order_independent():
     a, b = _row(product_slug="a"), _row(product_slug="b")
-    assert observation_snapshot_id([a, b]) == observation_snapshot_id([b, a])
+    assert observation_content_digest([a, b]) == observation_content_digest([b, a])
 
 
-def test_lineage_and_capture_time_do_not_change_the_id():
-    """Run identifiers, capture time, and provenance are lineage — a re-run that changes only
-    those keeps the same snapshot id (§4.3)."""
-    base = observation_snapshot_id([_row()])
+def test_lineage_and_capture_time_do_not_change_the_content_digest():
+    base = observation_content_digest([_row()])
     for excluded, value in (
         ("source_run_id", "run-xyz"),
         ("ingested_at", datetime.datetime(2027, 1, 1, 0, 0, 0)),
         ("observation_id", "cafebabe"),
-        ("source_table", "somewhere.else"),
         ("is_valid", False),
-        ("supersedes_observation_id", "prior"),
     ):
-        assert observation_snapshot_id([_row(**{excluded: value})]) == base, (
-            f"changing {excluded} changed the snapshot id; it must be content-alone"
-        )
+        assert observation_content_digest([_row(**{excluded: value})]) == base
 
 
-def test_measurement_changes_do_change_the_id():
-    base = observation_snapshot_id([_row()])
-    assert observation_snapshot_id([_row(raw_value=101)]) != base
-    assert observation_snapshot_id([_row(observed_at=datetime.datetime(2026, 8, 21, 12, 0, 0))]) != base
-    assert observation_snapshot_id([_row(metric_type="downloads")]) != base
-    assert observation_snapshot_id([_row(measurement_window_days=30)]) != base
+def test_measurement_changes_change_the_content_digest():
+    base = observation_content_digest([_row()])
+    assert observation_content_digest([_row(raw_value=101)]) != base
+    assert observation_content_digest([_row(metric_type="downloads")]) != base
 
 
-def test_canonicalization_version_is_not_folded_into_the_id(monkeypatch):
-    """§4.5 is strict: the id is content and nothing else. Bumping the canonicalization version
-    (recorded beside the id) must NOT change the id itself."""
-    before = observation_snapshot_id([_row()])
+def test_content_digest_is_version_independent(monkeypatch):
+    """§4.5: the content digest is content and nothing else — the version is bound in the snapshot
+    id, not the digest."""
+    before = observation_content_digest([_row()])
     monkeypatch.setattr(osnap, "CANONICALIZATION_VERSION", osnap.CANONICALIZATION_VERSION + 1)
-    assert observation_snapshot_id([_row()]) == before
-
-
-def test_shape_is_64_hex():
-    vid = observation_snapshot_id([_row()])
-    assert len(vid) == 64 and vid == vid.lower()
-    int(vid, 16)
+    assert observation_content_digest([_row()]) == before
 
 
 def test_non_finite_numbers_are_rejected():
     with pytest.raises(ValueError):
-        observation_snapshot_id([_row(raw_value=float("inf"))])
+        observation_content_digest([_row(raw_value=float("inf"))])
 
 
 def test_missing_content_column_is_loud():
     bad = _row()
     del bad["metric_type"]
     with pytest.raises(KeyError):
-        observation_snapshot_id([bad])
+        observation_content_digest([bad])
 
 
-# --- the pinned contract over the immutable baseline ------------------------------
+# --- UTC timestamp normalization (finding 2) -------------------------------------
 
 
-def test_reproduces_the_baseline_snapshot_id():
-    """The id over the committed baseline is a fixed contract: the baseline bytes are immutable,
-    so this value only changes if the canonicalization changes — which requires a version bump."""
+def test_equivalent_instants_produce_one_digest():
+    """The same instant, whatever its written offset or naivety, digests identically."""
+    aware_utc = _row(observed_at=datetime.datetime(2026, 8, 25, 12, 0, 0, tzinfo=_UTC))
+    aware_off = _row(observed_at=datetime.datetime(
+        2026, 8, 25, 8, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=-4))))
+    naive = _row(observed_at=datetime.datetime(2026, 8, 25, 12, 0, 0))
+    d = observation_content_digest([aware_utc])
+    assert observation_content_digest([aware_off]) == d  # -04:00 same instant
+    assert observation_content_digest([naive]) == d       # naive interpreted UTC
+
+
+def test_different_instants_differ():
+    a = _row(observed_at=datetime.datetime(2026, 8, 25, 12, 0, 0, tzinfo=_UTC))
+    b = _row(observed_at=datetime.datetime(2026, 8, 25, 13, 0, 0, tzinfo=_UTC))
+    assert observation_content_digest([a]) != observation_content_digest([b])
+
+
+# --- the versioned snapshot id (finding 1) ---------------------------------------
+
+
+def test_snapshot_id_binds_the_canonicalization_version(monkeypatch):
+    """Bumping the version MUST change the snapshot id, so a stored id names its rule."""
+    before = observation_snapshot_id([_row()])
+    monkeypatch.setattr(osnap, "CANONICALIZATION_VERSION", osnap.CANONICALIZATION_VERSION + 1)
+    assert observation_snapshot_id([_row()]) != before
+
+
+def test_snapshot_id_is_not_the_bare_content_digest():
+    rows = [_row()]
+    assert observation_snapshot_id(rows) != observation_content_digest(rows)
+
+
+def test_snapshot_id_is_a_function_of_the_content_digest():
+    rows = [_row()]
+    assert observation_snapshot_id(rows) == snapshot_id_from_digest(
+        observation_content_digest(rows)
+    )
+
+
+def test_snapshot_id_shape():
+    vid = observation_snapshot_id([_row()])
+    assert len(vid) == 64 and vid == vid.lower()
+    int(vid, 16)
+
+
+# --- the canonicalization ratchet (finding 3) ------------------------------------
+
+
+def test_fingerprint_matches_the_current_serializer():
+    """The committed fingerprint must equal the digest the current serializer produces over the
+    fixture; regenerating it is the only way to change it, which the ratchet then guards."""
+    assert observation_content_digest(_FINGERPRINT_FIXTURE) == CANONICALIZATION_FINGERPRINT
+
+
+def test_ratchet_fires_on_a_serializer_change_without_a_version_bump():
+    before = {"version": 1, "fingerprint": "a" * 64}
+    with pytest.raises(CanonicalizationRatchetError):
+        check_canonicalization_ratchet(before, {"version": 1, "fingerprint": "b" * 64})
+
+
+def test_ratchet_passes_when_the_version_advances_with_the_fingerprint():
+    before = {"version": 1, "fingerprint": "a" * 64}
+    check_canonicalization_ratchet(before, {"version": 2, "fingerprint": "b" * 64})
+
+
+def test_ratchet_passes_when_nothing_changed():
+    same = {"version": 1, "fingerprint": "a" * 64}
+    check_canonicalization_ratchet(same, dict(same))
+
+
+def test_ratchet_first_install_is_not_a_violation():
+    check_canonicalization_ratchet(None, {"version": 1, "fingerprint": "a" * 64})
+
+
+def test_canonicalization_ratchet_against_the_merge_base():
+    """The real gate: on this branch the module is new (absent at the merge base) so there is
+    nothing to ratchet against and this passes; once merged, any serializer change without a
+    version bump fails here."""
+    before = merge_base_canonicalization()
+    now = {"version": osnap.CANONICALIZATION_VERSION, "fingerprint": CANONICALIZATION_FINGERPRINT}
+    check_canonicalization_ratchet(before, now)
+
+
+# --- the pinned contracts over the immutable baseline ----------------------------
+
+
+def test_reproduces_the_baseline_digests():
     rows = rows_from_parquet()
     assert len(rows) == 654
-    assert observation_snapshot_id(rows) == BASELINE_SNAPSHOT_ID
+    digest = observation_content_digest(rows)
+    assert digest == BASELINE_CONTENT_DIGEST
+    assert snapshot_id_from_digest(digest) == BASELINE_SNAPSHOT_ID
 
 
-def test_baseline_snapshot_ignores_the_row_order_it_is_read_in():
+def test_baseline_digest_ignores_read_order():
     rows = rows_from_parquet()
-    shuffled = copy.deepcopy(rows)[::-1]
-    assert observation_snapshot_id(shuffled) == BASELINE_SNAPSHOT_ID
+    assert observation_content_digest(rows[::-1]) == BASELINE_CONTENT_DIGEST

--- a/tests/test_observation_snapshot.py
+++ b/tests/test_observation_snapshot.py
@@ -1,35 +1,58 @@
 """The observation content digest, the versioned snapshot id, and the canonicalization ratchet.
 
-`build/observation_snapshot.py` derives two things §4.5 names separately:
+`build/observation_snapshot.py` derives the two things §4.5 names separately —
 `observation_content_digest` (the pure content address) and `observation_snapshot_id` (the
-versioned identity reconciliation and releases key on). These tests pin the content-alone contract
-of the digest, the version binding of the id, UTC timestamp normalization, and a merge-base ratchet
-that forbids changing the serializer without a version bump.
+versioned, domain-separated identity). These tests pin the content-alone contract, the version
+binding and exact preimage of the id, UTC timestamp normalization with strict typing, and a
+merge-base ratchet over an explicit contract descriptor that forbids a serialization change without
+a version bump.
 """
 
 import datetime
+import hashlib
 
 import pytest
 
 import build.observation_snapshot as osnap
 from build.observation_snapshot import (
+    CANONICALIZATION_CONTRACT,
     CANONICALIZATION_FINGERPRINT,
+    CANONICALIZATION_VERSION,
     CONTENT_COLUMNS,
     CanonicalizationRatchetError,
+    canonicalization_fingerprint,
     check_canonicalization_ratchet,
     merge_base_canonicalization,
     observation_content_digest,
     observation_snapshot_id,
     rows_from_parquet,
     snapshot_id_from_digest,
-    _FINGERPRINT_FIXTURE,
 )
 
 _UTC = datetime.timezone.utc
 
 # Fixed contracts over the immutable Phase-2 baseline parquet.
 BASELINE_CONTENT_DIGEST = "8a6c3e984776302ce116bc2f119a77eaf45dfc7b7aaffc734de74c63ae0d6eab"
-BASELINE_SNAPSHOT_ID = "ae1e9dfbc55c82c522edddc03c6286a6b57242a5fd104d2763ec2f966ef3e462"
+BASELINE_SNAPSHOT_ID = "9bd4d93a6fc67a2b9d89d91adeb4bb3f4fd9b612cc26e6647c67210c9a37a8d4"
+
+# A behavioral fixture exercising tz-aware + naive timestamps, a null window, and unicode. Its
+# digest is a separate behavioral golden — the canonicalization FINGERPRINT is over the contract
+# descriptor, not this fixture, so a declared-rule change is caught even if no fixture exercises it.
+_BEHAVIOR_FIXTURE = (
+    {
+        "product_slug": "fixture-a", "product_type": "model", "artifact_kind": "github",
+        "artifact_id": "ówner/repo", "channel": "github", "metric_type": "stars",
+        "raw_value": 42, "unit": "stars", "measurement_window_days": None,
+        "observed_at": datetime.datetime(2026, 1, 2, 3, 4, 5, tzinfo=_UTC),
+    },
+    {
+        "product_slug": "fixture-b", "product_type": "dataset", "artifact_kind": "huggingface_dataset",
+        "artifact_id": "org/set", "channel": "huggingface", "metric_type": "downloads",
+        "raw_value": 1000, "unit": "downloads", "measurement_window_days": 30,
+        "observed_at": datetime.datetime(2026, 1, 2, 3, 4, 5),  # naive → interpreted UTC
+    },
+)
+BEHAVIOR_FIXTURE_DIGEST = "e2e93998bdcf8fabe99fc2fb6d8e3870bf255785b153ba53138fd15ae578eb5c"
 
 
 def _row(**overrides) -> dict:
@@ -38,7 +61,6 @@ def _row(**overrides) -> dict:
         "artifact_id": "acme/thing", "channel": "github", "metric_type": "stars",
         "raw_value": 100, "unit": "stars", "measurement_window_days": None,
         "observed_at": datetime.datetime(2026, 8, 20, 12, 0, 0),
-        # excluded: lineage / capture-time / derived / history
         "observation_id": "deadbeef", "ingested_at": datetime.datetime(2026, 8, 25, 5, 0, 0),
         "source_dataset": "signal_github", "source_table": "currentai.signal_github.artifact_state",
         "source_run_id": None, "source_record_id": None, "is_valid": True,
@@ -48,7 +70,7 @@ def _row(**overrides) -> dict:
     return base
 
 
-# --- content columns -------------------------------------------------------------
+# --- content columns & the pure content digest -----------------------------------
 
 
 def test_content_columns_exclude_lineage_and_capture_time():
@@ -57,11 +79,6 @@ def test_content_columns_exclude_lineage_and_capture_time():
         "source_dataset", "source_table", "is_valid", "supersedes_observation_id",
     ):
         assert excluded not in CONTENT_COLUMNS
-    for included in ("product_slug", "artifact_id", "metric_type", "raw_value", "observed_at"):
-        assert included in CONTENT_COLUMNS
-
-
-# --- the pure content digest -----------------------------------------------------
 
 
 def test_content_digest_is_deterministic_and_order_independent():
@@ -73,7 +90,7 @@ def test_lineage_and_capture_time_do_not_change_the_content_digest():
     base = observation_content_digest([_row()])
     for excluded, value in (
         ("source_run_id", "run-xyz"),
-        ("ingested_at", datetime.datetime(2027, 1, 1, 0, 0, 0)),
+        ("ingested_at", datetime.datetime(2027, 1, 1)),
         ("observation_id", "cafebabe"),
         ("is_valid", False),
     ):
@@ -87,16 +104,29 @@ def test_measurement_changes_change_the_content_digest():
 
 
 def test_content_digest_is_version_independent(monkeypatch):
-    """§4.5: the content digest is content and nothing else — the version is bound in the snapshot
-    id, not the digest."""
     before = observation_content_digest([_row()])
     monkeypatch.setattr(osnap, "CANONICALIZATION_VERSION", osnap.CANONICALIZATION_VERSION + 1)
     assert observation_content_digest([_row()]) == before
 
 
+# --- strict typing (refinement: observed_at must be a datetime) ------------------
+
+
+def test_observed_at_must_be_a_datetime():
+    """A string or other lookalike is rejected — it would bypass UTC normalization."""
+    for bad in ("2026-08-20T12:00:00", "2026-08-20T12:00:00Z", 1_755_000_000, datetime.date(2026, 8, 20)):
+        with pytest.raises(TypeError):
+            observation_content_digest([_row(observed_at=bad)])
+
+
 def test_non_finite_numbers_are_rejected():
     with pytest.raises(ValueError):
         observation_content_digest([_row(raw_value=float("inf"))])
+
+
+def test_unexpected_type_in_a_content_column_is_rejected():
+    with pytest.raises(TypeError):
+        observation_content_digest([_row(raw_value={1, 2})])
 
 
 def test_missing_content_column_is_loud():
@@ -106,18 +136,17 @@ def test_missing_content_column_is_loud():
         observation_content_digest([bad])
 
 
-# --- UTC timestamp normalization (finding 2) -------------------------------------
+# --- UTC timestamp normalization -------------------------------------------------
 
 
 def test_equivalent_instants_produce_one_digest():
-    """The same instant, whatever its written offset or naivety, digests identically."""
     aware_utc = _row(observed_at=datetime.datetime(2026, 8, 25, 12, 0, 0, tzinfo=_UTC))
     aware_off = _row(observed_at=datetime.datetime(
         2026, 8, 25, 8, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=-4))))
     naive = _row(observed_at=datetime.datetime(2026, 8, 25, 12, 0, 0))
     d = observation_content_digest([aware_utc])
-    assert observation_content_digest([aware_off]) == d  # -04:00 same instant
-    assert observation_content_digest([naive]) == d       # naive interpreted UTC
+    assert observation_content_digest([aware_off]) == d
+    assert observation_content_digest([naive]) == d
 
 
 def test_different_instants_differ():
@@ -126,26 +155,27 @@ def test_different_instants_differ():
     assert observation_content_digest([a]) != observation_content_digest([b])
 
 
-# --- the versioned snapshot id (finding 1) ---------------------------------------
+# --- the versioned, domain-separated snapshot id ---------------------------------
 
 
 def test_snapshot_id_binds_the_canonicalization_version(monkeypatch):
-    """Bumping the version MUST change the snapshot id, so a stored id names its rule."""
     before = observation_snapshot_id([_row()])
     monkeypatch.setattr(osnap, "CANONICALIZATION_VERSION", osnap.CANONICALIZATION_VERSION + 1)
     assert observation_snapshot_id([_row()]) != before
 
 
+def test_snapshot_id_uses_the_documented_domain_separated_preimage():
+    """The id is SHA-256 of exactly 'os-ai-map:observation-snapshot:v<N>\\0<content_digest>'."""
+    digest = "b" * 64
+    expected = hashlib.sha256(
+        f"os-ai-map:observation-snapshot:v{CANONICALIZATION_VERSION}\0{digest}".encode("utf-8")
+    ).hexdigest()
+    assert snapshot_id_from_digest(digest) == expected
+
+
 def test_snapshot_id_is_not_the_bare_content_digest():
     rows = [_row()]
     assert observation_snapshot_id(rows) != observation_content_digest(rows)
-
-
-def test_snapshot_id_is_a_function_of_the_content_digest():
-    rows = [_row()]
-    assert observation_snapshot_id(rows) == snapshot_id_from_digest(
-        observation_content_digest(rows)
-    )
 
 
 def test_snapshot_id_shape():
@@ -154,22 +184,32 @@ def test_snapshot_id_shape():
     int(vid, 16)
 
 
-# --- the canonicalization ratchet (finding 3) ------------------------------------
+# --- the canonicalization ratchet over an explicit contract descriptor -----------
 
 
-def test_fingerprint_matches_the_current_serializer():
-    """The committed fingerprint must equal the digest the current serializer produces over the
-    fixture; regenerating it is the only way to change it, which the ratchet then guards."""
-    assert observation_content_digest(_FINGERPRINT_FIXTURE) == CANONICALIZATION_FINGERPRINT
+def test_contract_descriptor_matches_the_live_constants():
+    assert CANONICALIZATION_CONTRACT["version"] == CANONICALIZATION_VERSION
+    assert CANONICALIZATION_CONTRACT["content_columns"] == list(CONTENT_COLUMNS)
 
 
-def test_ratchet_fires_on_a_serializer_change_without_a_version_bump():
+def test_fingerprint_is_the_contract_descriptor_digest():
+    """The fingerprint is over the DECLARED contract, so a rule change moves it even where no
+    fixture exercises that rule."""
+    assert canonicalization_fingerprint() == CANONICALIZATION_FINGERPRINT
+
+
+def test_behavioral_fixture_digest_is_pinned():
+    """Implementation behavior is pinned separately from the contract fingerprint."""
+    assert observation_content_digest(_BEHAVIOR_FIXTURE) == BEHAVIOR_FIXTURE_DIGEST
+
+
+def test_ratchet_fires_on_a_contract_change_without_a_version_bump():
     before = {"version": 1, "fingerprint": "a" * 64}
     with pytest.raises(CanonicalizationRatchetError):
         check_canonicalization_ratchet(before, {"version": 1, "fingerprint": "b" * 64})
 
 
-def test_ratchet_passes_when_the_version_advances_with_the_fingerprint():
+def test_ratchet_passes_when_the_version_advances():
     before = {"version": 1, "fingerprint": "a" * 64}
     check_canonicalization_ratchet(before, {"version": 2, "fingerprint": "b" * 64})
 
@@ -184,11 +224,10 @@ def test_ratchet_first_install_is_not_a_violation():
 
 
 def test_canonicalization_ratchet_against_the_merge_base():
-    """The real gate: on this branch the module is new (absent at the merge base) so there is
-    nothing to ratchet against and this passes; once merged, any serializer change without a
-    version bump fails here."""
+    """The real gate: the module is new on this branch (absent at the merge base) so this passes
+    without a skip; once merged, a contract change without a version bump fails here."""
     before = merge_base_canonicalization()
-    now = {"version": osnap.CANONICALIZATION_VERSION, "fingerprint": CANONICALIZATION_FINGERPRINT}
+    now = {"version": CANONICALIZATION_VERSION, "fingerprint": CANONICALIZATION_FINGERPRINT}
     check_canonicalization_ratchet(before, now)
 
 


### PR DESCRIPTION
## What

Implements the two observation identities §4.5 names — `releases.manifest` carries both — in `build/observation_snapshot.py`, ahead of the evaluation tables that key on them.

- **`observation_content_digest`** — SHA-256 over the measurement columns only (`product_slug`, `product_type`, `artifact_kind`, `artifact_id`, `channel`, `metric_type`, `raw_value`, `unit`, `measurement_window_days`, `observed_at`) as an **order-independent multiset**. Lineage, capture time (`ingested_at`), the derived `observation_id`, `is_valid`, `supersedes_observation_id` excluded. It does not fold in the version *number*, but it is **not** invariant across canonicalization rules — the canonical bytes change if the contract changes, so two digests are comparable only under the same contract.
- **`observation_snapshot_id`** — the identity reconciliation and `release_id` key on. **Domain-separated, versioned preimage** (exact bytes, documented): `SHA-256("os-ai-map:observation-snapshot:v" + version + "\0" + content_digest)`. Binds the canonicalization version, so a persisted id names its rule and two rules can't collide.

**Strict per-column typing.** Every column is checked against its declared type by exact `type()` identity (so a `bool` never slips through): identity/vocabulary/unit fields must be **nonempty strings**; `raw_value` a **finite int/float excluding bool**; `measurement_window_days` a **nonnegative int or null excluding bool**; `observed_at` a real `datetime` (a string, epoch int, or bare `date` is rejected — it would bypass UTC normalization). Aware timestamps → UTC; naive → interpreted UTC; fixed microsecond precision, `Z`.

**Fail-closed identity minting.** `snapshot_id_from_digest()` requires a positive int version and a 64-character lowercase-hex content digest before minting — `"x"`, uppercase, or a truncated digest is refused.

**Canonicalization ratchet over a contract descriptor.** `CANONICALIZATION_FINGERPRINT` is the digest of an explicit `CANONICALIZATION_CONTRACT` (columns, ordering, per-column `column_types`, timestamp rule, null/number encoding, serialization, hash), so a declared-rule change is caught even where no fixture exercises it. A merge-base ratchet fails if the descriptor changes without advancing `CANONICALIZATION_VERSION`. Implementation conformance is pinned separately (a behavioral fixture digest + the baseline goldens).

**Derived, not stored** — computed over the live rows at reconciliation/release time; exercised in-repo against the immutable Phase-2 baseline, whose digests are pinned (`content 8a6c3e98…`, `snapshot 9bd4d93a…`).

## Tests

`tests/test_observation_snapshot.py`: content-alone + version-independence of the digest; version-binding, exact domain-separated preimage, and shape of the id; UTC-equivalence and `observed_at`-must-be-datetime; **per-column malformed-row rejection** (non-string/empty identity fields, numeric-string/bool/None `raw_value`, non-int/negative window); **`snapshot_id_from_digest` preimage validation** (malformed digest, nonpositive/non-int version); the fingerprint equals the contract-descriptor digest; a behavioral fixture golden; the ratchet fires on a contract change without a bump (synthetic) and passes on the merge base (real, no skip); baseline goldens.

Docs: §4.5 note + the full canonicalization declaration for `observation_content_digest`, and the migration-status entry, describe the split, the preimage, and the descriptor ratchet.

## Review responses (three rounds)

Round 1: split content-digest vs versioned snapshot-id; UTC normalization; merge-base ratchet; §4.5 reference + full canonicalization declaration.
Round 2 (refinements): fingerprint the contract **descriptor** not one fixture; **domain-separate** the snapshot-id preimage with documented exact bytes; require `observed_at` to be a `datetime`.
Round 3: correct the two remaining architecture passages (`observation_snapshot_id` was still defined as content-alone) and the module's "digests identically forever regardless of the rule" claim; implement **strict per-column typing** (identity fields nonempty str, `raw_value` finite non-bool number, window nonnegative non-bool int/null); fail-closed digest/version validation in `snapshot_id_from_digest`.

## Checklist

- [x] `uv run python -m build.validate` prints `0 error(s)`
- [x] Did not edit `build/notebook_data.json` or `notebooks/ai-stack-map.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)