### PR TITLE
Registry publish: per-model run requests + serialized await (finish the OSO API repair)

### DIFF
--- a/build/publish_registry.py
+++ b/build/publish_registry.py
@@ -297,17 +297,18 @@ def main() -> int:
         upload(path, url)
         print(f"  uploaded {table}.csv ({path.stat().st_size:,} bytes, {counts[table]:,} rows)")
 
-    run_group = graphql(
-        M_RUN,
-        {
-            "input": {
-                "datasetId": dataset_id,
-                "selectedModels": [models[t][0] for t in populated],
-            }
-        },
-        token,
-    )["createStaticModelRunRequest"]["runGroup"]
-    print(f"materialization run group {run_group['id']} ({run_group['status']}) over {len(populated)} models")
+    # The run request is per static model: CreateStaticModelRunRequestInput takes
+    # (datasetId, staticModelId), not a selectedModels list. Request one run group per
+    # populated model in turn rather than one batch over all of them — a single request
+    # naming many models fans out into runs that race to create the dataset's Trino schema.
+    for table in populated:
+        run_group = graphql(
+            M_RUN,
+            {"input": {"datasetId": dataset_id, "staticModelId": models[table][0]}},
+            token,
+        )["createStaticModelRunRequest"]["runGroup"]
+        print(f"  requested {table}: run group {run_group['id']} ({run_group['status']})")
+    print(f"requested {len(populated)} materialization run groups")
     return 0
 
 

--- a/build/publish_registry.py
+++ b/build/publish_registry.py
@@ -96,6 +96,36 @@ M_URL = """mutation($staticModelId: ID!){ createStaticModelUploadUrl(staticModel
 M_RUN = """mutation($input: CreateStaticModelRunRequestInput!){
   createStaticModelRunRequest(input:$input){ success runGroup{ id status } } }"""
 M_DELETE = """mutation($id: ID!){ deleteStaticModel(id:$id){ success message } }"""
+Q_MODEL_RUN = """query($where: JSON){ staticModels(where:$where){
+  edges{ node{ runs(first:1){ edges{ node{ id status } } } } } } }"""
+
+RUN_SUCCESS = "SUCCESS"
+RUN_TERMINAL = frozenset({"SUCCESS", "FAILED", "CANCELED", "CANCELLED", "ERROR", "TIMEOUT", "ABORTED"})
+
+
+def latest_run_status(model_id: str, token: str) -> str | None:
+    """The status of a static model's most recent run, or None if it has none yet."""
+    edges = graphql(Q_MODEL_RUN, {"where": {"id": {"eq": model_id}}}, token)["staticModels"]["edges"]
+    runs = edges[0]["node"]["runs"]["edges"] if edges else []
+    return runs[0]["node"]["status"] if runs else None
+
+
+def poll_model_run(model_id: str, token: str, timeout: float = 600.0, interval: float = 5.0) -> str:
+    """Block until the model's latest run reaches a terminal state, or the timeout elapses.
+
+    A non-terminal status at timeout (e.g. RUNNING/QUEUED) is returned as-is, which the caller
+    treats as not-SUCCESS — a hung run never certifies as materialized.
+    """
+    import time
+
+    deadline = time.time() + timeout
+    status = latest_run_status(model_id, token)
+    while status not in RUN_TERMINAL:
+        if time.time() >= deadline:
+            return status or "UNKNOWN"
+        time.sleep(interval)
+        status = latest_run_status(model_id, token)
+    return status
 
 
 def resolve_dataset(name: str, org_id: str, token: str, create: bool = True) -> str | None:
@@ -298,17 +328,32 @@ def main() -> int:
         print(f"  uploaded {table}.csv ({path.stat().st_size:,} bytes, {counts[table]:,} rows)")
 
     # The run request is per static model: CreateStaticModelRunRequestInput takes
-    # (datasetId, staticModelId), not a selectedModels list. Request one run group per
-    # populated model in turn rather than one batch over all of them — a single request
-    # naming many models fans out into runs that race to create the dataset's Trino schema.
+    # (datasetId, staticModelId), not a selectedModels list. Materialize ONE model at a time,
+    # awaiting each run to a terminal state before requesting the next. A run request only
+    # QUEUES a run; the loads then execute asynchronously, and firing them all at once makes
+    # their loads collide on the destination — a transient "Failed to query OPA backend"
+    # (DatabaseTransientException) that fails a nondeterministic subset. Serializing keeps each
+    # load alone, and polling to terminal is what certifies the table actually materialized
+    # (an accepted request is not a finished one).
+    failures: list[tuple[str, str]] = []
     for table in populated:
+        model_id = models[table][0]
         run_group = graphql(
             M_RUN,
-            {"input": {"datasetId": dataset_id, "staticModelId": models[table][0]}},
+            {"input": {"datasetId": dataset_id, "staticModelId": model_id}},
             token,
         )["createStaticModelRunRequest"]["runGroup"]
-        print(f"  requested {table}: run group {run_group['id']} ({run_group['status']})")
-    print(f"requested {len(populated)} materialization run groups")
+        status = poll_model_run(model_id, token)
+        print(f"  {table}: run group {run_group['id']} finished {status}")
+        if status != RUN_SUCCESS:
+            failures.append((table, status))
+
+    if failures:
+        print("materialization did not succeed for every model:", file=sys.stderr)
+        for table, status in failures:
+            print(f"  ! {table}: {status}", file=sys.stderr)
+        return 1
+    print(f"materialized {len(populated)} models")
     return 0
 
 

--- a/build/publish_registry.py
+++ b/build/publish_registry.py
@@ -96,35 +96,38 @@ M_URL = """mutation($staticModelId: ID!){ createStaticModelUploadUrl(staticModel
 M_RUN = """mutation($input: CreateStaticModelRunRequestInput!){
   createStaticModelRunRequest(input:$input){ success runGroup{ id status } } }"""
 M_DELETE = """mutation($id: ID!){ deleteStaticModel(id:$id){ success message } }"""
-Q_MODEL_RUN = """query($where: JSON){ staticModels(where:$where){
-  edges{ node{ runs(first:1){ edges{ node{ id status } } } } } } }"""
+Q_RUN_GROUP = """query($where: JSON){ runGroups(where:$where){ edges{ node{ id status } } } }"""
 
-RUN_SUCCESS = "SUCCESS"
-RUN_TERMINAL = frozenset({"SUCCESS", "FAILED", "CANCELED", "CANCELLED", "ERROR", "TIMEOUT", "ABORTED"})
-
-
-def latest_run_status(model_id: str, token: str) -> str | None:
-    """The status of a static model's most recent run, or None if it has none yet."""
-    edges = graphql(Q_MODEL_RUN, {"where": {"id": {"eq": model_id}}}, token)["staticModels"]["edges"]
-    runs = edges[0]["node"]["runs"]["edges"] if edges else []
-    return runs[0]["node"]["status"] if runs else None
+GROUP_SUCCESS = "SUCCESS"
+GROUP_TERMINAL = frozenset({"SUCCESS", "FAILED", "CANCELED", "CANCELLED"})
 
 
-def poll_model_run(model_id: str, token: str, timeout: float = 600.0, interval: float = 5.0) -> str:
-    """Block until the model's latest run reaches a terminal state, or the timeout elapses.
+def run_group_status(run_group_id: str, token: str) -> str | None:
+    """The status of the run group with THIS id, or None if the platform does not know it yet.
 
