### PR TITLE
Bind a live evaluation read to its materialization via a bracket

### DIFF
--- a/build/read_binding.py
+++ b/build/read_binding.py
@@ -1,0 +1,175 @@
+"""Bind a live read of a deployed model to the materialization (and run) that produced it.
+
+## What this is
+
+`observations.product_adoption_current` carries no row-level run lineage (#355): the fetcher
+tables expose no run id, so `source_run_id` is NULL and the reconciliation report classifies
+every measured row `source_unavailable`. That gap is the platform's to close. What CAN be
+established repo-side, without timestamp inference, is a narrower fact: **which materialization
+of the current table a given read was served from** — and through it, that materialization's
+`run_id`.
+
+The platform makes this possible because a data-model run never rewrites a table in place: each
+run CTAS-es a fresh physical table and repoints the logical name at the new materialization, and
+the control plane records one materialization row per run (`id`, `runId`, `createdAt`). So at any
+instant the logical table IS exactly one materialization, and the only uncertainty is a race: a
+run could complete between our row read and our control-plane lookup.
+
+## The bracket
+
+The race is closed by bracketing, not by timestamps:
+
+  1. read the model's newest materialization id (control plane, before);
+  2. read the rows (pyoso; the query text is nonce-salted by `build.warehouse.query`, so the
+     result cannot be a cached answer from before an earlier materialization);
+  3. read the newest materialization id again (after).
+
+If the two control-plane reads name the SAME materialization, no run completed across the row
+read, so the rows were served by that materialization and are bound to its `run_id`. If they
+differ, a refresh landed mid-bracket and the read is honestly `unstable`: both ids are recorded
+and NO run id is claimed. An unstable bracket is a report, never an error — the caller decides
+whether to re-read.
+
+## What this is NOT
+
+  * Not row-to-run binding for the observations themselves. The bound run is the run of
+    `product_adoption_current`'s own materialization — the model evaluation that read the fetcher
+    tables — not the fetcher runs that measured the artifacts. Reconciliation's
+    `source_unavailable` posture is unchanged by this module (#355 remains open).
+  * Not inference. A bracket either proves the binding or reports that it could not; there is no
+    "probably this run" outcome, and `createdAt` ordering is used only to pick the newest
+    materialization within one control-plane response, never to correlate with row timestamps.
+
+Usage:
+    from build.read_binding import bound_read
+    result = bound_read(load_current_observations)
+    rows, binding = result.rows, result.binding
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+from collections.abc import Callable, Mapping, Sequence
+
+GRAPHQL_QUERY = """query($w: JSON) {
+  dataModels(where: $w, first: 10) {
+    edges { node {
+      id
+      name
+      dataset { name }
+      materializations(first: 50) {
+        edges { node { id runId createdAt } }
+      }
+    } }
+  }
+}"""
+
+MODEL_NAME = "product_adoption_current"
+DATASET_NAME = "observations"
+
+
+class BindingLookupError(RuntimeError):
+    """The control plane could not name the model's newest materialization."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Materialization:
+    """One control-plane materialization row, as much of it as the binding needs."""
+
+    materialization_id: str
+    run_id: str
+    created_at: str
+    model_id: str
+
+
+@dataclasses.dataclass(frozen=True)
+class BoundRead:
+    """The rows of one read plus the binding verdict for that read."""
+
+    rows: list[dict]
+    binding: dict
+
+
+def latest_materialization(
+    model_name: str = MODEL_NAME,
+    dataset_name: str = DATASET_NAME,
+    graphql: Callable[..., Mapping] | None = None,
+) -> Materialization:
+    """The newest materialization of one deployed model, from the control plane.
+
+    Newest within one response, by (createdAt, id) — a tiebreak inside a single authoritative
+    listing, not a cross-source timestamp correlation. Raises `BindingLookupError` when the model
+    is missing, ambiguous, or has no materialization: a caller asking to bind a read of a model
+    that the control plane cannot name has a configuration problem, not an unstable bracket.
+    """
+    if graphql is None:
+        from build.publish_registry import graphql as live_graphql
+
+        def graphql(query: str, variables: Mapping, token: str) -> Mapping:  # type: ignore[misc]
+            return live_graphql(query, dict(variables), token)
+
+    token = os.environ.get("OSO_API_KEY", "")
+    if not token:
+        raise BindingLookupError("OSO_API_KEY must be set to read the control plane")
+
+    response = graphql(GRAPHQL_QUERY, {"w": {"name": {"eq": model_name}}}, token)
+    nodes = [edge["node"] for edge in response["dataModels"]["edges"]]
+    matches = [node for node in nodes if (node.get("dataset") or {}).get("name") == dataset_name]
+    if not matches:
+        raise BindingLookupError(
+            f"no deployed model {dataset_name}.{model_name} visible to this token"
+        )
+    if len(matches) > 1:
+        raise BindingLookupError(
+            f"{len(matches)} deployed models named {dataset_name}.{model_name}; refusing to guess"
+        )
+    node = matches[0]
+    materializations = [edge["node"] for edge in node["materializations"]["edges"]]
+    if not materializations:
+        raise BindingLookupError(f"{dataset_name}.{model_name} has no materialization to bind to")
+    newest = max(materializations, key=lambda m: (m["createdAt"], m["id"]))
+    return Materialization(
+        materialization_id=newest["id"],
+        run_id=newest["runId"],
+        created_at=newest["createdAt"],
+        model_id=node["id"],
+    )
+
+
+def bound_read(
+    reader: Callable[[], Sequence[Mapping]],
+    model_name: str = MODEL_NAME,
+    dataset_name: str = DATASET_NAME,
+    graphql: Callable[..., Mapping] | None = None,
+) -> BoundRead:
+    """Run `reader` inside a materialization bracket and report what the read was bound to.
+
+    The binding dict always carries `binding_status` (`bound` | `unstable`) and the model
+    coordinates. `bound` adds the proven `materialization_id` / `run_id` / `materialized_at`;
+    `unstable` records both bracket ends and claims nothing.
+    """
+    before = latest_materialization(model_name, dataset_name, graphql=graphql)
+    rows = [dict(row) for row in reader()]
+    after = latest_materialization(model_name, dataset_name, graphql=graphql)
+
+    coordinates = {
+        "model": f"{dataset_name}.{model_name}",
+        "model_id": before.model_id,
+    }
+    if before.materialization_id == after.materialization_id:
+        binding = {
+            **coordinates,
+            "binding_status": "bound",
+            "materialization_id": before.materialization_id,
+            "run_id": before.run_id,
+            "materialized_at": before.created_at,
+        }
+    else:
+        binding = {
+            **coordinates,
+            "binding_status": "unstable",
+            "materialization_id_before": before.materialization_id,
+            "materialization_id_after": after.materialization_id,
+        }
+    return BoundRead(rows=rows, binding=binding)

