### PR TITLE
Fix registry publish: read runGroup, not the dropped run field

### DIFF
--- a/build/publish_registry.py
+++ b/build/publish_registry.py
@@ -94,7 +94,7 @@ M_STATIC = """mutation($input: CreateStaticModelInput!){
   createStaticModel(input:$input){ success staticModel{ id name } } }"""
 M_URL = """mutation($staticModelId: ID!){ createStaticModelUploadUrl(staticModelId:$staticModelId) }"""
 M_RUN = """mutation($input: CreateStaticModelRunRequestInput!){
-  createStaticModelRunRequest(input:$input){ success run{ id status } } }"""
+  createStaticModelRunRequest(input:$input){ success runGroup{ id status } } }"""
 M_DELETE = """mutation($id: ID!){ deleteStaticModel(id:$id){ success message } }"""
 
 
@@ -297,7 +297,7 @@ def main() -> int:
         upload(path, url)
         print(f"  uploaded {table}.csv ({path.stat().st_size:,} bytes, {counts[table]:,} rows)")
 
-    run = graphql(
+    run_group = graphql(
         M_RUN,
         {
             "input": {
@@ -306,8 +306,8 @@ def main() -> int:
             }
         },
         token,
-    )["createStaticModelRunRequest"]["run"]
-    print(f"materialization run {run['id']} ({run['status']}) over {len(populated)} models")
+    )["createStaticModelRunRequest"]["runGroup"]
+    print(f"materialization run group {run_group['id']} ({run_group['status']}) over {len(populated)} models")
     return 0
 
 

--- a/tests/test_publish_registry.py
+++ b/tests/test_publish_registry.py
@@ -283,7 +283,7 @@ def test_a_failed_delete_does_not_fail_the_publish(
             return {"createStaticModelUploadUrl": "https://upload.example/put"}
         if query is pr.M_RUN:
             ran.append(variables["input"]["selectedModels"])
-            return {"createStaticModelRunRequest": {"run": {"id": "run-1", "status": "QUEUED"}}}
+            return {"createStaticModelRunRequest": {"runGroup": {"id": "run-1", "status": "QUEUED"}}}
         raise AssertionError(f"unexpected query: {query[:40]}")
 
     monkeypatch.setattr(pr, "graphql", fake_graphql)


### PR DESCRIPTION
## What

Repairs the `registry` / `publish` job, which has been failing on push to `main` at the final run request:

```
build/publish_registry.py:300
RuntimeError: HTTP 400 from the API:
  Cannot query field "run" on type "CreateRunGroupPayload"
```

## Root cause — OSO API drift, not a recent PR

The OSO GraphQL API moved `createStaticModelRunRequest`'s payload to **`CreateRunGroupPayload`**, which exposes **`runGroup`** (a `RunGroup` carrying `id` + `status`), not `run`. `publish_registry.py` still selected `run { id status }`, so the mutation was rejected as a validation error. This is the same class of drift as the earlier `createStaticModelRunRequest {staticModelId}` input fix; it is unrelated to #372/#378 (neither touches `publish_registry.py`).

Operationally: every registry CSV *uploaded* successfully; only the run-group request that materializes them failed — so the last publish left the models uploaded but **unmaterialized**.

## The fix

- `M_RUN` now selects `runGroup { id status }`; the call reads `["createStaticModelRunRequest"]["runGroup"]`.
- The `test_publish_registry.py` mock returns the `runGroup` payload.

**Verified against the live schema by introspection** (read-only, no mutation run): `CreateRunGroupPayload.runGroup: RunGroup`, and `RunGroup` exposes `id` and `status`.

## Verification note

The `publish` job runs only on **push to `main`** / `workflow_dispatch`; a PR runs the structural `check` job only, which does not exercise this path. So this PR's CI won't re-trigger the failure — end-to-end confirmation is the next publish run on `main` (or a manual `workflow_dispatch`). Full suite green (1053 passed), including the 11 `test_publish_registry.py` cases.

## Scoped follow-up (not in this PR)

`build/publish_evaluation.py:451` carries the identical `["createStaticModelRunRequest"]["run"]` drift. Its correct fix is larger — it *polls* `poll_run(run["id"])`, so it must reconcile polling a **run group** vs. a **run** (a group contains runs) — so it's left to its own change rather than folded into this focused repair.

## Checklist

- [x] `uv run python -m build.validate` prints `0 error(s)`
- [x] Full suite green (1053 passed)
- [x] Fix verified against the live OSO GraphQL schema by introspection
- [ ] N/A: no product/score/roster changes (publish CLI + its test only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5bY5TtNtdqoxaeJBdNmXv)_