### PR TITLE
Evaluation publish: reconcile run-group polling after the runGroup payload change (closes #380)

### DIFF
--- a/build/publish_evaluation.py
+++ b/build/publish_evaluation.py
@@ -4,7 +4,8 @@ The maintainer half of the evaluation release path. `build/serialize_evaluation.
 CSVs (`product_adoption_measurements`, `adoption_reconciliation`) from one atomic read of
 `observations.product_adoption_current`; this validates and uploads them as `currentai.evaluation.*`
 static models. It reuses the exact GraphQL mechanics of `build/publish_registry.py` — the `graphql`
-helper, `resolve_static_models`, `upload`, `data_rows` — so the two publishers cannot drift.
+helper, `resolve_static_models`, `upload`, `data_rows`, and the run-group-bound `poll_run_group` —
+so the two publishers cannot drift.
 
 ## Validation before any mutation
 
@@ -62,12 +63,14 @@ from pathlib import Path
 from build.adoption_measurements import COLUMNS as MEASUREMENTS_COLUMNS
 from build.adoption_reconciliation import COLUMNS as RECONCILIATION_COLUMNS
 from build.publish_registry import (
+    GROUP_SUCCESS,
     M_DATASET,
     M_RUN,
     M_URL,
     Q_DATASETS,
     data_rows,
     graphql,
+    poll_run_group,
     resolve_static_models,
     upload,
 )
@@ -234,35 +237,10 @@ def latest_archive(out_dir: Path) -> Path | None:
 
 
 # A run request is only ACCEPTED synchronously; materialization happens asynchronously, so the
-# archive is gated on the run reaching terminal SUCCESS and the deployed data matching, not on the
-# request being accepted. `runs(where:{id})` is the same read snapshot_source_runs.py uses.
-Q_RUN = """query($where: JSON){ runs(where:$where){ edges{ node{ id status } } } }"""
-RUN_SUCCESS = "SUCCESS"
-RUN_TERMINAL = frozenset({"SUCCESS", "FAILED", "CANCELED", "CANCELLED", "ERROR", "TIMEOUT", "ABORTED"})
-
-
-def run_status(run_id: str, token: str) -> str | None:
-    """The current status of a run, or None if the platform does not know the id yet."""
-    edges = graphql(Q_RUN, {"where": {"id": {"eq": run_id}}}, token)["runs"]["edges"]
-    return edges[0]["node"]["status"] if edges else None
-
-
-def poll_run(run_id: str, token: str, timeout: float = 1800.0, interval: float = 15.0) -> str:
-    """Block until the run reaches a terminal state or the timeout elapses; return the last status.
-
-    A non-terminal status at timeout is returned as-is (e.g. RUNNING/QUEUED), which the caller
-    treats as not-SUCCESS — so a queued or hung run never certifies a deployment.
-    """
-    import time
-
-    deadline = time.time() + timeout
-    status = run_status(run_id, token)
-    while status not in RUN_TERMINAL:
-        if time.time() >= deadline:
-            return status or "UNKNOWN"
-        time.sleep(interval)
-        status = run_status(run_id, token)
-    return status
+# archive is gated on the run group reaching terminal SUCCESS and the deployed data matching, not on
+# the request being accepted. Polling is `build/publish_registry.py`'s run-group-bound
+# `poll_run_group` (imported above), shared so the two publishers cannot drift: it polls the exact
+# run group `createStaticModelRunRequest` returns, never a model's "latest run".
 
 
 def deployed_table_state(dataset: str, table: str, timeout: float = 300.0,
@@ -294,12 +272,15 @@ def deployed_table_state(dataset: str, table: str, timeout: float = 300.0,
     return {"rows": len(rows), "columns": sorted(columns)}
 
 
-def runs_all_succeeded(statuses: dict[str, tuple[str, str]]) -> list[str]:
-    """Problems if any run did not reach terminal SUCCESS. `statuses` is table -> (run_id, status)."""
+def run_groups_all_succeeded(statuses: dict[str, tuple[str, str]]) -> list[str]:
+    """Problems if any run group did not reach terminal SUCCESS.
+
+    `statuses` is table -> (run_group_id, status).
+    """
     return [
-        f"{table}: run {run_id} ended {status!r}, not SUCCESS"
-        for table, (run_id, status) in statuses.items()
-        if status != RUN_SUCCESS
+        f"{table}: run group {run_group_id} ended {status!r}, not SUCCESS"
+        for table, (run_group_id, status) in statuses.items()
+        if status != GROUP_SUCCESS
     ]
 
 
@@ -425,37 +406,31 @@ def main() -> int:
         upload(path, url)
         print(f"  uploaded {table}.csv ({path.stat().st_size:,} bytes, {receipt[table]['rows']:,} rows)")
 
-    # ONE RUN REQUEST PER MODEL, awaited in turn. The request is addressed to a dataset with an
-    # explicit model selection (`datasetId` + `selectedModels`) — there is no per-static-model
-    # input, so a `{staticModelId}` payload is rejected outright and nothing materializes. But a
-    # request naming N models FANS OUT INTO N RUNS and returns only ONE of them, which breaks this
-    # publisher's contract in two ways at once, both observed on the first publish (2026-08-25):
-    #
-    #   * The returned run cannot certify its siblings. Polling it reported SUCCESS while the
-    #     sibling run loading the other table had already FAILED — exactly the half-loaded
-    #     deployment the wait exists to prevent.
-    #   * The sibling runs start concurrently and RACE to create the dataset's Trino schema, which
-    #     no run has created yet on a first publish. One wins; the other dies with
-    #     "Key 'org_<org>__<dataset>' already exists". Selecting both models is therefore not
-    #     merely unverifiable, it is the cause of the failure.
-    #
-    # Serializing costs a few seconds on two small tables and buys a pollable run id per table and
-    # a schema created exactly once. Fail fast: a table that does not load stops the deploy rather
-    # than uploading over a table whose sibling is already broken.
+    # ONE RUN REQUEST PER MODEL, awaited in turn — the same discipline `build/publish_registry.py`
+    # uses, down to its shared run-group-bound `poll_run_group`. `CreateStaticModelRunRequestInput`
+    # takes (datasetId, staticModelId), one model per request; a request naming N models would fan
+    # out into N runs and return only one run group, which cannot certify its siblings, and the
+    # sibling loads would RACE to create the dataset's Trino schema. Both were observed on the first
+    # publish (2026-08-25). Serialize, and poll the EXACT run group this request returned — never a
+    # model's "latest run", which could be an earlier unrelated success that would pass the poll
+    # before this run has even appeared. The 1800s budget keeps the more generous patience this
+    # maintainer deploy has always allowed while sharing the one helper. Fail fast: the first model
+    # that does not reach SUCCESS stops the deploy rather than uploading over a table whose sibling
+    # is already broken.
     statuses: dict[str, tuple[str, str]] = {}
     for table in EVAL_TABLES:
-        run = graphql(
+        run_group = graphql(
             M_RUN,
-            {"input": {"datasetId": dataset_id, "selectedModels": [models[table][0]]}},
+            {"input": {"datasetId": dataset_id, "staticModelId": models[table][0]}},
             token,
-        )["createStaticModelRunRequest"]["run"]
-        # A run request is only ACCEPTED here; wait for THIS table's run to reach a terminal state.
-        status = poll_run(run["id"], token)
-        statuses[table] = (run["id"], status)
-        print(f"  {table}: run {run['id']} finished {status}")
-        if status != RUN_SUCCESS:
+        )["createStaticModelRunRequest"]["runGroup"]
+        # A run request is only ACCEPTED here; wait for THIS run group to reach a terminal state.
+        status = poll_run_group(run_group["id"], token, timeout=1800.0)
+        statuses[table] = (run_group["id"], status)
+        print(f"  {table}: run group {run_group['id']} finished {status}")
+        if status != GROUP_SUCCESS:
             break
-    problems = runs_all_succeeded(statuses)
+    problems = run_groups_all_succeeded(statuses)
     if problems:
         print("deployment did not succeed — not archiving:", file=sys.stderr)
         for problem in problems:

--- a/docs/operations/deploy-evaluation.md
+++ b/docs/operations/deploy-evaluation.md
@@ -89,9 +89,13 @@ uv run python -m build.publish_evaluation              # validate, upload, run, 
 
 `--plan` and `--dry-run` write nothing. A real publish resolves (or creates) the `evaluation`
 dataset and each static model, `PUT`s the CSV, and requests the load run — which is only *accepted*
-synchronously. Runs are requested **one model at a time and awaited in turn** — a request naming
-both models fans out into two runs, returns only one of them, and the two race to create the
-dataset's Trino schema on a first publish. It **waits for each load run to reach terminal
+synchronously. The run request is **per static model** (`createStaticModelRunRequest` takes
+`datasetId` + `staticModelId`, one model per request); runs are requested **one model at a time and
+awaited in turn**, because starting both loads at once would race them to create the dataset's Trino
+schema on a first publish. Each request returns a **run group**, and the publisher polls that
+group's exact id to a terminal state — never a model's "latest run", which could be an earlier,
+unrelated success. It reuses `build/publish_registry.py`'s run-group-bound `poll_run_group` so the
+two publishers cannot drift. It **waits for each load run group to reach terminal
 `SUCCESS`** and **verifies the deployed row counts and column schema match the candidate** (read
 back via `pyoso`, retrying while the query catalog catches up, and ignoring the loader's own
 `_dlt_*` columns). A candidate column that is null in every row may be absent from the deployed

--- a/tests/test_publish_evaluation.py
+++ b/tests/test_publish_evaluation.py
@@ -141,15 +141,15 @@ def test_missing_csv_is_a_loud_failure(tmp_path, monkeypatch):
 # --- the archive is gated on terminal SUCCESS and verified deployed data ---------
 
 
-def test_runs_all_succeeded_requires_terminal_success():
-    ok = {"product_adoption_measurements": ("r1", "SUCCESS"),
-          "adoption_reconciliation": ("r2", "SUCCESS")}
-    assert P.runs_all_succeeded(ok) == []
-    # A queued/running/failed run is not success — each is a problem, so no archive.
+def test_run_groups_all_succeeded_requires_terminal_success():
+    ok = {"product_adoption_measurements": ("g1", "SUCCESS"),
+          "adoption_reconciliation": ("g2", "SUCCESS")}
+    assert P.run_groups_all_succeeded(ok) == []
+    # A queued/running/failed run group is not success — each is a problem, so no archive.
     for bad in ("RUNNING", "QUEUED", "FAILED", "UNKNOWN", "TIMEOUT"):
-        statuses = {"product_adoption_measurements": ("r1", "SUCCESS"),
-                    "adoption_reconciliation": ("r2", bad)}
-        assert P.runs_all_succeeded(statuses), f"{bad} must be treated as not-succeeded"
+        statuses = {"product_adoption_measurements": ("g1", "SUCCESS"),
+                    "adoption_reconciliation": ("g2", bad)}
+        assert P.run_groups_all_succeeded(statuses), f"{bad} must be treated as not-succeeded"
 
 
 def test_deployment_mismatches_catches_row_and_schema_drift():
@@ -164,11 +164,50 @@ def test_deployment_mismatches_catches_row_and_schema_drift():
     assert any("columns" in m for m in P.deployment_mismatches(expected, wrong_cols))
 
 
-def test_poll_run_returns_last_status_at_timeout(monkeypatch):
-    """A run that never reaches a terminal state returns its last (non-SUCCESS) status, so the
-    caller does not archive a queued run."""
-    monkeypatch.setattr(P, "run_status", lambda run_id, token: "RUNNING")
-    assert P.poll_run("r1", "tok", timeout=0.0, interval=0.0) == "RUNNING"
+def test_the_publisher_polls_the_exact_run_group_the_mutation_returned(tmp_path, monkeypatch):
+    """The reconciled polling (#380) is bound to the run group `createStaticModelRunRequest`
+    returns — never a model's latest run — so an earlier unrelated success can't satisfy the wait.
+
+    Pinned by capturing the id handed to `poll_run_group` and asserting it is the group id the
+    mutation returned for that model, in order.
+    """
+    _valid_candidates(tmp_path)
+    polled: list[str] = []
+
+    def fake_graphql(query, variables, token):
+        if query is P.Q_DATASETS:
+            return {"datasets": {"edges": [{"node": {"id": "ds-eval", "name": "evaluation",
+                                                     "type": "STATIC_MODEL"}}]}}
+        if query is PR.Q_STATIC:
+            return {"staticModels": {"edges": [
+                {"node": {"id": f"id-{t}", "name": t, "materializations": {"totalCount": 1}}}
+                for t in P.EVAL_TABLES
+            ]}}
+        if query is P.M_URL:
+            return {"createStaticModelUploadUrl": "https://upload.example/put"}
+        if query is P.M_RUN:
+            model = variables["input"]["staticModelId"]
+            return {"createStaticModelRunRequest":
+                    {"runGroup": {"id": f"grp-for-{model}", "status": "QUEUED"}}}
+        raise AssertionError(f"unexpected query: {query[:60]}")
+
+    def record_poll(group_id, token, timeout=1800.0):
+        polled.append(group_id)
+        return "SUCCESS"
+
+    monkeypatch.setattr(P, "graphql", fake_graphql)
+    monkeypatch.setattr(PR, "graphql", fake_graphql)
+    monkeypatch.setattr(P, "upload", lambda path, url: None)
+    monkeypatch.setattr(P, "poll_run_group", record_poll)
+    monkeypatch.setattr(P, "deployed_table_state",
+                        lambda dataset, table: {"rows": 0, "columns": []})
+    monkeypatch.setattr(P, "deployment_mismatches", lambda expected, deployed: ["stop here"])
+    monkeypatch.setenv("OSO_API_KEY", "tok")
+    monkeypatch.setenv("OSO_ORG_ID", "org")
+    monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--dir", str(tmp_path)])
+
+    assert P.main() == 2  # stopped at the injected mismatch, after polling every group
+    assert polled == [f"grp-for-id-{t}" for t in P.EVAL_TABLES]
 
 
 # --- the immutable deployment archive --------------------------------------------
@@ -194,13 +233,11 @@ def test_deployment_archive_is_immutable(tmp_path):
 def test_load_run_is_requested_once_per_model_and_awaited(tmp_path, monkeypatch):
     """Each table gets its OWN run request, naming exactly one model, and is awaited in turn.
 
-    Two things were wrong on the first publish (2026-08-25) and both are pinned here:
-
-      * `{staticModelId: ...}` is not a valid input — the API requires `datasetId`, so the upload
-        landed and nothing ever materialized.
-      * A single request naming BOTH models fans out into two runs and returns only one of them.
-        The returned run reported SUCCESS while its sibling FAILED (the two raced to create the
-        dataset's Trino schema), so the wait certified a half-loaded deployment.
+    The input is per static model — `CreateStaticModelRunRequestInput` takes
+    `(datasetId, staticModelId)`, not a `selectedModels` list (the API drift #380/#381 corrected).
+    A single request naming BOTH models would fan out into two runs and return one run group, which
+    cannot certify its siblings; the two would also race to create the dataset's Trino schema. One
+    request per model, awaited to its own run group's terminal state, is what this pins.
     """
     _valid_candidates(tmp_path)
     requested: list[dict] = []
@@ -219,13 +256,13 @@ def test_load_run_is_requested_once_per_model_and_awaited(tmp_path, monkeypatch)
         if query is P.M_RUN:
             requested.append(variables["input"])
             return {"createStaticModelRunRequest":
-                    {"run": {"id": f"run-{len(requested)}", "status": "QUEUED"}}}
+                    {"runGroup": {"id": f"group-{len(requested)}", "status": "QUEUED"}}}
         raise AssertionError(f"unexpected query: {query[:60]}")
 
     monkeypatch.setattr(P, "graphql", fake_graphql)
     monkeypatch.setattr(PR, "graphql", fake_graphql)
     monkeypatch.setattr(P, "upload", lambda path, url: None)
-    monkeypatch.setattr(P, "poll_run", lambda run_id, token: "SUCCESS")
+    monkeypatch.setattr(P, "poll_run_group", lambda group_id, token, timeout=1800.0: "SUCCESS")
     monkeypatch.setattr(P, "deployed_table_state",
                         lambda dataset, table: {"rows": 0, "columns": []})
     # Stop before the archive: this test is about the request shape, not the receipt.
@@ -239,9 +276,8 @@ def test_load_run_is_requested_once_per_model_and_awaited(tmp_path, monkeypatch)
     assert len(requested) == len(P.EVAL_TABLES), "one run request per model"
     for payload in requested:
         assert payload["datasetId"] == "ds-eval"
-        assert "staticModelId" not in payload
-        assert len(payload["selectedModels"]) == 1, "never select two models in one request"
-    assert [pl["selectedModels"][0] for pl in requested] == [f"id-{t}" for t in P.EVAL_TABLES]
+        assert "selectedModels" not in payload, "the batch selectedModels payload is gone"
+    assert [pl["staticModelId"] for pl in requested] == [f"id-{t}" for t in P.EVAL_TABLES]
 
 
 def test_a_failed_run_stops_the_deploy_before_the_next_model(tmp_path, monkeypatch):
@@ -262,7 +298,7 @@ def test_a_failed_run_stops_the_deploy_before_the_next_model(tmp_path, monkeypat
             return {"createStaticModelUploadUrl": "https://upload.example/put"}
         if query is P.M_RUN:
             requested.append(variables["input"])
-            return {"createStaticModelRunRequest": {"run": {"id": "run-1", "status": "QUEUED"}}}
+            return {"createStaticModelRunRequest": {"runGroup": {"id": "group-1", "status": "QUEUED"}}}
         raise AssertionError(f"unexpected query: {query[:60]}")
 
     def boom(dataset, table):
@@ -271,7 +307,7 @@ def test_a_failed_run_stops_the_deploy_before_the_next_model(tmp_path, monkeypat
     monkeypatch.setattr(P, "graphql", fake_graphql)
     monkeypatch.setattr(PR, "graphql", fake_graphql)
     monkeypatch.setattr(P, "upload", lambda path, url: None)
-    monkeypatch.setattr(P, "poll_run", lambda run_id, token: "FAILED")
+    monkeypatch.setattr(P, "poll_run_group", lambda group_id, token, timeout=1800.0: "FAILED")
     monkeypatch.setattr(P, "deployed_table_state", boom)
     monkeypatch.setenv("OSO_API_KEY", "tok")
     monkeypatch.setenv("OSO_ORG_ID", "org")


### PR DESCRIPTION
## What

Reconciles `build/publish_evaluation.py` against the OSO API drift that #379/#381 fixed for the registry publisher. The evaluation publisher still read `["createStaticModelRunRequest"]["run"]` and requested `{datasetId, selectedModels}` — both dropped by the API. After the shared `M_RUN` query began selecting `runGroup`, the **next real evaluation publish would have created the run group on the platform and then died locally with a `KeyError` before polling it** (the awkward partial-execution failure #380 called out: the platform work happens, the CLI observes nothing).

Fix — poll a **run group**, not a run, **reusing** the registry publisher's run-group-bound helper rather than duplicating polling semantics:

- request one run per model with `{datasetId, staticModelId}`; read `runGroup`;
- poll the **exact** run group `createStaticModelRunRequest` returned via the shared `poll_run_group` — never a model's "latest run", which could be an earlier, unrelated success that passes the poll before this run has appeared — with the `1800s` budget this maintainer deploy has always allowed;
- rename bookkeeping to `run_groups_all_succeeded`; drop the now-duplicate `Q_RUN`/`run_status`/`poll_run`.

## Guarantees preserved

Per-model serialization (starting both loads at once would race them to create the dataset's Trino schema); `--plan`/`--dry-run` write nothing and make no mutation; fail-fast on the first non-`SUCCESS` group; deployed row-count/column-schema verification read back via `pyoso`; and the **immutable deployment archive written only after every run group reaches `SUCCESS`**.

## Tests

`tests/test_publish_evaluation.py` updated to the `runGroup` payload; the request-shape test now pins `{datasetId, staticModelId}` with no `selectedModels`; a new test captures the id handed to `poll_run_group` and asserts it is exactly the group the mutation returned, in order; the fail-fast and terminal-`SUCCESS` tests carry over to run groups. `docs/operations/deploy-evaluation.md` updated to the run-group-bound mechanism.

Full suite green (**1058 passed**); 21 `test_publish_evaluation.py` cases.

## Note

Live end-to-end confirmation is a maintainer evaluation deploy (`workflow_dispatch` / explicit deploy), not run on every push — so unlike the registry publish there is no automatic 21/21 on merge. The registry side of the identical helper was verified live at 21/21 SUCCESS in #381.

## Checklist

- [x] `uv run python -m build.validate` prints `0 error(s)`
- [ ] N/A: no new/changed scores (publish CLI + its test + runbook only)
- [x] I did not edit `build/notebook_data.json` or `notebooks/ai-stack-map.py`
- [ ] N/A: no product/roster changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5bY5TtNtdqoxaeJBdNmXv)_