--- a/build/serialize_evaluation.py
+++ b/build/serialize_evaluation.py
@@ -13,6 +13,14 @@ maintainer uploads as the `currentai.evaluation.*` static models; see
 `docs/operations/deploy-evaluation.md`. Nothing here writes to the platform — publishing is the
 maintainer step.
 
+A `--live` read is additionally run inside a materialization bracket (`build.read_binding`), and
+the verdict lands in `build/evaluation/read_binding.json` beside the CSVs: `bound` proves which
+materialization (and so which run) of `product_adoption_current` served the rows the snapshot id
+was minted over; `unstable` or `unavailable` records that it could not be proven, claiming
+nothing. The receipt is provenance for the read only — it does not enter either table's columns,
+does not move `observation_snapshot_id`, and does not bind the underlying fetcher runs (#355).
+The baseline path reads frozen bytes, so no receipt is written there.
+
 Usage:
     uv run python -m build.serialize_evaluation                 # baseline -> build/evaluation/*.csv
     uv run python -m build.serialize_evaluation --live          # deployed current table
@@ -24,6 +32,7 @@ from __future__ import annotations
 import argparse
 import csv
 import datetime
+import json
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
@@ -61,6 +70,40 @@ def build_tables(
     return measurements, reconciliation
 
 
+def read_live_bound() -> tuple[list[dict], dict]:
+    """The deployed current table, read inside a materialization bracket where possible.
+
+    A control-plane failure degrades the BINDING, never the read: the rows still load (unbracketed)
+    and the receipt records `unavailable` with the reason. The bracket is provenance, not a gate —
+    refusing to serialize because a lookup failed would block a deploy on a blip while proving
+    nothing about the rows.
+    """
+    from build.read_binding import bound_read
+
+    try:
+        result = bound_read(M.load_current_observations)
+    except Exception as exc:  # noqa: BLE001 — any binding failure degrades to `unavailable`, by design
+        return M.load_current_observations(), {
+            "binding_status": "unavailable",
+            "model": "observations.product_adoption_current",
+            "reason": str(exc),
+        }
+    return result.rows, result.binding
+
+
+def write_binding_receipt(binding: Mapping, observation_rows: Sequence[Mapping], path: Path) -> None:
+    """The read-binding verdict plus the identity of the rows it is a verdict about."""
+    from build.observation_snapshot import observation_snapshot_id
+
+    receipt = {
+        "observation_snapshot_id": observation_snapshot_id(observation_rows),
+        "row_count": len(observation_rows),
+        **binding,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
 def _flat(row: Mapping, columns: Sequence[str]) -> dict:
     out: dict[str, object] = {}
     for key in columns:
@@ -90,8 +133,9 @@ def main() -> int:
                         help="stamp a diagnostic declaration_version_id over a dirty worktree")
     args = parser.parse_args()
 
+    binding: dict | None = None
     if args.live:
-        observation_rows = M.load_current_observations()
+        observation_rows, binding = read_live_bound()
     else:
         from build.observation_snapshot import rows_from_parquet
 
@@ -102,6 +146,8 @@ def main() -> int:
     )
     print(f"product_adoption_measurements  {len(measurements)} rows")
     print(f"adoption_reconciliation        {len(reconciliation)} rows")
+    if binding is not None:
+        print(f"read binding                   {binding['binding_status']}")
     if args.check:
         print("\ncheck only: nothing written")
         return 0
@@ -109,6 +155,9 @@ def main() -> int:
     write_csv(measurements, M.COLUMNS, OUT_DIR / "product_adoption_measurements.csv")
     write_csv(reconciliation, R.COLUMNS, OUT_DIR / "adoption_reconciliation.csv")
     print(f"\nwrote {OUT_DIR}/product_adoption_measurements.csv and adoption_reconciliation.csv")
+    if binding is not None:
+        write_binding_receipt(binding, observation_rows, OUT_DIR / "read_binding.json")
+        print(f"wrote {OUT_DIR}/read_binding.json ({binding['binding_status']})")
     return 0
 
 

--- a/tests/test_read_binding.py
+++ b/tests/test_read_binding.py
@@ -1,0 +1,154 @@
+"""The materialization bracket: what it proves, what it refuses to claim, and its receipt.
+
+The bracket's whole value is honesty at the edges, so the tests concentrate there: a stable
+bracket binds, a moved bracket claims nothing, a lookup failure degrades the binding and never
+the read, and the receipt names the exact rows (by snapshot id) its verdict is about.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from build import read_binding as B
+from build import serialize_evaluation as SE
+
+
+def _control_plane(materialization_lists):
+    """A fake GraphQL endpoint serving successive materialization listings for one model.
+
+    `materialization_lists` is consumed one listing per call — the two bracket ends of
+    `bound_read` see the first and second entries.
+    """
+    listings = list(materialization_lists)
+
+    def graphql(query, variables, token):
+        assert variables == {"w": {"name": {"eq": "product_adoption_current"}}}
+        current = listings.pop(0) if len(listings) > 1 else listings[0]
+        return {
+            "dataModels": {
+                "edges": [
+                    {
+                        "node": {
+                            "id": "model-1",
+                            "name": "product_adoption_current",
+                            "dataset": {"name": "observations"},
+                            "materializations": {
+                                "edges": [{"node": m} for m in current]
+                            },
+                        }
+                    }
+                ]
+            }
+        }
+
+    return graphql
+
+
+M_OLD = {"id": "mat-old", "runId": "run-old", "createdAt": "2026-08-24T15:02:16.919Z"}
+M_NEW = {"id": "mat-new", "runId": "run-new", "createdAt": "2026-08-25T05:49:57.943Z"}
+ROWS = [{"product_slug": "olmo-3", "raw_value": 7}]
+
+
+@pytest.fixture(autouse=True)
+def api_key(monkeypatch):
+    monkeypatch.setenv("OSO_API_KEY", "test-token")
+
+
+def test_latest_materialization_is_newest_by_created_at_not_listing_order():
+    graphql = _control_plane([[M_OLD, M_NEW]])
+    newest = B.latest_materialization(graphql=graphql)
+    assert newest.materialization_id == "mat-new"
+    assert newest.run_id == "run-new"
+
+
+def test_stable_bracket_binds_the_read_to_one_run():
+    graphql = _control_plane([[M_OLD, M_NEW], [M_OLD, M_NEW]])
+    result = B.bound_read(lambda: ROWS, graphql=graphql)
+    assert result.rows == ROWS
+    assert result.binding["binding_status"] == "bound"
+    assert result.binding["materialization_id"] == "mat-new"
+    assert result.binding["run_id"] == "run-new"
+    assert result.binding["model"] == "observations.product_adoption_current"
+
+
+def test_moved_bracket_is_unstable_and_claims_no_run():
+    m_next = {"id": "mat-next", "runId": "run-next", "createdAt": "2026-08-25T06:10:00.000Z"}
+    graphql = _control_plane([[M_NEW], [M_NEW, m_next]])
+    result = B.bound_read(lambda: ROWS, graphql=graphql)
+    assert result.binding["binding_status"] == "unstable"
+    assert "run_id" not in result.binding
+    assert result.binding["materialization_id_before"] == "mat-new"
+    assert result.binding["materialization_id_after"] == "mat-next"
+    assert result.rows == ROWS  # an unstable bracket still returns the rows
+
+
+def test_missing_model_and_empty_materializations_fail_the_lookup_loudly():
+    def wrong_dataset(query, variables, token):
+        return {"dataModels": {"edges": [{"node": {
+            "id": "model-9", "name": "product_adoption_current",
+            "dataset": {"name": "scores"},
+            "materializations": {"edges": []},
+        }}]}}
+
+    with pytest.raises(B.BindingLookupError, match="no deployed model"):
+        B.latest_materialization(graphql=wrong_dataset)
+    with pytest.raises(B.BindingLookupError, match="no materialization"):
+        B.latest_materialization(graphql=_control_plane([[]]))
+
+
+def test_duplicate_models_refuse_to_guess():
+    def two_models(query, variables, token):
+        node = {
+            "id": "model-1", "name": "product_adoption_current",
+            "dataset": {"name": "observations"},
+            "materializations": {"edges": [{"node": M_NEW}]},
+        }
+        return {"dataModels": {"edges": [{"node": node}, {"node": dict(node, id="model-2")}]}}
+
+    with pytest.raises(B.BindingLookupError, match="refusing to guess"):
+        B.latest_materialization(graphql=two_models)
+
+
+def test_lookup_failure_degrades_the_binding_never_the_read(monkeypatch):
+    def broken(*args, **kwargs):
+        raise B.BindingLookupError("control plane down")
+
+    monkeypatch.setattr("build.read_binding.bound_read", broken)
+    monkeypatch.setattr(SE.M, "load_current_observations", lambda: list(ROWS))
+    rows, binding = SE.read_live_bound()
+    assert rows == ROWS
+    assert binding["binding_status"] == "unavailable"
+    assert "control plane down" in binding["reason"]
+
+
+def test_receipt_names_the_rows_it_judges(tmp_path):
+    from build.observation_snapshot import observation_snapshot_id, rows_from_parquet
+
+    rows = rows_from_parquet()
+    binding = {
+        "binding_status": "bound",
+        "model": "observations.product_adoption_current",
+        "model_id": "model-1",
+        "materialization_id": "mat-new",
+        "run_id": "run-new",
+        "materialized_at": M_NEW["createdAt"],
+    }
+    path = tmp_path / "read_binding.json"
+    SE.write_binding_receipt(binding, rows, path)
+    receipt = json.loads(path.read_text(encoding="utf-8"))
+    assert receipt["observation_snapshot_id"] == observation_snapshot_id(rows)
+    assert receipt["row_count"] == len(rows)
+    assert receipt["run_id"] == "run-new"
+
+
+def test_binding_does_not_move_the_snapshot_id():
+    """The bracket is provenance about a read; the identity of the rows must not see it."""
+    from build.observation_snapshot import observation_snapshot_id, rows_from_parquet
+
+    rows = rows_from_parquet()
+    before = observation_snapshot_id(rows)
+    graphql = _control_plane([[M_NEW], [M_NEW]])
+    result = B.bound_read(lambda: rows, graphql=graphql)
+    assert observation_snapshot_id(result.rows) == before


### PR DESCRIPTION
## Summary

* New `build/read_binding.py`: a **materialization bracket** for reads of `observations.product_adoption_current` — fetch the model's newest materialization id from the control plane, read the rows (nonce-salted query text, so the result cannot be a cached pre-materialization answer), fetch again. A stable bracket proves which materialization — and so which `run_id` — served the rows; a moved bracket reports `unstable` and claims nothing. No timestamp inference anywhere: `createdAt` is only used to pick the newest entry within one control-plane response.
* `build/serialize_evaluation.py --live` now reads inside that bracket and writes the verdict to `build/evaluation/read_binding.json` (git-ignored, beside the CSVs), stamped with the `observation_snapshot_id` and row count it judges. A control-plane failure degrades the binding to `unavailable` — provenance, never a gate: it does not fail the serialization, and it does not move the snapshot id.
* Scope guard, stated in both modules: this binds the **reading** of the current table (the model-evaluation run), not the fetcher runs behind the observations. Reconciliation's `source_unavailable` posture is unchanged; #355 stays open on its own criteria (run-id exposure to model code is filed platform-side).

## Test plan

* `tests/test_read_binding.py` (8 tests): newest-by-createdAt selection, stable bracket binds, moved bracket is unstable with no run claimed, missing/ambiguous model and empty materializations fail the lookup loudly, lookup failure degrades the binding but still returns rows, receipt carries the snapshot id of the exact rows, and the bracket does not move `observation_snapshot_id`.
* Full suite: 967 passed in 8m40s. `build.validate`: 0 errors. Ruff clean on touched files.
* `serialize_evaluation --check` over the baseline unchanged: 377 / 522 rows, no receipt written (frozen bytes bind to nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wzAXtPjK9amV8mZJ9c7s3