### PR TITLE
A workflow for discovering candidates (rebased + review corrections)

### DIFF
--- a/.claude/skills/discover-candidates
+++ b/.claude/skills/discover-candidates
@@ -1,0 +1,1 @@
+../../skills/discover-candidates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,7 +299,7 @@ once in `docs/reference/`, not in the skill. Skills are registered under `.claud
 Claude Code session discovers them by name; if yours does not list them, read
 `skills/<name>/SKILL.md` directly.
 
-**Six primary editor skills** (the contributor front door):
+**Primary editor skills** (the contributor front door):
 
 | Skill | When to use | Workflow |
 |-------|------------|----------|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,6 +303,7 @@ Claude Code session discovers them by name; if yours does not list them, read
 
 | Skill | When to use | Workflow |
 |-------|------------|----------|
+| `discover-candidates` | Sweep for products the map does not have yet | `docs/workflows/discover-candidates.md` |
 | `add-product` | Add a new product | `docs/workflows/add-product.md` |
 | `update-product` | Change an existing product (identity, prose, a score, rosters, retirement) | `docs/workflows/update-product.md` |
 | `edit-category` | Create a category, or change its definition/weights/roster | `docs/workflows/edit-category.md` |

--- a/build/validate.py
+++ b/build/validate.py
@@ -148,6 +148,18 @@ def validate_sources(data: dict) -> list[str]:
     tail_slugs: dict[str, str] = {}
     tail_repos: dict[str, str] = {}
     head_repos: dict[str, str] = {}
+    # A retired slug is a settled decision, so it disqualifies a candidate exactly as a live
+    # slug does: re-adding it re-opens the consolidation that retired it. Checking only
+    # `slug in prods` missed that entirely -- amazon-nova-pro, an alias of amazon-nova, passed
+    # validation as a new candidate. Resolved here rather than reusing the `claimed` map built
+    # in the slug-stability section below, because that map is built by a loop whose purpose is
+    # to REPORT duplicate claims as it goes; this one only needs to resolve them.
+    alias_of = {
+        alias: slug
+        for slug, product in sorted(prods.items())
+        for alias in product.get("aliases") or []
+        if isinstance(alias, str)
+    }
     for slug, product in prods.items():
         for artifact in product.get("github") or []:
             if isinstance(artifact, dict) and isinstance(artifact.get("url"), str):
@@ -174,6 +186,12 @@ def validate_sources(data: dict) -> list[str]:
                 continue
             if slug in prods:
                 errors.append(f"registry/{cid}.yaml: tail slug {slug!r} already exists as a head product")
+            if slug in alias_of:
+                errors.append(
+                    f"registry/{cid}.yaml: tail slug {slug!r} is a retired alias of head product "
+                    f"{alias_of[slug]!r}. A retired slug was deliberately consolidated or "
+                    f"dropped; re-adding it as a candidate re-opens a settled decision."
+                )
             if slug in tail_slugs:
                 errors.append(
                     f"registry/{cid}.yaml: tail slug {slug!r} already belongs to "

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ know the internal vocabulary before you begin.
 
 | I want to… | Workflow | Skill |
 |---|---|---|
+| Find products the map does not have yet | [`workflows/discover-candidates.md`](workflows/discover-candidates.md) | `discover-candidates` |
 | Add a new product to the map | [`workflows/add-product.md`](workflows/add-product.md) | `add-product` |
 | Change something about an existing product | [`workflows/update-product.md`](workflows/update-product.md) | `update-product` |
 | Create a category, or change its definition, weights, or roster | [`workflows/edit-category.md`](workflows/edit-category.md) | `edit-category` |

--- a/docs/workflows/add-product.md
+++ b/docs/workflows/add-product.md
@@ -20,6 +20,21 @@ Five, and all in the same PR:
 
 `CONTRIBUTING.md` historically listed only the first four. The fifth is real.
 
+**A sixth, when the product starts life as a discovered candidate.** If a row for this slug
+exists in `sources/registry/<cat>.yaml` — put there by
+[`discover-candidates.md`](discover-candidates.md) — that row **comes out** in the same PR. A
+slug may live in exactly one tier, so adding the head product without removing the tail row
+fails `validate` with `tail slug '<slug>' already exists as a head product`. Check before you
+start:
+
+```bash
+grep -rn "slug: <slug>" sources/registry/
+```
+
+`promote-category` does the same removal for a whole roster, but it applies only to
+*preliminary* categories. A candidate discovered in an already-published category has no other
+workflow that clears its row, so this is the only place it happens.
+
 ## Procedure
 1. **Pick the slug.** Kebab-case, and it names the **tier the vendor sells**, not a version or
    size — see [`../reference/identity.md`](../reference/identity.md). Slugs are immutable.
@@ -43,7 +58,9 @@ Five, and all in the same PR:
    [`../reference/openness.md`](../reference/openness.md), [`../reference/adoption.md`](../reference/adoption.md),
    [`../reference/capability.md`](../reference/capability.md).
 5. **Update both rosters** (category and org), and the org file if the org is new. A slug
-   appears in exactly one of each.
+   appears in exactly one of each. **If the product came from a registry row, delete that row
+   now** — see the sixth file above. If it was the last row in the file, leave `products: []`
+   rather than deleting the file: the file pairs with a category, not with its contents.
 6. **For a batch,** generate the files with a small script (dump for new files, and a helper
    that inserts `- <slug>` lines under existing `products:` blocks so their formatting is
    preserved). Never load-modify-dump an existing corpus file. Re-check the two hand-authored
@@ -58,8 +75,8 @@ uv run python -m build.check_verification  # producible pair; invariant if you d
 Preview only, never commit: `build/notebook_data.json`, `notebooks/ai-stack-map.py` (bot-owned).
 
 ## Expected PR contents
-The five files above, nothing generated. A one-line note per product on the evidence that
-settled its openness score.
+The five files above — six when a discovered candidate's registry row comes out — and nothing
+generated. A one-line note per product on the evidence that settled its openness score.
 
 ## Stop and escalate when
 - The product needs a **new category** → do [`edit-category.md`](edit-category.md) first (and a

--- a/docs/workflows/discover-candidates.md
+++ b/docs/workflows/discover-candidates.md
@@ -1,0 +1,142 @@
+# Discover candidates
+
+## Use this when
+
+A sweep of the outside world should turn into candidate rows the map can act on: new
+products from GitHub, Hugging Face, package registries, papers, or launch venues.
+
+This is the step *before* the map changes. It decides what should exist. For a single
+product you already know about use `add-product`; to turn a seeded roster into researched
+head products use `promote-category`; to re-verify what is already published use
+`refresh-category`.
+
+## Inputs you need
+
+- The categories to sweep. Read them from `sources/taxonomy.yaml` at run time. **Never work
+  from a remembered list** — the taxonomy grows, and a stale list silently drops every
+  candidate belonging to a category added since.
+- A time window, so the sweep is reproducible and the next one knows where to start.
+- Warehouse access for the discovery pool (`currentai.entities.repos`), if available. It is
+  a dedup input, not a source of truth about what belongs on the map.
+
+## Files this changes
+
+| File | Change |
+|---|---|
+| `sources/registry/<category>.yaml` | Candidate rows appended to `products:`, one per accepted candidate |
+| `sources/taxonomy.yaml` | Only if a candidate needs a category that does not exist — and then only as a `category-proposal` issue first, never edited here |
+
+Nothing else. This workflow does not write `sources/products/`, `sources/scores/`, or any
+category roster. A candidate becomes a product through `promote-category` or `add-product`,
+both of which start from what this step leaves behind.
+
+## Procedure
+
+### 1. Read the taxonomy, then the corpus
+
+Load every category from `sources/taxonomy.yaml`, published and preliminary alike. Load the
+existing corpus: `sources/products/*.yaml` for current slugs, and `sources/slug_aliases.yaml`
+for retired ones. A candidate matching either is already mapped and is not a candidate.
+
+### 2. Sweep
+
+Sweep the sources appropriate to the categories in scope. Record, for every raw signal, the
+URL it came from and the date you fetched it. A candidate you cannot link to is not a
+candidate — see the emit contract below.
+
+### 3. Dedup, in this order
+
+1. Against current product slugs.
+2. Against `sources/slug_aliases.yaml` — a retired slug means the thing was deliberately
+   consolidated or dropped, and re-adding it re-opens a settled decision.
+3. Against the warehouse discovery pool, if reachable.
+4. Against itself: the same tool arriving from GitHub, PyPI and Hugging Face is one
+   candidate, not three.
+
+Entity resolution is the part that goes wrong. Where two signals might be the same product
+and you cannot tell, park both with the ambiguity stated rather than guessing.
+
+### 4. Assign exactly one category
+
+One product, one category, in every tier. It is what keeps the gap arithmetic sane.
+
+If a candidate fits no existing category, it does not get a new one here. Open a
+`category-proposal` issue on GitHub and park the candidate against it. Taxonomy changes are
+a governance event, not a data event.
+
+### 5. Emit rows, not prose
+
+Each accepted candidate becomes a row in `sources/registry/<category>.yaml` satisfying
+`docs/schemas/registry.schema.json`: `slug`, `display_name`, `type`, `org` and `github` are
+required, with `pypi`, `npm`, `huggingface_model`, `huggingface_dataset` and `homepage`
+where they apply.
+
+**The artifact URLs are the point of this step.** A report of names and star counts cannot
+become a registry row without redoing every lookup, so a sweep that omits them has produced
+nothing the repo can use.
+
+### 6. Park what you did not accept, with its reason
+
+Anything surveyed and not accepted is recorded with the reason: already mapped, a new SKU of
+an existing product, superseded, unmaintained, no public artifact, or a boundary rejection.
+A reject that leaves no trace comes back next week and is triaged again from scratch.
+
+### 7. Reconcile the counts
+
+Surveyed, deduped, accepted, parked. They must add up. Publishing counts that do not
+reconcile means nobody can tell whether candidates were dropped silently.
+
+## Rules that hold throughout
+
+**Do not invent a scoring or legitimacy rule mid-sweep.** If a signal looks implausible —
+an implausible star count, a suspicious growth curve — say so on the row and park it. A
+threshold that exists only in one run's output cannot be reproduced, reviewed or appealed,
+and it blocks real products against a standard nobody agreed to. New rules belong in a
+rubric or a reference doc, proposed separately.
+
+**A rate limit is not a finding.** HTTP 429, 403 and 5xx mean "not now", not "not here"
+(`build/fetch_source.py` treats them as transient for exactly this reason). Retry, use a
+token, or leave the field absent and say the fetch did not complete. Never record
+"cannot determine" as though it were a measured absence.
+
+**This step never scores.** Candidate rows carry identity and artifacts. Openness, adoption
+and capability are earned later against evidence, under `add-product` or `promote-category`.
+Preliminary scoring here would be a number with no source behind it.
+
+**No bot PRs.** The sweep ends at populated registry files and a summary for a human to
+approve. Opening PRs per candidate is not part of this workflow.
+
+## Validation
+
+```bash
+uv run python -m build.validate          # schema + roster integrity; must print 0 error(s)
+uv run pytest tests/ -q                  # full suite
+```
+
+`build.validate` is what catches a malformed registry row, a candidate assigned to a
+category that does not exist, and a slug that collides with a live product or a retired
+alias.
+
+## Expected PR contents
+
+- One or more `sources/registry/<category>.yaml` files with new rows.
+- A PR body listing: the window swept, the sources swept, the reconciled counts, and the
+  parked candidates with their reasons.
+- No product, score, or category-roster files.
+
+## Stop and escalate when
+
+- A candidate fits no category, or sits on a boundary between two. Open a
+  `category-proposal` issue; do not stretch a category to fit.
+- Two signals may be the same product and the evidence does not settle it.
+- A source blocks the sweep (rate limits that survive retry, an API that has changed).
+  Report the gap rather than filling it with a guess.
+- The sweep volume is large enough that nobody can review it. Tighten the signal floor
+  before relaxing the human-in-the-loop rule.
+
+## Relevant reference material
+
+- `docs/schemas/registry.schema.json` — the row contract
+- `docs/workflows/promote-category.md` — what happens to these rows next
+- `docs/workflows/add-product.md` — the record each promoted row becomes
+- `docs/reference/evidence-and-freshness.md` — why a fetched claim carries a URL and a date

--- a/docs/workflows/discover-candidates.md
+++ b/docs/workflows/discover-candidates.md
@@ -5,6 +5,13 @@
 A sweep of the outside world should turn into candidate rows the map can act on: new
 products from GitHub, Hugging Face, package registries, papers, or launch venues.
 
+**Sweep every source; emit only GitHub-backed candidates.** The tail registry requires a
+`github` identifier on every row, so a candidate whose only handle is a Hugging Face repo, a
+package name, a paper or a product page cannot be stored yet. Those are still worth
+surveying — a HF release is often how you find a repo — but one that resolves to no
+repository is parked in the batch summary, against issue #365, rather than emitted. Do not
+work around this by inventing a plausible repo for a candidate that has none.
+
 This is the step *before* the map changes. It decides what should exist. For a single
 product you already know about use `add-product`; to turn a seeded roster into researched
 head products use `promote-category`; to re-verify what is already published use
@@ -12,9 +19,13 @@ head products use `promote-category`; to re-verify what is already published use
 
 ## Inputs you need
 
-- The categories to sweep. Read them from `sources/taxonomy.yaml` at run time. **Never work
-  from a remembered list** — the taxonomy grows, and a stale list silently drops every
-  candidate belonging to a category added since.
+- The categories to sweep. Read them at run time through
+  `build.taxonomy.category_statuses()`, which returns `{slug: status}` for the whole
+  taxonomy. **Never work from a remembered list** — the taxonomy grows, and a stale list
+  silently drops every candidate belonging to a category added since. **Never parse
+  `sources/taxonomy.yaml` yourself either:** a category entry is either a bare string or a
+  `{name, status}` mapping, and code that assumed the scalar form is what broke
+  `build_stack_map`. `category_statuses()` and `arc_categories()` own that normalization.
 - A time window, so the sweep is reproducible and the next one knows where to start.
 - Warehouse access for the discovery pool (`currentai.entities.repos`), if available. It is
   a dedup input, not a source of truth about what belongs on the map.
@@ -27,16 +38,34 @@ head products use `promote-category`; to re-verify what is already published use
 | `sources/taxonomy.yaml` | Only if a candidate needs a category that does not exist — and then only as a `category-proposal` issue first, never edited here |
 
 Nothing else. This workflow does not write `sources/products/`, `sources/scores/`, or any
-category roster. A candidate becomes a product through `promote-category` or `add-product`,
-both of which start from what this step leaves behind.
+category roster. A candidate becomes a product later, and **which workflow picks it up depends
+on the category's status** — a distinction worth getting right, because the two are not
+interchangeable:
+
+| Category status | Who promotes the row | 
+|---|---|
+| `preliminary` | [`promote-category`](promote-category.md), for the whole seed roster at once |
+| `published` | [`add-product`](add-product.md), one product at a time |
+
+`promote-category` is *only* for preliminary categories, so a candidate swept into a published
+one — which is every registry file today — is promoted through `add-product`. Either way the
+registry row **comes out** in the promoting PR: a slug lives in exactly one tier, and leaving
+the row behind fails `validate` as a duplicate.
 
 ## Procedure
 
 ### 1. Read the taxonomy, then the corpus
 
-Load every category from `sources/taxonomy.yaml`, published and preliminary alike. Load the
-existing corpus: `sources/products/*.yaml` for current slugs, and `sources/slug_aliases.yaml`
-for retired ones. A candidate matching either is already mapped and is not a candidate.
+Load every category through `build.taxonomy.category_statuses()`, published and preliminary
+alike. Then load the existing corpus:
+
+- **current slugs** — the filename stems of `sources/products/*.yaml`;
+- **retired slugs** — the `aliases:` list on each of those records. There is no
+  `sources/slug_aliases.yaml`; the single alias mapping was deleted in #157 because two
+  renames of the same retired slug silently kept whichever came last. Aliases now live on
+  the record that replaced the slug, so the retired set is derived, not read from a file.
+
+A candidate matching either set is already mapped and is not a candidate.
 
 ### 2. Sweep
 
@@ -47,8 +76,10 @@ candidate — see the emit contract below.
 ### 3. Dedup, in this order
 
 1. Against current product slugs.
-2. Against `sources/slug_aliases.yaml` — a retired slug means the thing was deliberately
-   consolidated or dropped, and re-adding it re-opens a settled decision.
+2. Against the retired slugs derived in step 1 — the union of every `aliases:` entry across
+   `sources/products/*.yaml`. A retired slug means the thing was deliberately consolidated or
+   dropped, and re-adding it re-opens a settled decision. `amazon-nova-pro` is the shape to
+   watch for: a SKU that was folded into `amazon-nova` and reads like a new product.
 3. Against the warehouse discovery pool, if reachable.
 4. Against itself: the same tool arriving from GitHub, PyPI and Hugging Face is one
    candidate, not three.
@@ -68,18 +99,42 @@ a governance event, not a data event.
 
 Each accepted candidate becomes a row in `sources/registry/<category>.yaml` satisfying
 `docs/schemas/registry.schema.json`: `slug`, `display_name`, `type`, `org` and `github` are
-required, with `pypi`, `npm`, `huggingface_model`, `huggingface_dataset` and `homepage`
-where they apply.
+required, with `pypi`, `npm`, `huggingface_model`, `huggingface_dataset` and `homepage` where
+they apply. The row rejects any other key (`additionalProperties: false`).
 
-**The artifact URLs are the point of this step.** A report of names and star counts cannot
-become a registry row without redoing every lookup, so a sweep that omits them has produced
-nothing the repo can use.
+**Artifacts are canonical identifiers, not URLs.** This is the single easiest way to produce a
+sweep that has to be redone, because a URL looks obviously right and fails two ways at once —
+the schema rejects it, and `build/serialize_registry.py` builds the public URL *from* the
+identifier, so a stored URL would serialize to `https://github.com/https://github.com/owner/repo`.
+
+| Field | Write | Not |
+|---|---|---|
+| `github` | `owner/repo` | `https://github.com/owner/repo` |
+| `huggingface_model` | `owner/name` | `https://huggingface.co/owner/name` |
+| `huggingface_dataset` | `owner/name` | `https://huggingface.co/datasets/owner/name` |
+| `pypi` | `package-name` | `https://pypi.org/project/package-name/` |
+| `npm` | `package-name` | `https://www.npmjs.com/package/package-name` |
+| `homepage` | a full URL | — the one field that *is* a URL |
+
+Head product records are the opposite convention — `sources/products/<slug>.yaml` stores typed
+arrays of `{url: ...}` — so do not carry a habit from `add-product` into a registry row, or
+back the other way.
+
+**The source URLs still matter, they just live elsewhere.** Every raw signal's URL and fetch
+date belong in the batch summary, which is what makes the sweep auditable and lets the next
+step verify a claim without re-running the lookup. A sweep that reports names and star counts
+and keeps neither the identifiers nor the source URLs has produced nothing the repo can use.
 
 ### 6. Park what you did not accept, with its reason
 
-Anything surveyed and not accepted is recorded with the reason: already mapped, a new SKU of
-an existing product, superseded, unmaintained, no public artifact, or a boundary rejection.
-A reject that leaves no trace comes back next week and is triaged again from scratch.
+Anything surveyed and not accepted is recorded **in the batch summary** with the reason:
+already mapped, a retired alias, a new SKU of an existing product, superseded, unmaintained,
+no public artifact, GitHub-backed storage not yet available (#365), or a boundary rejection. A
+reject that leaves no trace comes back next week and is triaged again from scratch.
+
+Parked candidates do not go in `products:`. A registry row has no `notes` field and rejects
+unknown keys, so there is nowhere on a row to write a reason — and a parked candidate is not a
+candidate row in the first place.
 
 ### 7. Reconcile the counts
 
@@ -88,11 +143,12 @@ reconcile means nobody can tell whether candidates were dropped silently.
 
 ## Rules that hold throughout
 
-**Do not invent a scoring or legitimacy rule mid-sweep.** If a signal looks implausible —
-an implausible star count, a suspicious growth curve — say so on the row and park it. A
-threshold that exists only in one run's output cannot be reproduced, reviewed or appealed,
-and it blocks real products against a standard nobody agreed to. New rules belong in a
-rubric or a reference doc, proposed separately.
+**Do not invent a scoring or legitimacy rule mid-sweep.** If a signal looks implausible — an
+implausible star count, a suspicious growth curve — park the candidate and say why in the
+batch summary, with the number that bothered you. A threshold that exists only in one run's
+output cannot be reproduced, reviewed or appealed, and it blocks real products against a
+standard nobody agreed to. New rules belong in a rubric or a reference doc, proposed
+separately.
 
 **A rate limit is not a finding.** HTTP 429, 403 and 5xx mean "not now", not "not here"
 (`build/fetch_source.py` treats them as transient for exactly this reason). Retry, use a
@@ -113,15 +169,23 @@ uv run python -m build.validate          # schema + roster integrity; must print
 uv run pytest tests/ -q                  # full suite
 ```
 
-`build.validate` is what catches a malformed registry row, a candidate assigned to a
-category that does not exist, and a slug that collides with a live product or a retired
-alias.
+`build.validate` catches a malformed registry row (including a URL where an identifier
+belongs), a candidate assigned to a category that does not exist, a slug that collides with a
+live product, a retired alias or another registry file, and a GitHub artifact already claimed
+by a head or tail product.
+
+Two limits worth knowing, so the gate is not trusted past its reach. Artifact-level dedup is
+keyed on `github` only: two rows carrying the same `pypi` or `huggingface_model` and different
+repos both pass, so the self-dedup in step 3 is yours to get right (#365). And validation
+cannot tell a genuinely new product from one you failed to recognize — it checks identity
+collisions, not judgment.
 
 ## Expected PR contents
 
 - One or more `sources/registry/<category>.yaml` files with new rows.
-- A PR body listing: the window swept, the sources swept, the reconciled counts, and the
-  parked candidates with their reasons.
+- A PR body listing: the window swept, the sources swept, the reconciled counts, the source
+  URL and fetch date behind each accepted candidate, and the parked candidates with their
+  reasons.
 - No product, score, or category-roster files.
 
 ## Stop and escalate when
@@ -136,7 +200,11 @@ alias.
 
 ## Relevant reference material
 
-- `docs/schemas/registry.schema.json` — the row contract
-- `docs/workflows/promote-category.md` — what happens to these rows next
-- `docs/workflows/add-product.md` — the record each promoted row becomes
+- `docs/schemas/registry.schema.json` — the row contract, including which fields are
+  identifiers and which is a URL
+- `docs/reference/identity.md` — why a retired slug stays retired, and why aliases live on
+  records rather than in one mapping
+- `docs/workflows/add-product.md` — what happens to a row in a **published** category
+- `docs/workflows/promote-category.md` — what happens to a whole roster in a **preliminary**
+  category
 - `docs/reference/evidence-and-freshness.md` — why a fetched claim carries a URL and a date

--- a/docs/workflows/discover-candidates.md
+++ b/docs/workflows/discover-candidates.md
@@ -20,24 +20,44 @@ head products use `promote-category`; to re-verify what is already published use
 ## Inputs you need
 
 - The categories to sweep. Read them at run time through
-  `build.taxonomy.category_statuses()`, which returns `{slug: status}` for the whole
-  taxonomy. **Never work from a remembered list** — the taxonomy grows, and a stale list
-  silently drops every candidate belonging to a category added since. **Never parse
-  `sources/taxonomy.yaml` yourself either:** a category entry is either a bare string or a
-  `{name, status}` mapping, and code that assumed the scalar form is what broke
-  `build_stack_map`. `category_statuses()` and `arc_categories()` own that normalization.
+  `build.taxonomy.category_statuses(taxonomy)`, which takes the loaded taxonomy mapping and
+  returns `{slug: status}` for the whole taxonomy. Load the mapping first, exactly as the
+  build code does:
+
+  ```python
+  import yaml
+  from pathlib import Path
+  from build.taxonomy import category_statuses
+
+  taxonomy = yaml.safe_load(Path("sources/taxonomy.yaml").read_text()) or {}
+  statuses = category_statuses(taxonomy)   # {slug: "published" | "preliminary"}
+  ```
+
+  `category_statuses()` is not a zero-argument call — passing nothing raises `TypeError`.
+  **Never work from a remembered list** — the taxonomy grows, and a stale list silently drops
+  every candidate belonging to a category added since. **Never parse `sources/taxonomy.yaml`
+  yourself either:** a category entry is either a bare string or a `{name, status}` mapping,
+  and code that assumed the scalar form is what broke `build_stack_map`. `category_statuses()`
+  and `arc_categories()` own that normalization.
 - A time window, so the sweep is reproducible and the next one knows where to start.
-- Warehouse access for the discovery pool (`currentai.entities.repos`), if available. It is
-  a dedup input, not a source of truth about what belongs on the map.
+- Warehouse access for the discovery pool (`currentai.entities.repos`), if available. This is
+  the long-tail *discovery* set, not the accepted Gap Map: a repository appearing there may be
+  exactly what this workflow should emit. Use it to consolidate multiple signals into one
+  entity, recover a canonical repository identity, and enrich a candidate — **presence in the
+  pool never disqualifies a candidate.** A repository is only ruled out when it resolves to an
+  existing head product or an existing registry row (see the dedup order below).
 
 ## Files this changes
 
 | File | Change |
 |---|---|
-| `sources/registry/<category>.yaml` | Candidate rows appended to `products:`, one per accepted candidate |
-| `sources/taxonomy.yaml` | Only if a candidate needs a category that does not exist — and then only as a `category-proposal` issue first, never edited here |
+| `sources/registry/<category>.yaml` | One accepted candidate per row under `products:` — appended to an existing file, or a new file created for a category that has none yet (see step 5) |
 
-Nothing else. This workflow does not write `sources/products/`, `sources/scores/`, or any
+Nothing else. A candidate that needs a category which does not exist is a governance event,
+not a data event: open a `category-proposal` issue and park the candidate against it (see
+**Stop and escalate**). This workflow never edits `sources/taxonomy.yaml`.
+
+This workflow does not write `sources/products/`, `sources/scores/`, or any
 category roster. A candidate becomes a product later, and **which workflow picks it up depends
 on the category's status** — a distinction worth getting right, because the two are not
 interchangeable:
@@ -56,16 +76,21 @@ the row behind fails `validate` as a duplicate.
 
 ### 1. Read the taxonomy, then the corpus
 
-Load every category through `build.taxonomy.category_statuses()`, published and preliminary
-alike. Then load the existing corpus:
+Load every category through `build.taxonomy.category_statuses(taxonomy)`, published and
+preliminary alike. Then load the existing corpus:
 
 - **current slugs** — the filename stems of `sources/products/*.yaml`;
 - **retired slugs** — the `aliases:` list on each of those records. There is no
   `sources/slug_aliases.yaml`; the single alias mapping was deleted in #157 because two
   renames of the same retired slug silently kept whichever came last. Aliases now live on
   the record that replaced the slug, so the retired set is derived, not read from a file.
+- **existing registry slugs and artifacts** — the `slug` and `github` of every row already in
+  `sources/registry/*.yaml`. These are candidates a previous sweep already found; without this
+  set a repeated sweep rediscovers and re-triages them every time, only failing at final
+  `validate` if a slug or repository collides. Loading them here is what makes a sweep
+  incremental rather than a full re-triage.
 
-A candidate matching either set is already mapped and is not a candidate.
+A candidate matching any of these sets is already known and is not a new candidate.
 
 ### 2. Sweep
 
@@ -80,8 +105,18 @@ candidate — see the emit contract below.
    `sources/products/*.yaml`. A retired slug means the thing was deliberately consolidated or
    dropped, and re-adding it re-opens a settled decision. `amazon-nova-pro` is the shape to
    watch for: a SKU that was folded into `amazon-nova` and reads like a new product.
-3. Against the warehouse discovery pool, if reachable.
-4. Against itself: the same tool arriving from GitHub, PyPI and Hugging Face is one
+3. Against the existing registry rows loaded in step 1 — every `slug` and `github` already in
+   `sources/registry/*.yaml`. A match here is a candidate a previous sweep already emitted;
+   drop it and, if the earlier decision was to park it, do not re-triage it. This set is
+   deduped *before* the warehouse pool because a match here is a settled outcome, while a match
+   in the pool is only a signal.
+4. Against the warehouse discovery pool, if reachable. This step is enrichment and
+   consolidation, **not rejection**: use the pool to fold several signals into one entity,
+   recover the canonical `owner/repo`, and fill in artifacts. A repository being present in the
+   pool does not disqualify it — the pool *is* the long-tail set this workflow harvests from.
+   Only rule a candidate out here when the pool resolves it to a slug or repository already
+   caught by dedup sets 1–3.
+5. Against itself: the same tool arriving from GitHub, PyPI and Hugging Face is one
    candidate, not three.
 
 Entity resolution is the part that goes wrong. Where two signals might be the same product
@@ -101,6 +136,25 @@ Each accepted candidate becomes a row in `sources/registry/<category>.yaml` sati
 `docs/schemas/registry.schema.json`: `slug`, `display_name`, `type`, `org` and `github` are
 required, with `pypi`, `npm`, `huggingface_model`, `huggingface_dataset` and `homepage` where
 they apply. The row rejects any other key (`additionalProperties: false`).
+
+**When the category has no registry file yet, create it.** Only `compilers` and `storage` have
+registry files today, so a sweep over any other category is creating the file, not appending to
+one. The file is a mapping with a `category` key naming the category slug and a `products:`
+list of rows:
+
+```yaml
+category: <category_slug>
+products:
+  - slug: <kebab-case-slug>
+    display_name: <Display Name>
+    type: software
+    org: <org-slug>
+    github: owner/repo
+```
+
+Append to `products:` only when the file already exists; do not load-modify-dump an existing
+file, since that reformats rows a human authored. For a new file, write the two-key mapping
+above.
 
 **Artifacts are canonical identifiers, not URLs.** This is the single easiest way to produce a
 sweep that has to be redone, because a URL looks obviously right and fails two ways at once —
@@ -129,8 +183,11 @@ and keeps neither the identifiers nor the source URLs has produced nothing the r
 
 Anything surveyed and not accepted is recorded **in the batch summary** with the reason:
 already mapped, a retired alias, a new SKU of an existing product, superseded, unmaintained,
-no public artifact, GitHub-backed storage not yet available (#365), or a boundary rejection. A
-reject that leaves no trace comes back next week and is triaged again from scratch.
+no public artifact, GitHub-backed storage not yet available (#365), or a boundary rejection.
+Record the source URL and fetch date for a parked candidate too, not only for an accepted one:
+the sweep earlier promised provenance for *every* raw signal, and a parked candidate with no
+source URL cannot be re-checked next week — it just comes back and is triaged again from
+scratch.
 
 Parked candidates do not go in `products:`. A registry row has no `notes` field and rejects
 unknown keys, so there is nowhere on a row to write a reason — and a parked candidate is not a
@@ -138,8 +195,18 @@ candidate row in the first place.
 
 ### 7. Reconcile the counts
 
-Surveyed, deduped, accepted, parked. They must add up. Publishing counts that do not
-reconcile means nobody can tell whether candidates were dropped silently.
+The counts must satisfy two invariants, stated as equations so the reconciliation is
+executable rather than a slogan:
+
+```
+raw_signals       = duplicate_signals + unique_candidates
+unique_candidates = accepted          + parked
+```
+
+Every raw signal is either a duplicate (caught by one of the dedup sets in step 3) or a unique
+candidate; every unique candidate is either accepted (emitted as a row) or parked (recorded in
+the summary with its reason). Publish all five numbers. If either equation does not balance,
+some signal was dropped without a trace — find it before opening the PR.
 
 ## Rules that hold throughout
 
@@ -182,10 +249,12 @@ collisions, not judgment.
 
 ## Expected PR contents
 
-- One or more `sources/registry/<category>.yaml` files with new rows.
-- A PR body listing: the window swept, the sources swept, the reconciled counts, the source
-  URL and fetch date behind each accepted candidate, and the parked candidates with their
-  reasons.
+- One or more `sources/registry/<category>.yaml` files with new rows — appended to existing
+  files, or created for a category that had none.
+- A PR body listing: the window swept, the sources swept, the five reconciled counts
+  (`raw_signals`, `duplicate_signals`, `unique_candidates`, `accepted`, `parked`), the source
+  URL and fetch date behind each accepted candidate, and the parked candidates each with their
+  reason and their own source URL and fetch date.
 - No product, score, or category-roster files.
 
 ## Stop and escalate when
@@ -195,8 +264,14 @@ collisions, not judgment.
 - Two signals may be the same product and the evidence does not settle it.
 - A source blocks the sweep (rate limits that survive retry, an API that has changed).
   Report the gap rather than filling it with a guess.
-- The sweep volume is large enough that nobody can review it. Tighten the signal floor
-  before relaxing the human-in-the-loop rule.
+- The sweep volume is large enough that nobody can review it. The fix is a **disclosed,
+  predeclared retrieval cutoff** — how far down a ranked source you swept (top-N by stars, a
+  minimum release date) — not a legitimacy rule. This is not the mid-sweep threshold the rules
+  above prohibit: that one adjudicates whether a *discovered* product is real; a retrieval
+  cutoff only bounds *how much* you retrieved. Keep the two apart: pause and define the cutoff
+  before you rerun, report the resulting coverage limitation in the summary, and never use the
+  cutoff to reject a product the sweep already surfaced — an already-discovered candidate below
+  the cutoff is parked with its reason, not dropped.
 
 ## Relevant reference material
 

--- a/skills/discover-candidates/SKILL.md
+++ b/skills/discover-candidates/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: discover-candidates
+description: Use when sweeping the outside world for products the map does not yet have — GitHub, Hugging Face, package registries, papers, launch venues — and turning the result into candidate rows in sources/registry/. This is the step before the map changes. For one product you already know about use add-product; to turn a seeded roster into published products use promote-category; to re-verify what is published use refresh-category.
+---
+
+# Discover candidates for the map
+
+Thin wrapper. The procedure lives in the workflow doc; this file does not restate it.
+
+## Trigger
+
+A sweep should turn into candidate rows the map can act on. Typically a recurring pass over
+new releases and launches, or a targeted sweep of one category that looks thin.
+
+Not for adding a product you have already chosen (`add-product`), not for promoting a seeded
+roster into head products (`promote-category`), not for re-verifying a published category
+(`refresh-category`).
+
+## Required reading
+
+**Read `docs/workflows/discover-candidates.md` and follow it.** It carries the dedup order,
+the emit contract, the one-product-one-category rule and the escalation conditions. Read
+`docs/workflows/promote-category.md` too — it consumes what this produces, and its triage
+rules are the standard these rows are eventually held to.
+
+## The four traps, named
+
+The workflow explains each. They are listed here because every one of them has produced a
+sweep that had to be thrown away.
+
+1. **Read the category list from `sources/taxonomy.yaml` at run time.** A remembered list
+   silently drops every candidate belonging to a category added since.
+2. **Emit artifact URLs.** `slug`, `display_name`, `type`, `org` and `github` are required by
+   `docs/schemas/registry.schema.json`. Names and star counts alone cannot become a row.
+3. **Do not invent a legitimacy rule mid-sweep.** Flag the row and park it. A threshold that
+   exists only in one run's output cannot be reproduced or appealed.
+4. **A 429 is not a measured absence.** Retry or leave the field out; never record
+   "cannot determine" for a rate limit.
+
+## Agent orchestration
+
+Parallelizes well on fetching, badly on judgment. Harvest signals and artifact URLs
+concurrently; keep dedup, category assignment and boundary calls in one place, because they
+depend on the whole candidate set rather than on any single row.
+
+## Output
+
+Populated `sources/registry/<category>.yaml` files and a summary with reconciled counts and
+parked candidates. Not a prose report, and not a PR per candidate.

--- a/skills/discover-candidates/SKILL.md
+++ b/skills/discover-candidates/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: discover-candidates
-description: Use when sweeping the outside world for products the map does not yet have — GitHub, Hugging Face, package registries, papers, launch venues — and turning the result into candidate rows in sources/registry/. This is the step before the map changes. For one product you already know about use add-product; to turn a seeded roster into published products use promote-category; to re-verify what is published use refresh-category.
+description: Use when sweeping the outside world for products the map does not yet have — GitHub, Hugging Face, package registries, papers, launch venues — and turning the result into candidate rows in sources/registry/. Every source is swept, but only GitHub-backed candidates can be emitted today. This is the step before the map changes. For one product you already know about use add-product; to turn a seeded roster into published products use promote-category; to re-verify what is published use refresh-category.
 ---
 
 # Discover candidates for the map
@@ -23,27 +23,39 @@ the emit contract, the one-product-one-category rule and the escalation conditio
 `docs/workflows/promote-category.md` too — it consumes what this produces, and its triage
 rules are the standard these rows are eventually held to.
 
-## The four traps, named
+## The five traps, named
 
 The workflow explains each. They are listed here because every one of them has produced a
 sweep that had to be thrown away.
 
-1. **Read the category list from `sources/taxonomy.yaml` at run time.** A remembered list
-   silently drops every candidate belonging to a category added since.
-2. **Emit artifact URLs.** `slug`, `display_name`, `type`, `org` and `github` are required by
-   `docs/schemas/registry.schema.json`. Names and star counts alone cannot become a row.
-3. **Do not invent a legitimacy rule mid-sweep.** Flag the row and park it. A threshold that
-   exists only in one run's output cannot be reproduced or appealed.
-4. **A 429 is not a measured absence.** Retry or leave the field out; never record
+1. **Read the category list at run time, through `build.taxonomy.category_statuses()`.** A
+   remembered list silently drops every candidate belonging to a category added since — and
+   parsing `sources/taxonomy.yaml` by hand drops the `{name, status}` entries, which is the
+   failure that broke `build_stack_map`.
+2. **Artifacts are identifiers, not URLs.** `github: owner/repo`, not
+   `https://github.com/owner/repo`; same for `huggingface_*`, and bare package names for
+   `pypi` / `npm`. `homepage` is the only URL on the row. Serialization builds the public URL
+   *from* the identifier, so a URL there serializes to a doubled link. Source URLs and fetch
+   dates go in the batch summary, not on the row.
+3. **Only GitHub-backed candidates can be emitted.** `github` is required on every row, so an
+   HF-only, package-only, paper-only or hardware candidate is parked in the summary against
+   issue #365. Never invent a repo to satisfy the schema.
+4. **Do not invent a legitimacy rule mid-sweep.** Park the candidate and say why in the
+   summary. A threshold that exists only in one run's output cannot be reproduced or appealed.
+5. **A 429 is not a measured absence.** Retry or leave the field out; never record
    "cannot determine" for a rate limit.
 
 ## Agent orchestration
 
-Parallelizes well on fetching, badly on judgment. Harvest signals and artifact URLs
-concurrently; keep dedup, category assignment and boundary calls in one place, because they
-depend on the whole candidate set rather than on any single row.
+Parallelizes well on fetching, badly on judgment. Harvest signals, source URLs and artifact
+identifiers concurrently; keep dedup, category assignment and boundary calls in one place,
+because they depend on the whole candidate set rather than on any single row.
 
 ## Output
 
-Populated `sources/registry/<category>.yaml` files and a summary with reconciled counts and
-parked candidates. Not a prose report, and not a PR per candidate.
+Populated `sources/registry/<category>.yaml` files and a summary carrying the reconciled
+counts, the source URL and fetch date behind each accepted candidate, and the parked
+candidates with their reasons. Not a prose report, and not a PR per candidate.
+
+A registry row rejects unknown keys, so the summary is the only place a reason, a source URL
+or an ambiguity can be recorded. It is part of the deliverable, not a covering note.

--- a/skills/discover-candidates/SKILL.md
+++ b/skills/discover-candidates/SKILL.md
@@ -28,10 +28,11 @@ rules are the standard these rows are eventually held to.
 The workflow explains each. They are listed here because every one of them has produced a
 sweep that had to be thrown away.
 
-1. **Read the category list at run time, through `build.taxonomy.category_statuses()`.** A
-   remembered list silently drops every candidate belonging to a category added since — and
-   parsing `sources/taxonomy.yaml` by hand drops the `{name, status}` entries, which is the
-   failure that broke `build_stack_map`.
+1. **Read the category list at run time, through `build.taxonomy.category_statuses(taxonomy)`.**
+   It takes the loaded taxonomy mapping — `category_statuses(yaml.safe_load(...))`, not a
+   zero-argument call, which raises `TypeError`. A remembered list silently drops every
+   candidate belonging to a category added since — and parsing `sources/taxonomy.yaml` by hand
+   drops the `{name, status}` entries, which is the failure that broke `build_stack_map`.
 2. **Artifacts are identifiers, not URLs.** `github: owner/repo`, not
    `https://github.com/owner/repo`; same for `huggingface_*`, and bare package names for
    `pypi` / `npm`. `homepage` is the only URL on the row. Serialization builds the public URL
@@ -53,9 +54,11 @@ because they depend on the whole candidate set rather than on any single row.
 
 ## Output
 
-Populated `sources/registry/<category>.yaml` files and a summary carrying the reconciled
-counts, the source URL and fetch date behind each accepted candidate, and the parked
-candidates with their reasons. Not a prose report, and not a PR per candidate.
+Populated `sources/registry/<category>.yaml` files — appended, or created for a category with
+no file yet — and a summary carrying the five reconciled counts (`raw_signals =
+duplicate_signals + unique_candidates`; `unique_candidates = accepted + parked`), and the
+source URL and fetch date behind every candidate, accepted or parked, each parked one with its
+reason. Not a prose report, and not a PR per candidate.
 
 A registry row rejects unknown keys, so the summary is the only place a reason, a source URL
 or an ambiguity can be recorded. It is part of the deliverable, not a covering note.

--- a/skills/registry.yaml
+++ b/skills/registry.yaml
@@ -7,6 +7,8 @@
 # - internal: infrastructure / read-only analysis, not editorial map-editing.
 
 primary:
+  - skill: discover-candidates
+    workflow: docs/workflows/discover-candidates.md
   - skill: add-product
     workflow: docs/workflows/add-product.md
   - skill: update-product

--- a/tests/test_docs_integrity.py
+++ b/tests/test_docs_integrity.py
@@ -23,8 +23,8 @@ DOC_FILES = sorted(
     + [REPO / n for n in ("README.md", "CONTRIBUTING.md", "AGENTS.md", "CLAUDE.md")]
 )
 
-PRIMARY_SKILLS = ["add-product", "update-product", "edit-category", "promote-category",
-                  "refresh-category", "migrate-axis"]
+PRIMARY_SKILLS = ["discover-candidates", "add-product", "update-product", "edit-category",
+                  "promote-category", "refresh-category", "migrate-axis"]
 
 # Paths that were deleted or renamed in the reorg. A live reference to one is a regression.
 DEAD_FRAGMENTS = [

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -204,6 +204,55 @@ def test_tail_registry_cannot_duplicate_a_head_product_or_artifact():
     assert any("already exists as a head product" in e for e in errs)
     assert any("already belongs to head product" in e for e in errs)
 
+def test_tail_slug_cannot_be_a_retired_alias():
+    """A retired slug disqualifies a candidate exactly as a live slug does.
+
+    The discover-candidates workflow makes "dedup against retired aliases" its second
+    dedup rule and its Validation section claimed this check existed. It did not: the tail
+    block tested `slug in prods` and nothing else, so amazon-nova-pro -- an alias of
+    amazon-nova in the real corpus -- passed as a brand-new candidate. An advisory dedup
+    rule that validation does not enforce is a rule that fails silently."""
+    d = _fixture()
+    d["products"]["llama"]["aliases"] = ["llama-70b-chat"]
+    d["registry"] = {
+        "storage": {
+            "category": "storage",
+            "products": [
+                {
+                    "slug": "llama-70b-chat",
+                    "display_name": "Llama 70B Chat",
+                    "type": "software",
+                    "org": "meta",
+                    "github": "meta-llama/some-other-repo",
+                }
+            ],
+        }
+    }
+    errs = validate_sources(d)
+    assert any("is a retired alias of head product 'llama'" in e for e in errs), errs
+
+
+def test_a_tail_slug_that_is_no_alias_passes():
+    """The mirror of the above: the check must be able to pass, or it proves nothing."""
+    d = _fixture()
+    d["products"]["llama"]["aliases"] = ["llama-70b-chat"]
+    d["registry"] = {
+        "storage": {
+            "category": "storage",
+            "products": [
+                {
+                    "slug": "some-new-thing",
+                    "display_name": "Some New Thing",
+                    "type": "software",
+                    "org": "meta",
+                    "github": "acme/some-new-thing",
+                }
+            ],
+        }
+    }
+    assert not any("retired alias" in e for e in validate_sources(d))
+
+
 def test_roster_pointing_at_missing_product_fails():
     d = _fixture()
     d["categories"]["base_pretrained"]["products"].append("does-not-exist")


### PR DESCRIPTION
## What

Adds `docs/workflows/discover-candidates.md` plus a thin `discover-candidates` skill (registered `primary`) — the discovery step that runs *before* `add-product` / `promote-category`, ending at candidate rows in `sources/registry/<category>.yaml` rather than a prose report. This is PR #364 rebased onto current `main` (its two original commits, authored by @ccerv1, are preserved) with the eight review findings addressed in a follow-up commit.

### Review findings addressed

1. **Existing registry rows now dedup.** Step 1 loads every `slug` + `github` from `sources/registry/*.yaml`; step 3 dedups against them as the third set, *before* the warehouse pool, so a repeated sweep does not re-triage candidates a prior sweep already emitted.
2. **Warehouse-pool semantics corrected.** `currentai.entities.repos` is documented as the long-tail *discovery* set, used to consolidate signals, recover canonical repo identities, and enrich — presence there never disqualifies a candidate; a repo is ruled out only when it resolves to an existing head product or registry row.
3. **Reconciliation made executable.** Two explicit invariants (`raw_signals = duplicate_signals + unique_candidates`; `unique_candidates = accepted + parked`), and source URL + fetch date now required for parked candidates too, not only accepted ones.
4. **Creating a new registry file documented** (`category:` / `products:` shape) for a category that has none yet — only `compilers` and `storage` exist today, so "appended" did not cover most categories.
5. **`category_statuses()` given its real call shape** — it takes the loaded taxonomy mapping; a zero-arg call raises `TypeError`.
6. **Signal-floor conflict resolved.** The escalation distinguishes a disclosed, predeclared *retrieval cutoff* from a mid-sweep *legitimacy rule*: define the cutoff before rerunning, report the coverage limitation, never use it to reject an already-discovered product.
7. **Handwritten "Six primary editor skills" count removed** from `AGENTS.md`.
8. **`sources/taxonomy.yaml` removed** from "Files this changes"; category proposals stay under "Stop and escalate".

### Test plan

- `uv run python -m build.validate` → `0 error(s)`
- `uv run pytest -q` → **1010 passed**
- Focused doc-integrity + validate suites → 53 passed (includes the new retired-alias validation tests)

## Checklist

- [x] `uv run python -m build.validate` prints `0 error(s)`
- [x] New/changed scores cite sources (`url`, `shows`, `accessed`) — n/a, no score changes
- [x] I did not edit `build/notebook_data.json` or `notebooks/ai-stack-map.py` (a bot regenerates them on merge)
- [x] Product appears in exactly one category roster and one org roster — n/a, no product changes

Supersedes #364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012AQyWpS442ZFdJaM65S31T)_