-    A non-terminal status at timeout (e.g. RUNNING/QUEUED) is returned as-is, which the caller
-    treats as not-SUCCESS — a hung run never certifies as materialized.
+    Bound to the exact run group `createStaticModelRunRequest` returned — never a model's
+    "latest run", which could be an earlier, unrelated success and would let the poll pass
+    before this request's run has even appeared.
+    """
+    edges = graphql(Q_RUN_GROUP, {"where": {"id": {"eq": run_group_id}}}, token)["runGroups"]["edges"]
+    return edges[0]["node"]["status"] if edges else None
+
+
+def poll_run_group(run_group_id: str, token: str, timeout: float = 600.0, interval: float = 5.0) -> str:
+    """Block until THIS run group reaches a terminal state, or the timeout elapses.
+
+    A non-terminal status at timeout (e.g. RUNNING) is returned as-is, which the caller treats
+    as not-SUCCESS — a hung run never certifies as materialized.
     """
     import time
 
     deadline = time.time() + timeout
-    status = latest_run_status(model_id, token)
-    while status not in RUN_TERMINAL:
+    status = run_group_status(run_group_id, token)
+    while status not in GROUP_TERMINAL:
         if time.time() >= deadline:
             return status or "UNKNOWN"
         time.sleep(interval)
-        status = latest_run_status(model_id, token)
+        status = run_group_status(run_group_id, token)
     return status
 
 
@@ -329,13 +332,13 @@ def main() -> int:
 
     # The run request is per static model: CreateStaticModelRunRequestInput takes
     # (datasetId, staticModelId), not a selectedModels list. Materialize ONE model at a time,
-    # awaiting each run to a terminal state before requesting the next. A run request only
-    # QUEUES a run; the loads then execute asynchronously, and firing them all at once makes
-    # their loads collide on the destination — a transient "Failed to query OPA backend"
-    # (DatabaseTransientException) that fails a nondeterministic subset. Serializing keeps each
-    # load alone, and polling to terminal is what certifies the table actually materialized
-    # (an accepted request is not a finished one).
-    failures: list[tuple[str, str]] = []
+    # awaiting THIS request's run group to a terminal state before requesting the next. A run
+    # request only QUEUES a run; the loads then execute asynchronously, and firing them all at
+    # once makes their loads collide on the destination — a transient "Failed to query OPA
+    # backend" (DatabaseTransientException) that fails a nondeterministic subset. Serializing
+    # keeps each load alone, and polling the run group we just created (by its id, never the
+    # model's "latest run") is what certifies the table actually materialized. Fail fast: the
+    # first unsuccessful model stops the publish rather than queuing more runs behind a failure.
     for table in populated:
         model_id = models[table][0]
         run_group = graphql(
@@ -343,16 +346,11 @@ def main() -> int:
             {"input": {"datasetId": dataset_id, "staticModelId": model_id}},
             token,
         )["createStaticModelRunRequest"]["runGroup"]
-        status = poll_model_run(model_id, token)
+        status = poll_run_group(run_group["id"], token)
         print(f"  {table}: run group {run_group['id']} finished {status}")
-        if status != RUN_SUCCESS:
-            failures.append((table, status))
-
-    if failures:
-        print("materialization did not succeed for every model:", file=sys.stderr)
-        for table, status in failures:
-            print(f"  ! {table}: {status}", file=sys.stderr)
-        return 1
+        if status != GROUP_SUCCESS:
+            print(f"materialization did not succeed: {table} run group {run_group['id']} is {status}", file=sys.stderr)
+            return 1
     print(f"materialized {len(populated)} models")
     return 0
 

--- a/tests/test_publish_registry.py
+++ b/tests/test_publish_registry.py
@@ -282,10 +282,12 @@ def test_a_failed_delete_does_not_fail_the_publish(
         if query is pr.M_URL:
             return {"createStaticModelUploadUrl": "https://upload.example/put"}
         if query is pr.M_RUN:
+            assert "selectedModels" not in variables["input"]
             ran.append(variables["input"]["staticModelId"])
-            return {"createStaticModelRunRequest": {"runGroup": {"id": "run-1", "status": "QUEUED"}}}
-        if query is pr.Q_MODEL_RUN:
-            return {"staticModels": {"edges": [{"node": {"runs": {"edges": [{"node": {"id": "r", "status": "SUCCESS"}}]}}}]}}
+            return {"createStaticModelRunRequest": {"runGroup": {"id": "run-1", "status": "RUNNING"}}}
+        if query is pr.Q_RUN_GROUP:
+            assert variables["where"]["id"]["eq"] == "run-1"  # poll the exact group we created
+            return {"runGroups": {"edges": [{"node": {"id": "run-1", "status": "SUCCESS"}}]}}
         raise AssertionError(f"unexpected query: {query[:40]}")
 
     monkeypatch.setattr(pr, "graphql", fake_graphql)
@@ -301,3 +303,148 @@ def test_a_failed_delete_does_not_fail_the_publish(
     assert len(ran) == len(pr.TABLES) - 1
     assert "id-tail_products" not in ran
     assert "WARNING could not delete empty tail_products" in capsys.readouterr().err
+
+
+# --- run-group identity binding + serial execution -----------------------------------------
+
+def _populated_tables() -> list[str]:
+    """Every table except the empty one the guard skips, in publish order."""
+    return [t for t in pr.TABLES if t != "tail_products"]
+
+
+def _fake_platform(group_status: dict[str, list[str]]):
+    """A fake `graphql` over the publish flow with a scripted run-group lifecycle.
+
+    `group_status` maps a run-group id to the statuses returned on successive polls (the last
+    repeats). A run request for `id-<table>` mints group id `grp-id-<table>`. `fake.calls`
+    records `("run"|"poll", group_id)` in order so a test can assert identity and ordering.
+    """
+    calls: list[tuple[str, str]] = []
+    poll_index: dict[str, int] = {}
+
+    def fake(query: str, variables: dict, token: str) -> dict:
+        if query is pr.Q_DATASETS:
+            return {"datasets": {"edges": [{"node": {"id": "ds", "name": "registry", "type": "STATIC_MODEL"}}]}}
+        if query is pr.Q_STATIC:
+            return {"staticModels": {"edges": [
+                {"node": {"id": f"id-{t}", "name": t,
+                          "materializations": {"totalCount": None if t == "tail_products" else 5}}}
+                for t in pr.TABLES]}}
+        if query is pr.M_URL:
+            return {"createStaticModelUploadUrl": "https://upload.example/put"}
+        if query is pr.M_DELETE:
+            return {"deleteStaticModel": {"success": True, "message": "ok"}}
+        if query is pr.M_RUN:
+            assert "selectedModels" not in variables["input"]  # obsolete batch input is gone
+            gid = f"grp-{variables['input']['staticModelId']}"
+            calls.append(("run", gid))
+            return {"createStaticModelRunRequest": {"runGroup": {"id": gid, "status": "RUNNING"}}}
+        if query is pr.Q_RUN_GROUP:
+            gid = variables["where"]["id"]["eq"]
+            calls.append(("poll", gid))
+            seq = group_status.get(gid, ["SUCCESS"])
+            i = poll_index.get(gid, 0)
+            poll_index[gid] = i + 1
+            return {"runGroups": {"edges": [{"node": {"id": gid, "status": seq[min(i, len(seq) - 1)]}}]}}
+        raise AssertionError(f"unexpected query: {query[:40]}")
+
+    fake.calls = calls  # type: ignore[attr-defined]
+    return fake
+
+
+def _segments(calls: list[tuple[str, str]]) -> list[tuple[str, list[str]]]:
+    """Group the call log into (requested_group, [polled_groups...]) per run request."""
+    segments: list[tuple[str, list[str]]] = []
+    for op, gid in calls:
+        if op == "run":
+            segments.append((gid, []))
+        else:
+            segments[-1][1].append(gid)
+    return segments
+
+
+def _run_publish(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake) -> int:
+    for t in pr.TABLES:
+        write_csv(tmp_path, t, [] if t == "tail_products" else [{"slug": "a", "display_name": "A"}])
+    monkeypatch.setattr(pr, "graphql", fake)
+    monkeypatch.setattr(pr, "upload", lambda path, url: None)
+    monkeypatch.setattr("time.sleep", lambda _s: None)  # no real waiting between polls
+    monkeypatch.setenv("OSO_API_KEY", "tok")
+    monkeypatch.setenv("OSO_ORG_ID", "org")
+    monkeypatch.setattr("sys.argv", ["publish_registry", "--dir", str(tmp_path)])
+    return pr.main()
+
+
+def test_polls_the_exact_run_group_and_waits_for_it(tmp_path, monkeypatch):
+    """Each poll targets the run group the mutation returned — never the model's latest run —
+    and the publisher waits for that group to leave RUNNING rather than accepting an instant
+    answer. This is the guard against an earlier, unrelated SUCCESS satisfying the poll before
+    the new run has even appeared."""
+    populated = _populated_tables()
+    # every group is RUNNING on the first poll and only SUCCEEDS on the second: if the code
+    # accepted anything but this exact group's terminal state, it would finish too early.
+    status = {f"grp-id-{t}": ["RUNNING", "SUCCESS"] for t in populated}
+    fake = _fake_platform(status)
+    assert _run_publish(tmp_path, monkeypatch, fake) == 0
+
+    run_gids = [g for op, g in fake.calls if op == "run"]
+    poll_gids = {g for op, g in fake.calls if op == "poll"}
+    assert run_gids == [f"grp-id-{t}" for t in populated]   # one request per populated model
+    assert poll_gids == set(run_gids)                        # polled exactly the groups we created
+    # every requested group was polled, and only that group, before the next request:
+    for requested, polled in _segments(fake.calls):
+        assert polled and set(polled) == {requested}
+        assert polled.count(requested) >= 2                  # RUNNING then SUCCESS — it waited
+
+
+def test_next_model_is_requested_only_after_the_prior_group_succeeds(tmp_path, monkeypatch):
+    """Serial execution: run request N+1 must not be issued until group N is terminal-SUCCESS."""
+    populated = _populated_tables()
+    status = {f"grp-id-{t}": ["RUNNING", "SUCCESS"] for t in populated}
+    fake = _fake_platform(status)
+    assert _run_publish(tmp_path, monkeypatch, fake) == 0
+    # the log strictly alternates: run(g1), poll(g1).., run(g2), poll(g2).. — never run(g2)
+    # before g1 has been polled, which (with main()==0) means g1 reached SUCCESS first.
+    order = [op for op, _ in fake.calls]
+    for i, (op, _) in enumerate(fake.calls):
+        if op == "run" and i > 0:
+            assert order[i - 1] == "poll", "a new run was requested before polling the previous group"
+
+
+def test_a_failed_group_fails_fast_and_returns_nonzero(tmp_path, monkeypatch):
+    """A FAILED run group stops the publish immediately (no further runs queued) and exits nonzero."""
+    populated = _populated_tables()
+    status = {f"grp-id-{t}": ["SUCCESS"] for t in populated}
+    status[f"grp-id-{populated[1]}"] = ["RUNNING", "FAILED"]  # the second model fails
+    fake = _fake_platform(status)
+    assert _run_publish(tmp_path, monkeypatch, fake) == 1
+    run_gids = [g for op, g in fake.calls if op == "run"]
+    # fail-fast: only the first two models were ever requested — nothing after the failure
+    assert run_gids == [f"grp-id-{populated[0]}", f"grp-id-{populated[1]}"]
+
+
+def test_poll_run_group_treats_a_timeout_as_not_success(monkeypatch):
+    """A run group stuck non-terminal at the deadline returns its last status, which is not
+    SUCCESS, so the caller fails the publish rather than certifying a hung run."""
+    def always_running(query, variables, token):
+        return {"runGroups": {"edges": [{"node": {"id": variables["where"]["id"]["eq"], "status": "RUNNING"}}]}}
+
+    monkeypatch.setattr(pr, "graphql", always_running)
+    status = pr.poll_run_group("g-stuck", "tok", timeout=0.0, interval=0.0)
+    assert status == "RUNNING"
+    assert status != pr.GROUP_SUCCESS
+
+
+def test_run_request_input_is_static_model_id_not_selected_models(tmp_path, monkeypatch):
+    """The request carries a single staticModelId; the obsolete selectedModels batch input is gone."""
+    inputs: list[dict] = []
+    base = _fake_platform({f"grp-id-{t}": ["SUCCESS"] for t in _populated_tables()})
+
+    def recording(query, variables, token):
+        if query is pr.M_RUN:
+            inputs.append(variables["input"])
+        return base(query, variables, token)
+
+    assert _run_publish(tmp_path, monkeypatch, recording) == 0
+    assert inputs and all(set(i) == {"datasetId", "staticModelId"} for i in inputs)
+    assert not any("selectedModels" in i for i in inputs)

--- a/tests/test_publish_registry.py
+++ b/tests/test_publish_registry.py
@@ -284,6 +284,8 @@ def test_a_failed_delete_does_not_fail_the_publish(
         if query is pr.M_RUN:
             ran.append(variables["input"]["staticModelId"])
             return {"createStaticModelRunRequest": {"runGroup": {"id": "run-1", "status": "QUEUED"}}}
+        if query is pr.Q_MODEL_RUN:
+            return {"staticModels": {"edges": [{"node": {"runs": {"edges": [{"node": {"id": "r", "status": "SUCCESS"}}]}}}]}}
         raise AssertionError(f"unexpected query: {query[:40]}")
 
     monkeypatch.setattr(pr, "graphql", fake_graphql)

--- a/tests/test_publish_registry.py
+++ b/tests/test_publish_registry.py
@@ -257,7 +257,7 @@ def test_a_failed_delete_does_not_fail_the_publish(
         )
 
     uploaded: list[str] = []
-    ran: list[list[str]] = []
+    ran: list[str] = []
 
     def fake_graphql(query: str, variables: dict, token: str) -> dict:
         if query is pr.Q_DATASETS:
@@ -282,7 +282,7 @@ def test_a_failed_delete_does_not_fail_the_publish(
         if query is pr.M_URL:
             return {"createStaticModelUploadUrl": "https://upload.example/put"}
         if query is pr.M_RUN:
-            ran.append(variables["input"]["selectedModels"])
+            ran.append(variables["input"]["staticModelId"])
             return {"createStaticModelRunRequest": {"runGroup": {"id": "run-1", "status": "QUEUED"}}}
         raise AssertionError(f"unexpected query: {query[:40]}")
 
@@ -295,5 +295,7 @@ def test_a_failed_delete_does_not_fail_the_publish(
     assert pr.main() == 0
     assert "tail_products.csv" not in uploaded
     assert len(uploaded) == len(pr.TABLES) - 1
-    assert "id-tail_products" not in ran[0]
+    # one run request per populated model, tail_products (empty) skipped from both
+    assert len(ran) == len(pr.TABLES) - 1
+    assert "id-tail_products" not in ran
     assert "WARNING could not delete empty tail_products" in capsys.readouterr().err


### PR DESCRIPTION
## What

Completes the registry-publish repair begun in #379. Running the publish manually after #379 surfaced two further drifts on the same `createStaticModelRunRequest` call; review then caught a polling-identity race. This PR fixes all three, with live verification that the tables actually materialize.

## The problems, in the order they surfaced

**1. Output field (fixed in #379).** Payload became `CreateRunGroupPayload`; `run` → `runGroup`. This *masked* the next error (GraphQL validates the selection set before coercing variables).

**2. Input shape.** `CreateStaticModelRunRequestInput` now requires `(datasetId, staticModelId)` — one model per request — and no longer accepts `selectedModels`. Fixed by requesting one run per populated model.

**3. Concurrency race.** Firing per-model requests without awaiting them lets the async loads collide on the destination — a transient `dlt DatabaseTransientException: TrinoQueryError(..., "Failed to query OPA backend")` at `step=load` that fails a **nondeterministic** subset (two live runs failed a different **5** and **9** of 21). Fixed by serializing: request one model, await its run to terminal, then the next.

**4. Polling identity (review fix).** The serialized loop first polled the model's *latest run* (`staticModels{ runs(first:1) }`) — unbound from the run just requested. An earlier successful run could satisfy the poll before the new run was visible, letting the publisher advance early (recreating the concurrency) and the new run fail while the workflow returned zero. **Fixed by binding to the exact run group:** the API exposes a top-level `runGroups(where:{id:{eq}})` with a terminal `RunGroupStatus`, so `poll_run_group` polls the id `createStaticModelRunRequest` returned — never a model's latest run. The loop **fails fast** on the first non-SUCCESS group.

Polling is also what makes the publish honest — an accepted request is not a finished run. Before this, a **workflow-green publish left half the tables FAILED**. The publisher now polls each group to terminal and **exits non-zero**, so the job's green/red reflects whether the tables materialized.

## Live verification (workflow_dispatch on this branch)

| Run | Behavior | Result |
|---|---|---|
| batch input | rejected | `HTTP 400` invalid `$input` |
| per-model, concurrent | requests accepted | **16/21** then **11/21** SUCCESS (nondeterministic) |
| per-model, serialized (latest-run poll) | request + poll | 21/21, but poll was identity-unsafe |
| **per-model, serialized (run-group-bound poll)** | request + poll the exact group | **21/21 SUCCESS**, workflow exited green |

Confirmed against OSO directly: all 21 registry models' latest run is `SUCCESS`.

## Changes

- `build/publish_registry.py`: per-model `{datasetId, staticModelId}` requests; `Q_RUN_GROUP` + `run_group_status` + `poll_run_group` (`GROUP_TERMINAL`/`GROUP_SUCCESS`) bound to the returned run-group id; fail-fast on the first non-SUCCESS.
- `tests/test_publish_registry.py`: polls the exact returned group id and waits `RUNNING→SUCCESS` (an earlier SUCCESS can't satisfy it); the next request only after the prior group succeeds; a FAILED group fails fast → nonzero; a timed-out group is not-SUCCESS; request input is `{datasetId, staticModelId}` with no `selectedModels`.

Full suite green (**1058 passed**), incl. 16 `test_publish_registry.py` cases.

## Note

`build/publish_evaluation.py` carries the same output+input drift and needs the identical run-group-bound helper; tracked in #380 as its own change.

## Checklist

- [x] `uv run python -m build.validate` prints `0 error(s)`
- [x] Full suite green (1058)
- [x] Polling bound to the exact run group returned; never a model's latest run
- [x] Fail-fast on the first non-SUCCESS; timeout treated as not-SUCCESS
- [x] Verified end-to-end: serialized run-group-bound publish materialized all 21 registry models (workflow green)
- [ ] N/A: no product/score/roster changes (publish CLI + its test only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)