### PR TITLE
Dedicated scoring-trace publisher (Phase 6 deploy prerequisite)

### DIFF
--- a/build/publish_scoring_trace.py
+++ b/build/publish_scoring_trace.py
@@ -23,6 +23,15 @@ scored row means the repository-owned evaluator computed the same score `check_r
 scored row with `reproduces_recorded` anything but `True` is a `check_rubric` disagreement, and this
 publisher REFUSES to upload it — a disagreement is resolved in the evaluator, never deployed around.
 
+## Canonical equivalence is the authority
+
+The structural checks above prove a candidate is internally consistent; they cannot prove it is the
+COMPLETE, AUTHENTIC trace. So before any mutation the publisher re-runs the builder in memory
+(`build.axis_scoring_trace.resolve()`) and requires the candidate to be byte-for-byte that output —
+every product, fact, and rule-walk row, the current `declaration_version_id` and `source_git_sha`,
+and every result disposition. A truncated subset or a fabricated/stale identity is rejected here,
+and there is no second evaluation that could drift from the builder.
+
 ## No writes before the dry-run returns; rollback is by BYTES
 
 Like the evaluation publisher: `--plan` (offline) and `--dry-run` (read-only id resolution) validate
@@ -123,11 +132,13 @@ def _read_rows(path: Path) -> tuple[list[str], list[dict]]:
         return list(reader.fieldnames or []), list(reader)
 
 
-def validate_candidates(out_dir: Path = OUT_DIR) -> list[str]:
-    """Every check that must pass before a byte is uploaded. Returns a list of problems (empty = ok).
+def structural_problems(out_dir: Path = OUT_DIR) -> list[str]:
+    """The cheap, well-messaged structural checks. Returns a list of problems (empty = ok).
 
-    Run in --plan and --dry-run as well as a real publish: a candidate that fails here is never
-    published, and the failure is the same whether or not credentials are present.
+    These are NOT the authority — canonical equivalence (below) is — but they run first because a
+    header, empty-table, identity, grain, dual-run, or orphan failure is far more legible reported
+    on its own than as a wall of canonical-row diffs. A candidate that passes these is still only
+    published if it is byte-for-byte the trace this repository's builder produces.
     """
     errors: list[str] = []
     parsed: dict[str, tuple[list[str], list[dict]]] = {}
@@ -191,6 +202,76 @@ def validate_candidates(out_dir: Path = OUT_DIR) -> list[str]:
     return errors
 
 
+def canonical_equivalence_problems(
+    out_dir: Path = OUT_DIR, root: Path = ROOT, allow_dirty: bool = False
+) -> list[str]:
+    """The authority: the candidate must be EXACTLY the trace this repository's builder produces.
+
+    Structural checks prove a candidate is internally consistent; they cannot prove it is complete
+    or authentic. A truncated-but-consistent subset (one product, one fact, one rule, one result)
+    passes them, and any constant `declaration_version_id` / `source_git_sha` passes them — nothing
+    ties the bytes to *this* repository at *this* commit.
+
+    So, before any mutation, re-run the canonical builder in memory and compare. The expected rows
+    are written through the very `write_tables` the candidate was written with and read back with
+    the same reader, so the comparison is over identical serialization — then each table is an
+    order-independent multiset of `canonical_row` strings. Equality proves, in one gate: the exact
+    complete population (no omitted product, fact, or rule; no invented row), every value and result
+    disposition and `reproduces_recorded` flag, and the current declaration identity + source commit
+    (both are columns on every row, so a fabricated or stale id mismatches every row). There is no
+    second evaluation here — the authority is the builder itself.
+    """
+    import collections
+    import tempfile
+
+    from build.axis_scoring_trace import canonical_row, resolve
+    from build.axis_scoring_trace import TABLES as TRACE_SPEC_LOCAL
+    from build.serialize_registry import write_tables
+
+    try:
+        expected = resolve(root, allow_dirty=allow_dirty)
+    except Exception as exc:  # DirtyWorktreeError, a recipe error, or a contract breach
+        return [f"cannot rebuild the canonical trace to compare against (publish from a clean commit): {exc}"]
+
+    problems: list[str] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        expected_dir = Path(tmp)
+        write_tables(expected, expected_dir, TRACE_SPEC_LOCAL)
+        for table in TRACE_TABLES:
+            _eh, expected_rows = _read_rows(expected_dir / f"{table}.csv")
+            _ch, candidate_rows = _read_rows(out_dir / f"{table}.csv")
+            expected_canon = collections.Counter(canonical_row(table, r) for r in expected_rows)
+            candidate_canon = collections.Counter(canonical_row(table, r) for r in candidate_rows)
+            if candidate_canon == expected_canon:
+                continue
+            omitted = expected_canon - candidate_canon
+            invented = candidate_canon - expected_canon
+            detail = []
+            if omitted:
+                detail.append(f"{sum(omitted.values())} row(s) the builder produced are missing "
+                              f"(e.g. {next(iter(omitted))[:160]}…)")
+            if invented:
+                detail.append(f"{sum(invented.values())} row(s) the builder did not produce are present "
+                              f"(e.g. {next(iter(invented))[:160]}…)")
+            problems.append(
+                f"{table} is not the canonical trace this repository produces: " + "; ".join(detail)
+            )
+    return problems
+
+
+def validate_candidates(out_dir: Path = OUT_DIR, root: Path = ROOT, allow_dirty: bool = False) -> list[str]:
+    """Every check that must pass before a byte is uploaded (empty = ok).
+
+    Structural checks first, for legible messages; then canonical equivalence, the final authority.
+    Run in --plan and --dry-run as well as a real publish — a candidate that fails here is never
+    published, and the failure is the same whether or not credentials are present.
+    """
+    problems = structural_problems(out_dir)
+    if problems:
+        return problems
+    return canonical_equivalence_problems(out_dir, root, allow_dirty)
+
+
 def deployment_id(out_dir: Path = OUT_DIR) -> str:
     """A stable, immutable id for the candidate: the declaration identity it carries.
 
@@ -208,6 +289,14 @@ def archive_deployment(out_dir: Path, receipt: dict) -> Path:
     """Copy the just-deployed CSVs + completed receipt into an immutable per-deployment directory.
 
     Refuses to overwrite an existing archive: a deployment id is written exactly once.
+
+    KNOWN LIMITATION (non-blocking; shared with build/publish_evaluation.py, follow-up before the
+    rollback workflow is relied on): the archive root is derived from `out_dir`, so re-publishing a
+    prior archive's bytes with `--dir <that-archive>` would nest a new archive *inside* it and would
+    not update the canonical `build/evaluation/scoring-trace-deployments/` root's notion of what is
+    live. Deployment identity (the declaration) and deployment occurrence (a publish event) are
+    conflated. First deploys are unaffected; a rollback-from-archive flow needs the archive root
+    decoupled from the read `--dir` first.
     """
     target = deployments_dir(out_dir) / deployment_id(out_dir)
     if target.exists():

--- a/build/publish_scoring_trace.py
+++ b/build/publish_scoring_trace.py
@@ -1,0 +1,372 @@
+"""Publish the three repository-owned scoring-trace CSVs to OSO as static models.
+
+The maintainer half of the Phase-6 scoring-trace deploy (`docs/operations/deploy-scoring-trace.md`).
+`build/axis_scoring_trace.py --out build/evaluation` writes the three CSVs — `axis_facts`,
+`axis_rule_matches`, `axis_results` — by replaying the openness ladder once per product from the
+working tree; this validates and uploads them as `currentai.evaluation.*` static models. It reuses
+the exact GraphQL mechanics of `build/publish_registry.py` — the `graphql` helper,
+`resolve_static_models`, `upload`, `data_rows`, and the run-group-bound `poll_run_group` — and the
+generic read-back/immutable-archive machinery of `build/publish_evaluation.py`, so the evaluation
+and trace publishers cannot drift.
+
+## Identity: the declaration alone (§4.4)
+
+The three tables key on `declaration_version_id` and carry NO `release_id` and NO
+`observation_snapshot_id` — a deterministic evaluation of the declarations does not depend on any
+measurement. Validation pins that: `declaration_version_id` and `source_git_sha` are constant within
+each file and equal across all three, and each table is unique on its own grain.
+
+## The dual-run gate
+
+`axis_results.reproduces_recorded` is the ADR-001 dual-run agreement made queryable: `True` on every
+scored row means the repository-owned evaluator computed the same score `check_rubric` recorded. A
+scored row with `reproduces_recorded` anything but `True` is a `check_rubric` disagreement, and this
+publisher REFUSES to upload it — a disagreement is resolved in the evaluator, never deployed around.
+
+## No writes before the dry-run returns; rollback is by BYTES
+
+Like the evaluation publisher: `--plan` (offline) and `--dry-run` (read-only id resolution) validate
+and print the plan and perform NO mutation and NO local write. A real publish uploads, requests one
+run per model with `{datasetId, staticModelId}` and awaits each run group to terminal `SUCCESS`
+(polling the exact group the mutation returned), verifies the deployed row count and column schema
+via `pyoso`, and only then writes an immutable per-deployment archive of the exact bytes it uploaded
+— under `build/evaluation/scoring-trace-deployments/<deployment_id>/`, kept separate from the
+evaluation publisher's `deployments/` so neither reads the other's archives. It REFUSES to overwrite
+an existing archive.
+
+Environment:
+    OSO_API_KEY   required (except for --plan)
+    OSO_ORG_ID    required (except for --plan)
+    OSO_DATASET   optional, defaults to "evaluation"
+
+Usage:
+    uv run python -m build.axis_scoring_trace --out build/evaluation   # write the three CSVs first
+    uv run python -m build.publish_scoring_trace --plan       # offline: validate + plan, no creds, no network
+    uv run python -m build.publish_scoring_trace --dry-run    # read-only id resolution, no mutation, no write
+    uv run python -m build.publish_scoring_trace              # validate, publish, archive
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+from build.axis_scoring_trace import TABLES as TRACE_SPEC
+from build.publish_evaluation import (
+    csv_provenance,
+    deployed_table_state,
+    resolve_evaluation_dataset,
+    run_groups_all_succeeded,
+)
+from build.publish_registry import (
+    GROUP_SUCCESS,
+    M_RUN,
+    M_URL,
+    data_rows,
+    graphql,
+    poll_run_group,
+    resolve_static_models,
+    upload,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT_DIR = ROOT / "build" / "evaluation"
+DEFAULT_DATASET = "evaluation"
+
+# The three trace tables, in a stable publish order, and their exact expected headers.
+TRACE_TABLES: tuple[str, ...] = tuple(TRACE_SPEC)
+EXPECTED_HEADERS: dict[str, list[str]] = {name: list(cols) for name, cols in TRACE_SPEC.items()}
+
+# The declaration identity every row carries — constant within each file, equal across all three.
+_IDENTITY_COLUMNS = ("declaration_version_id", "source_git_sha")
+
+# The grain each table is unique on. All lead with the declaration + product/category/axis; the
+# finer tables add their own discriminator.
+_GRAIN: dict[str, tuple[str, ...]] = {
+    "axis_results": ("declaration_version_id", "product_slug", "category_slug", "axis"),
+    "axis_rule_matches": ("declaration_version_id", "product_slug", "category_slug", "axis", "rule_index"),
+    "axis_facts": (
+        "declaration_version_id", "product_slug", "category_slug", "axis",
+        "dimension", "part_index", "fact_kind",
+    ),
+}
+
+
+def deployments_dir(out_dir: Path) -> Path:
+    """Where completed, immutable trace-deployment archives live.
+
+    Deliberately NOT `deployments/` — that belongs to `build/publish_evaluation.py`, which shares
+    this `build/evaluation` directory. A separate subdirectory keeps each publisher's `latest_archive`
+    scan blind to the other's archives (a trace archive has no evaluation CSVs, and vice versa).
+    """
+    return out_dir / "scoring-trace-deployments"
+
+
+def build_receipt(out_dir: Path = OUT_DIR) -> dict:
+    """The provenance of every trace CSV present — the candidate description."""
+    return {
+        table: csv_provenance(out_dir / f"{table}.csv")
+        for table in TRACE_TABLES
+        if (out_dir / f"{table}.csv").exists()
+    }
+
+
+def _read_rows(path: Path) -> tuple[list[str], list[dict]]:
+    import csv
+
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        return list(reader.fieldnames or []), list(reader)
+
+
+def validate_candidates(out_dir: Path = OUT_DIR) -> list[str]:
+    """Every check that must pass before a byte is uploaded. Returns a list of problems (empty = ok).
+
+    Run in --plan and --dry-run as well as a real publish: a candidate that fails here is never
+    published, and the failure is the same whether or not credentials are present.
+    """
+    errors: list[str] = []
+    parsed: dict[str, tuple[list[str], list[dict]]] = {}
+    for table in TRACE_TABLES:
+        path = out_dir / f"{table}.csv"
+        if not path.exists():
+            errors.append(f"{table}.csv is missing")
+            continue
+        header, rows = _read_rows(path)
+        parsed[table] = (header, rows)
+        if header != EXPECTED_HEADERS[table]:
+            errors.append(
+                f"{table}.csv header does not match {table}.COLUMNS "
+                f"(got {header[:3]}… expected {EXPECTED_HEADERS[table][:3]}…)"
+            )
+        if not rows:
+            errors.append(f"{table}.csv is empty (a static model cannot materialize zero rows)")
+    # The cross-checks below index by the real column names, so they run only once every file is
+    # present with the exact expected header; a schema error is reported on its own.
+    if errors or len(parsed) != len(TRACE_TABLES):
+        return errors
+
+    # Identity columns constant within each file and equal across all three.
+    identities: dict[str, dict[str, set]] = {}
+    for table, (_header, rows) in parsed.items():
+        identities[table] = {col: {r.get(col) for r in rows} for col in _IDENTITY_COLUMNS}
+        for col in _IDENTITY_COLUMNS:
+            if len(identities[table][col]) != 1:
+                errors.append(f"{table}.csv has inconsistent {col}: {sorted(identities[table][col])[:3]}")
+    for col in _IDENTITY_COLUMNS:
+        values = {next(iter(identities[t][col])) for t in TRACE_TABLES if len(identities[t][col]) == 1}
+        if len(values) > 1:
+            errors.append(f"{col} differs across the three files: {sorted(values)}")
+
+    # Grain uniqueness per table.
+    for table, (_header, rows) in parsed.items():
+        keys = [tuple(r.get(c) for c in _GRAIN[table]) for r in rows]
+        if len(keys) != len(set(keys)):
+            errors.append(f"{table}.csv is not unique on its grain {_GRAIN[table]}")
+
+    # The dual-run gate: every SCORED result reproduces the recorded score. A false (or any
+    # non-"True") reproduces_recorded on a scored row is a check_rubric disagreement, never deployed.
+    disagreements = [
+        (r.get("product_slug"), r.get("category_slug"))
+        for r in parsed["axis_results"][1]
+        if r.get("status") == "scored" and r.get("reproduces_recorded") != "True"
+    ]
+    if disagreements:
+        errors.append(
+            f"axis_results has {len(disagreements)} scored row(s) that do not reproduce the recorded "
+            f"score (e.g. {disagreements[:3]}) — resolve the check_rubric disagreement, do not deploy it"
+        )
+
+    # Population coherence: every product/category traced in facts or rules has a result row.
+    result_products = {(r["product_slug"], r["category_slug"]) for r in parsed["axis_results"][1]}
+    for table in ("axis_facts", "axis_rule_matches"):
+        products = {(r["product_slug"], r["category_slug"]) for r in parsed[table][1]}
+        orphans = products - result_products
+        if orphans:
+            errors.append(f"{table} has product/category rows with no axis_results row: {sorted(orphans)[:3]}")
+    return errors
+
+
+def deployment_id(out_dir: Path = OUT_DIR) -> str:
+    """A stable, immutable id for the candidate: the declaration identity it carries.
+
+    The trace tables have no observation snapshot, so the id is the declaration version and the
+    commit it was cut at — two publishes of the same declaration share an id (and cannot both be
+    archived; a deployment is recorded once).
+    """
+    _header, rows = _read_rows(out_dir / "axis_results.csv")
+    dvid = rows[0]["declaration_version_id"]
+    sha = rows[0]["source_git_sha"]
+    return f"{dvid[:12]}-{sha[:12]}"
+
+
+def archive_deployment(out_dir: Path, receipt: dict) -> Path:
+    """Copy the just-deployed CSVs + completed receipt into an immutable per-deployment directory.
+
+    Refuses to overwrite an existing archive: a deployment id is written exactly once.
+    """
+    target = deployments_dir(out_dir) / deployment_id(out_dir)
+    if target.exists():
+        raise RuntimeError(
+            f"deployment archive {target} already exists — a deployment id is immutable and is "
+            f"never overwritten. If you are re-publishing identical bytes, the previous archive "
+            f"already records them; if not, the declaration identity would have changed."
+        )
+    target.mkdir(parents=True)
+    for table in TRACE_TABLES:
+        shutil.copy2(out_dir / f"{table}.csv", target / f"{table}.csv")
+    (target / "receipt.json").write_text(
+        json.dumps({"deployment_id": target.name, "tables": receipt}, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return target
+
+
+def latest_archive(out_dir: Path) -> Path | None:
+    """The most recently written trace-deployment archive, if any — the next deploy's rollback target."""
+    root = deployments_dir(out_dir)
+    if not root.exists():
+        return None
+    archives = [p for p in root.iterdir() if p.is_dir() and (p / "receipt.json").exists()]
+    return max(archives, key=lambda p: p.stat().st_mtime) if archives else None
+
+
+def deployment_mismatches(expected: dict, deployed: dict) -> list[str]:
+    """Problems if the deployed row count or column set does not match the validated candidate.
+
+    Row counts must match exactly. On columns, the deployed table must carry every candidate column
+    that holds a value somewhere, and NO column the candidate does not declare. The one permitted
+    absence is a candidate column that is null in every row: the loader types columns from records
+    and drops one it never sees a value for, so its absence is schema inference, not lost data.
+    """
+    problems: list[str] = []
+    for table in TRACE_TABLES:
+        exp, got = expected[table], deployed[table]
+        if got["rows"] != exp["rows"]:
+            problems.append(f"{table}: deployed {got['rows']} rows, candidate had {exp['rows']}")
+        permitted_absent = set(exp.get("all_null_columns") or ())
+        missing = set(exp["columns"]) - set(got["columns"]) - permitted_absent
+        extra = set(got["columns"]) - set(exp["columns"])
+        if missing:
+            problems.append(f"{table}: deployed table is missing candidate columns with data: {sorted(missing)}")
+        if extra:
+            problems.append(f"{table}: deployed table has undeclared columns: {sorted(extra)}")
+    return problems
+
+
+def print_plan(receipt: dict, dataset_name: str) -> None:
+    print(f"dataset {dataset_name} (currentai.{dataset_name}.*)")
+    for table in TRACE_TABLES:
+        entry = receipt.get(table)
+        if entry is None:
+            print(f"  MISSING {table}.csv — run build.axis_scoring_trace --out first")
+        else:
+            print(f"  {table}.csv  {entry['rows']:,} rows  sha256 {entry['sha256'][:12]}…")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan", action="store_true", help="validate + print the plan; no network, no creds, no write")
+    parser.add_argument("--dry-run", action="store_true", help="validate + resolve ids read-only; no mutation, no write")
+    parser.add_argument("--dir", type=Path, default=OUT_DIR)
+    args = parser.parse_args()
+
+    dataset_name = os.environ.get("OSO_DATASET", DEFAULT_DATASET)
+    missing = [t for t in TRACE_TABLES if not (args.dir / f"{t}.csv").exists()]
+    if missing:
+        print(f"missing CSVs: {missing}. Run `uv run python -m build.axis_scoring_trace --out {args.dir}` first.",
+              file=sys.stderr)
+        return 2
+
+    receipt = build_receipt(args.dir)
+    print_plan(receipt, dataset_name)
+
+    # Validate BEFORE any mutation — and in --plan / --dry-run too.
+    problems = validate_candidates(args.dir)
+    if problems:
+        print("candidate validation failed:", file=sys.stderr)
+        for problem in problems:
+            print(f"  ! {problem}", file=sys.stderr)
+        return 2
+
+    if args.plan:
+        return 0
+
+    token = os.environ.get("OSO_API_KEY")
+    org_id = os.environ.get("OSO_ORG_ID")
+    if not token or not org_id:
+        print("OSO_API_KEY and OSO_ORG_ID must both be set (use --plan for an offline plan)",
+              file=sys.stderr)
+        return 2
+
+    rollback_target = latest_archive(args.dir)
+    if rollback_target is not None:
+        print(f"rollback target if this deploy is bad: {rollback_target}")
+
+    dataset_id = resolve_evaluation_dataset(dataset_name, org_id, token, create=not args.dry_run)
+    if dataset_id is None:
+        print(f"would create dataset {dataset_name}, then create + upload {list(TRACE_TABLES)}")
+        return 0  # dry-run only reaches here; no write
+
+    models = resolve_static_models(dataset_id, org_id, token, TRACE_TABLES, create=not args.dry_run)
+    print(f"dataset {dataset_name} = {dataset_id}")
+
+    if args.dry_run:
+        for table in TRACE_TABLES:
+            model_id = models[table][0]
+            verb = "would upload" if model_id else "would create + upload"
+            print(f"  {verb} {table}.csv ({receipt[table]['rows']:,} rows) -> {model_id}")
+        return 0  # NO write on a dry run
+
+    for table in TRACE_TABLES:
+        path = args.dir / f"{table}.csv"
+        model_id = models[table][0]
+        url = graphql(M_URL, {"staticModelId": model_id}, token)["createStaticModelUploadUrl"]
+        upload(path, url)
+        print(f"  uploaded {table}.csv ({path.stat().st_size:,} bytes, {receipt[table]['rows']:,} rows)")
+
+    # ONE RUN REQUEST PER MODEL, awaited in turn — the same discipline the registry and evaluation
+    # publishers use, down to their shared run-group-bound `poll_run_group`.
+    # `CreateStaticModelRunRequestInput` takes (datasetId, staticModelId), one model per request; a
+    # request naming N models would fan out into N runs and return one run group, and the sibling
+    # loads would race to create the dataset's Trino schema. Serialize, poll the EXACT run group this
+    # request returned (never a model's "latest run"), and fail fast on the first non-SUCCESS group.
+    statuses: dict[str, tuple[str, str]] = {}
+    for table in TRACE_TABLES:
+        run_group = graphql(
+            M_RUN,
+            {"input": {"datasetId": dataset_id, "staticModelId": models[table][0]}},
+            token,
+        )["createStaticModelRunRequest"]["runGroup"]
+        status = poll_run_group(run_group["id"], token, timeout=1800.0)
+        statuses[table] = (run_group["id"], status)
+        print(f"  {table}: run group {run_group['id']} finished {status}")
+        if status != GROUP_SUCCESS:
+            break
+    problems = run_groups_all_succeeded(statuses)
+    if problems:
+        print("deployment did not succeed — not archiving:", file=sys.stderr)
+        for problem in problems:
+            print(f"  ! {problem}", file=sys.stderr)
+        return 2
+
+    deployed = {t: deployed_table_state(dataset_name, t) for t in TRACE_TABLES}
+    mismatches = deployment_mismatches(receipt, deployed)
+    if mismatches:
+        print("deployed data does not match the candidate — not archiving:", file=sys.stderr)
+        for mismatch in mismatches:
+            print(f"  ! {mismatch}", file=sys.stderr)
+        return 2
+
+    archive = archive_deployment(args.dir, receipt)
+    print(f"\nevery load run SUCCESS and deployed data verified; archived this deployment (immutable) at "
+          f"{archive} — the rollback target for the next deploy")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/operations/deploy-scoring-trace.md
+++ b/docs/operations/deploy-scoring-trace.md
@@ -47,15 +47,36 @@ before publishing, never something to deploy around.
 
 ## 3. Publish
 
-The three tables are static models in the `evaluation` dataset. They use the same publish mechanics
-as the Phase-3 evaluation tables (`resolve_dataset` → `resolve_static_models` → upload URL → `PUT`
-the CSV → `createStaticModelRunRequest`, requested **one model at a time and awaited in turn** so
-two runs never race to create the dataset's Trino schema, then wait for each run to reach terminal
-`SUCCESS` and read the deployed row count/schema back via `pyoso` before trusting it). They are
-**not** wired into any automatic table set, precisely because they are cut at a commit rather than
-on every merge; a maintainer publishes them explicitly. Wiring a dedicated publisher (mirroring
-`build/publish_evaluation.py`, with the same validate-before-mutation and SUCCESS-gated archive) is
-the natural follow-up once this deploy becomes routine.
+The three tables are static models in the `evaluation` dataset, published by the dedicated
+`build/publish_scoring_trace.py` — a mirror of `build/publish_evaluation.py` (same
+validate-before-mutation, the shared run-group-bound `poll_run_group`, deployed-schema read-back,
+and SUCCESS-gated immutable archive), so the two publishers cannot drift. They are **not** wired
+into any automatic table set, precisely because they are cut at a commit rather than on every merge;
+a maintainer publishes them explicitly.
+
+```bash
+uv run python -m build.publish_scoring_trace --plan       # validate + plan; offline, no creds, NO write
+uv run python -m build.publish_scoring_trace --dry-run    # validate + read-only id resolution; NO mutation, NO write
+uv run python -m build.publish_scoring_trace              # validate, upload, run, then archive
+```
+
+`--plan` and `--dry-run` write nothing. A real publish resolves the `evaluation` dataset and each
+static model, `PUT`s the CSV, and requests the load run **per static model** (`datasetId` +
+`staticModelId`, one model at a time and awaited in turn) so two runs never race to create the
+dataset's Trino schema. Each request returns a **run group**, whose exact id the publisher polls to
+terminal `SUCCESS` — never a model's "latest run". Before any upload it VALIDATES the candidates:
+exact headers against the builder's `COLUMNS`, non-empty tables, `declaration_version_id` /
+`source_git_sha` constant within each file and equal across all three, each table unique on its
+grain, and — the ADR-001 dual-run gate — **every scored `axis_results` row reproduces the recorded
+score** (a scored row that does not is a `check_rubric` disagreement, refused here, never deployed).
+It then reads the deployed row count/schema back via `pyoso` and, only when every run group reached
+`SUCCESS` and the deployed data matches, writes an **immutable deployment archive** at
+`build/evaluation/scoring-trace-deployments/<deployment_id>/` (the three CSVs plus a receipt of row
+counts, column schema, and SHA-256). The `deployment_id` is the declaration identity
+(`declaration_version_id` + `source_git_sha`); it is written once and never overwritten, and it
+lives in its own subdirectory so it is never confused with the evaluation publisher's `deployments/`.
+Any partial failure — a run group ending non-`SUCCESS` or timing out, or a deployed count/schema
+mismatch — returns nonzero and writes no archive.
 
 Record the `dataset_id`, each static-model id, and the `declaration_version_id` you published from
 in the deploy note.

--- a/tests/test_publish_scoring_trace.py
+++ b/tests/test_publish_scoring_trace.py
@@ -1,0 +1,324 @@
+"""The scoring-trace publisher's safety surface — validation, no-write dry runs, immutable archives.
+
+`build/publish_scoring_trace.py` uploads the three scoring-trace CSVs (`axis_facts`,
+`axis_rule_matches`, `axis_results`) to OSO. The network path is a maintainer step, but the guards
+that keep a bad or arbitrary CSV off the platform — the exact headers, the declaration-only identity,
+the per-table grain, the ADR-001 `reproduces_recorded` dual-run gate — the promise that
+`--plan`/`--dry-run` write nothing, and the immutable rollback archive (in its own subdirectory,
+never the evaluation publisher's) are pure and pinned here.
+"""
+
+import sys
+
+import build.publish_evaluation as PE
+import build.publish_registry as PR
+import build.publish_scoring_trace as P
+
+
+def _write_csv(path, header, rows):
+    lines = [",".join(header)] + [",".join(str(c) for c in r) for r in rows]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+# One tiny, internally-consistent trace: a single scored product reproducing its recorded score,
+# with a matching fact and rule-match row, all under one declaration identity.
+DVID = "d" * 64
+SHA = "f012d854eb87"
+
+
+def _valid_candidates(out_dir):
+    def row(table, **over):
+        base = {"declaration_version_id": DVID, "source_git_sha": SHA,
+                "product_slug": "p", "category_slug": "c", "product_type": "model", "axis": "openness"}
+        base.update(over)
+        return [base[c] if base.get(c) is not None else "" for c in P.EXPECTED_HEADERS[table]]
+
+    _write_csv(out_dir / "axis_facts.csv", P.EXPECTED_HEADERS["axis_facts"], [row(
+        "axis_facts", dimension="weights", part_index=0, fact_kind="dimension",
+        recorded_key="weights", recorded_value="open", normalized_value="open", in_declared_enum="True")])
+    _write_csv(out_dir / "axis_rule_matches.csv", P.EXPECTED_HEADERS["axis_rule_matches"], [row(
+        "axis_rule_matches", rule_index=0, rule_kind="when", outcome="fired", matched="True",
+        non_tier_matched="True", tests_license_tier="False", wanted_tier="", rule_conditions="weights=open",
+        result_score=4, result_class="open")])
+    _write_csv(out_dir / "axis_results.csv", P.EXPECTED_HEADERS["axis_results"], [row(
+        "axis_results", status="scored", result_score=4, result_class="open", matched_rule_index=0,
+        matched_rule_kind="when", has_license_tiers="False", license_tier="", raw_license="MIT",
+        recorded_score=4, recorded_class="open", reproduces_recorded="True", rule_count=1, deferral_reason="")])
+
+
+def test_trace_tables_are_the_three_outputs():
+    assert P.TRACE_TABLES == ("axis_facts", "axis_rule_matches", "axis_results")
+
+
+# --- validation before any mutation ----------------------------------------------
+
+
+def test_valid_candidates_pass_validation(tmp_path):
+    _valid_candidates(tmp_path)
+    assert P.validate_candidates(tmp_path) == []
+
+
+def test_arbitrary_headers_are_rejected(tmp_path):
+    for t in P.TRACE_TABLES:
+        _write_csv(tmp_path / f"{t}.csv", ["x", "y"], [[1, 2]])
+    problems = P.validate_candidates(tmp_path)
+    assert any("header does not match" in p for p in problems)
+
+
+def test_empty_table_is_rejected(tmp_path):
+    _valid_candidates(tmp_path)
+    header = (tmp_path / "axis_facts.csv").read_text().splitlines()[0]
+    (tmp_path / "axis_facts.csv").write_text(header + "\n", encoding="utf-8")
+    assert any("empty" in p for p in P.validate_candidates(tmp_path))
+
+
+def test_inconsistent_identity_within_a_file_is_rejected(tmp_path):
+    _valid_candidates(tmp_path)
+    # A second facts row under a different source_git_sha breaks within-file constancy.
+    path = tmp_path / "axis_facts.csv"
+    lines = path.read_text().splitlines()
+    row = lines[1].split(",")
+    row[1] = "deadbeefcafe"  # source_git_sha column
+    path.write_text("\n".join(lines + [",".join(row)]) + "\n", encoding="utf-8")
+    assert any("source_git_sha" in p for p in P.validate_candidates(tmp_path))
+
+
+def test_identity_differing_across_files_is_rejected(tmp_path):
+    _valid_candidates(tmp_path)
+    path = tmp_path / "axis_results.csv"
+    lines = path.read_text().splitlines()
+    row = lines[1].split(",")
+    row[0] = "e" * 64  # a different declaration_version_id than facts/rules carry
+    lines[1] = ",".join(row)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    assert any("declaration_version_id" in p for p in P.validate_candidates(tmp_path))
+
+
+def test_a_scored_row_that_does_not_reproduce_is_rejected(tmp_path):
+    """The ADR-001 dual-run gate: a scored result must reproduce the recorded score, or it is a
+    check_rubric disagreement that is resolved in the evaluator, never deployed."""
+    _valid_candidates(tmp_path)
+    path = tmp_path / "axis_results.csv"
+    header = P.EXPECTED_HEADERS["axis_results"]
+    lines = path.read_text().splitlines()
+    row = lines[1].split(",")
+    row[header.index("reproduces_recorded")] = "False"
+    lines[1] = ",".join(row)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    assert any("reproduce" in p for p in P.validate_candidates(tmp_path))
+
+
+def test_a_deferred_row_with_blank_reproduces_is_fine(tmp_path):
+    """Deferred results carry an empty reproduces_recorded and must NOT trip the dual-run gate."""
+    _valid_candidates(tmp_path)
+    path = tmp_path / "axis_results.csv"
+    header = P.EXPECTED_HEADERS["axis_results"]
+    lines = path.read_text().splitlines()
+    row = lines[1].split(",")
+    row[header.index("status")] = "deferred"
+    row[header.index("reproduces_recorded")] = ""
+    row[header.index("deferral_reason")] = "no_recipe"
+    lines[1] = ",".join(row)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    assert P.validate_candidates(tmp_path) == []
+
+
+def test_grain_uniqueness_is_enforced(tmp_path):
+    _valid_candidates(tmp_path)
+    path = tmp_path / "axis_results.csv"
+    lines = path.read_text().splitlines()
+    path.write_text("\n".join(lines + [lines[1]]) + "\n", encoding="utf-8")  # duplicate the one result
+    assert any("grain" in p for p in P.validate_candidates(tmp_path))
+
+
+def test_a_fact_with_no_result_row_is_rejected(tmp_path):
+    _valid_candidates(tmp_path)
+    path = tmp_path / "axis_facts.csv"
+    lines = path.read_text().splitlines()
+    row = lines[1].split(",")
+    row[2] = "orphan"  # product_slug not present in axis_results
+    path.write_text("\n".join(lines + [",".join(row)]) + "\n", encoding="utf-8")
+    assert any("no axis_results row" in p for p in P.validate_candidates(tmp_path))
+
+
+# --- --plan / --dry-run write nothing --------------------------------------------
+
+
+def test_plan_validates_offline_and_writes_nothing(tmp_path, monkeypatch):
+    _valid_candidates(tmp_path)
+
+    def _no_network(*a, **k):
+        raise AssertionError("--plan must not hit the network")
+
+    monkeypatch.setattr(P, "graphql", _no_network)
+    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--plan", "--dir", str(tmp_path)])
+    before = set(tmp_path.iterdir())
+    assert P.main() == 0
+    assert set(tmp_path.iterdir()) == before
+
+
+def test_dry_run_with_credentials_makes_no_mutation_and_no_write(tmp_path, monkeypatch):
+    _valid_candidates(tmp_path)
+    monkeypatch.setenv("OSO_API_KEY", "test-token")
+    monkeypatch.setenv("OSO_ORG_ID", "test-org")
+
+    def fake_graphql(query, variables, token):
+        if "datasets(" in query:
+            return {"datasets": {"edges": [{"node": {"id": "ds1", "name": "evaluation"}}]}}
+        if "staticModels(" in query:
+            return {"staticModels": {"edges": []}}
+        raise AssertionError(f"a dry run must issue no mutation, got: {query[:48]}")
+
+    monkeypatch.setattr(P, "graphql", fake_graphql)
+    monkeypatch.setattr(PR, "graphql", fake_graphql)
+    monkeypatch.setattr(PE, "graphql", fake_graphql)  # resolve_evaluation_dataset uses PE's graphql
+    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dry-run", "--dir", str(tmp_path)])
+    before = set(tmp_path.iterdir())
+    assert P.main() == 0
+    assert set(tmp_path.iterdir()) == before
+    assert not P.deployments_dir(tmp_path).exists()
+
+
+def test_publish_without_credentials_refuses(tmp_path, monkeypatch):
+    _valid_candidates(tmp_path)
+    monkeypatch.delenv("OSO_API_KEY", raising=False)
+    monkeypatch.delenv("OSO_ORG_ID", raising=False)
+
+    def _no_network(*a, **k):
+        raise AssertionError("must not hit the network without credentials")
+
+    monkeypatch.setattr(P, "graphql", _no_network)
+    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dry-run", "--dir", str(tmp_path)])
+    assert P.main() == 2
+
+
+def test_missing_csv_is_a_loud_failure(tmp_path, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--plan", "--dir", str(tmp_path)])
+    assert P.main() == 2
+
+
+# --- per-model run requests, exact-group polling, fail-fast ----------------------
+
+
+def _platform_graphql(requested):
+    def fake_graphql(query, variables, token):
+        if query is PE.Q_DATASETS or "datasets(" in query:
+            return {"datasets": {"edges": [{"node": {"id": "ds-eval", "name": "evaluation",
+                                                     "type": "STATIC_MODEL"}}]}}
+        if query is PR.Q_STATIC or "staticModels(" in query:
+            return {"staticModels": {"edges": [
+                {"node": {"id": f"id-{t}", "name": t, "materializations": {"totalCount": 1}}}
+                for t in P.TRACE_TABLES
+            ]}}
+        if query is P.M_URL:
+            return {"createStaticModelUploadUrl": "https://upload.example/put"}
+        if query is P.M_RUN:
+            requested.append(variables["input"])
+            return {"createStaticModelRunRequest":
+                    {"runGroup": {"id": f"grp-for-{variables['input']['staticModelId']}", "status": "QUEUED"}}}
+        raise AssertionError(f"unexpected query: {query[:60]}")
+    return fake_graphql
+
+
+def test_load_run_is_requested_once_per_model_with_static_model_id(tmp_path, monkeypatch):
+    _valid_candidates(tmp_path)
+    requested: list[dict] = []
+    fake = _platform_graphql(requested)
+    monkeypatch.setattr(P, "graphql", fake)
+    monkeypatch.setattr(PR, "graphql", fake)
+    monkeypatch.setattr(PE, "graphql", fake)
+    monkeypatch.setattr(P, "upload", lambda path, url: None)
+    monkeypatch.setattr(P, "poll_run_group", lambda gid, token, timeout=1800.0: "SUCCESS")
+    monkeypatch.setattr(P, "deployed_table_state", lambda dataset, table: {"rows": 0, "columns": []})
+    monkeypatch.setattr(P, "deployment_mismatches", lambda expected, deployed: ["stop here"])
+    monkeypatch.setenv("OSO_API_KEY", "tok")
+    monkeypatch.setenv("OSO_ORG_ID", "org")
+    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dir", str(tmp_path)])
+
+    assert P.main() == 2  # stopped at the injected mismatch, after all three runs were requested
+    assert len(requested) == len(P.TRACE_TABLES), "one run request per model"
+    for payload in requested:
+        assert payload["datasetId"] == "ds-eval"
+        assert "selectedModels" not in payload
+    assert [pl["staticModelId"] for pl in requested] == [f"id-{t}" for t in P.TRACE_TABLES]
+
+
+def test_the_publisher_polls_the_exact_run_group_the_mutation_returned(tmp_path, monkeypatch):
+    _valid_candidates(tmp_path)
+    requested: list[dict] = []
+    polled: list[str] = []
+    fake = _platform_graphql(requested)
+    monkeypatch.setattr(P, "graphql", fake)
+    monkeypatch.setattr(PR, "graphql", fake)
+    monkeypatch.setattr(PE, "graphql", fake)
+    monkeypatch.setattr(P, "upload", lambda path, url: None)
+
+    def record_poll(gid, token, timeout=1800.0):
+        polled.append(gid)
+        return "SUCCESS"
+
+    monkeypatch.setattr(P, "poll_run_group", record_poll)
+    monkeypatch.setattr(P, "deployed_table_state", lambda dataset, table: {"rows": 0, "columns": []})
+    monkeypatch.setattr(P, "deployment_mismatches", lambda expected, deployed: ["stop here"])
+    monkeypatch.setenv("OSO_API_KEY", "tok")
+    monkeypatch.setenv("OSO_ORG_ID", "org")
+    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dir", str(tmp_path)])
+
+    assert P.main() == 2
+    assert polled == [f"grp-for-id-{t}" for t in P.TRACE_TABLES]
+
+
+def test_a_failed_run_stops_the_deploy_before_the_next_model(tmp_path, monkeypatch):
+    _valid_candidates(tmp_path)
+    requested: list[dict] = []
+    fake = _platform_graphql(requested)
+    monkeypatch.setattr(P, "graphql", fake)
+    monkeypatch.setattr(PR, "graphql", fake)
+    monkeypatch.setattr(PE, "graphql", fake)
+    monkeypatch.setattr(P, "upload", lambda path, url: None)
+    monkeypatch.setattr(P, "poll_run_group", lambda gid, token, timeout=1800.0: "FAILED")
+
+    def boom(dataset, table):
+        raise AssertionError("must not read deployed state when a run failed")
+
+    monkeypatch.setattr(P, "deployed_table_state", boom)
+    monkeypatch.setenv("OSO_API_KEY", "tok")
+    monkeypatch.setenv("OSO_ORG_ID", "org")
+    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dir", str(tmp_path)])
+
+    assert P.main() == 2
+    assert len(requested) == 1, "the second model is not requested after the first fails"
+    assert P.latest_archive(tmp_path) is None, "a failed deploy archives nothing"
+
+
+# --- the deployed-schema comparison and the immutable archive --------------------
+
+
+def test_deployment_mismatches_catches_row_and_schema_drift():
+    expected = {t: {"rows": 3, "columns": ["a", "b"], "all_null_columns": []} for t in P.TRACE_TABLES}
+    deployed = {t: {"rows": 3, "columns": ["a", "b"]} for t in P.TRACE_TABLES}
+    assert P.deployment_mismatches(expected, deployed) == []
+    wrong_rows = {**deployed, "axis_facts": {"rows": 2, "columns": ["a", "b"]}}
+    assert any("rows" in m for m in P.deployment_mismatches(expected, wrong_rows))
+    wrong_cols = {**deployed, "axis_results": {"rows": 3, "columns": ["a"]}}
+    assert any("columns" in m for m in P.deployment_mismatches(expected, wrong_cols))
+
+
+def test_deployment_archive_is_immutable_and_in_its_own_subdir(tmp_path):
+    _valid_candidates(tmp_path)
+    receipt = P.build_receipt(tmp_path)
+    archive = P.archive_deployment(tmp_path, receipt)
+    assert archive.exists() and (archive / "receipt.json").exists()
+    for table in P.TRACE_TABLES:
+        assert (archive / f"{table}.csv").exists()
+    # Its own subdirectory — never the evaluation publisher's `deployments/`.
+    assert P.deployments_dir(tmp_path).name == "scoring-trace-deployments"
+    assert P.deployments_dir(tmp_path) != PE.deployments_dir(tmp_path)
+    assert P.latest_archive(tmp_path) == archive
+    try:
+        P.archive_deployment(tmp_path, receipt)
+    except RuntimeError as exc:
+        assert "already exists" in str(exc)
+    else:
+        raise AssertionError("archive_deployment must refuse to overwrite an existing deployment id")

--- a/tests/test_publish_scoring_trace.py
+++ b/tests/test_publish_scoring_trace.py
@@ -2,13 +2,25 @@
 
 `build/publish_scoring_trace.py` uploads the three scoring-trace CSVs (`axis_facts`,
 `axis_rule_matches`, `axis_results`) to OSO. The network path is a maintainer step, but the guards
-that keep a bad or arbitrary CSV off the platform — the exact headers, the declaration-only identity,
-the per-table grain, the ADR-001 `reproduces_recorded` dual-run gate — the promise that
-`--plan`/`--dry-run` write nothing, and the immutable rollback archive (in its own subdirectory,
-never the evaluation publisher's) are pure and pinned here.
+that keep a bad, incomplete, or inauthentic CSV off the platform are pinned here in two layers:
+
+* the cheap, well-messaged STRUCTURAL checks (`structural_problems`) — headers, non-empty,
+  declaration-only identity, per-table grain, the ADR-001 `reproduces_recorded` dual-run gate, and
+  product/category coherence; and
+* the AUTHORITY (`canonical_equivalence_problems`) — the candidate must be byte-for-byte the trace
+  this repository's builder produces at the current commit, which is the only thing that proves
+  complete population and an authentic identity. A truncated-but-consistent subset, or a fabricated
+  constant id, passes the structural checks and is caught here.
+
+The `--plan`/`--dry-run` no-write promise and the immutable rollback archive (in its own
+subdirectory, never the evaluation publisher's) are pinned too.
 """
 
+import csv
+import shutil
 import sys
+
+import pytest
 
 import build.publish_evaluation as PE
 import build.publish_registry as PR
@@ -22,12 +34,13 @@ def _write_csv(path, header, rows):
 
 
 # One tiny, internally-consistent trace: a single scored product reproducing its recorded score,
-# with a matching fact and rule-match row, all under one declaration identity.
+# with a matching fact and rule-match row, all under one declaration identity. It passes the
+# STRUCTURAL checks — and is exactly the truncated subset canonical equivalence must reject.
 DVID = "d" * 64
 SHA = "f012d854eb87"
 
 
-def _valid_candidates(out_dir):
+def _synthetic_candidates(out_dir):
     def row(table, **over):
         base = {"declaration_version_id": DVID, "source_git_sha": SHA,
                 "product_slug": "p", "category_slug": "c", "product_type": "model", "axis": "openness"}
@@ -51,54 +64,51 @@ def test_trace_tables_are_the_three_outputs():
     assert P.TRACE_TABLES == ("axis_facts", "axis_rule_matches", "axis_results")
 
 
-# --- validation before any mutation ----------------------------------------------
+# --- structural checks (well-messaged, not the authority) ------------------------
 
 
-def test_valid_candidates_pass_validation(tmp_path):
-    _valid_candidates(tmp_path)
-    assert P.validate_candidates(tmp_path) == []
+def test_synthetic_candidate_passes_the_structural_checks(tmp_path):
+    _synthetic_candidates(tmp_path)
+    assert P.structural_problems(tmp_path) == []
 
 
 def test_arbitrary_headers_are_rejected(tmp_path):
     for t in P.TRACE_TABLES:
         _write_csv(tmp_path / f"{t}.csv", ["x", "y"], [[1, 2]])
-    problems = P.validate_candidates(tmp_path)
-    assert any("header does not match" in p for p in problems)
+    assert any("header does not match" in p for p in P.structural_problems(tmp_path))
 
 
 def test_empty_table_is_rejected(tmp_path):
-    _valid_candidates(tmp_path)
+    _synthetic_candidates(tmp_path)
     header = (tmp_path / "axis_facts.csv").read_text().splitlines()[0]
     (tmp_path / "axis_facts.csv").write_text(header + "\n", encoding="utf-8")
-    assert any("empty" in p for p in P.validate_candidates(tmp_path))
+    assert any("empty" in p for p in P.structural_problems(tmp_path))
 
 
 def test_inconsistent_identity_within_a_file_is_rejected(tmp_path):
-    _valid_candidates(tmp_path)
-    # A second facts row under a different source_git_sha breaks within-file constancy.
+    _synthetic_candidates(tmp_path)
     path = tmp_path / "axis_facts.csv"
     lines = path.read_text().splitlines()
     row = lines[1].split(",")
     row[1] = "deadbeefcafe"  # source_git_sha column
     path.write_text("\n".join(lines + [",".join(row)]) + "\n", encoding="utf-8")
-    assert any("source_git_sha" in p for p in P.validate_candidates(tmp_path))
+    assert any("source_git_sha" in p for p in P.structural_problems(tmp_path))
 
 
 def test_identity_differing_across_files_is_rejected(tmp_path):
-    _valid_candidates(tmp_path)
+    _synthetic_candidates(tmp_path)
     path = tmp_path / "axis_results.csv"
     lines = path.read_text().splitlines()
     row = lines[1].split(",")
     row[0] = "e" * 64  # a different declaration_version_id than facts/rules carry
     lines[1] = ",".join(row)
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    assert any("declaration_version_id" in p for p in P.validate_candidates(tmp_path))
+    assert any("declaration_version_id" in p for p in P.structural_problems(tmp_path))
 
 
 def test_a_scored_row_that_does_not_reproduce_is_rejected(tmp_path):
-    """The ADR-001 dual-run gate: a scored result must reproduce the recorded score, or it is a
-    check_rubric disagreement that is resolved in the evaluator, never deployed."""
-    _valid_candidates(tmp_path)
+    """The ADR-001 dual-run gate: a scored result must reproduce the recorded score."""
+    _synthetic_candidates(tmp_path)
     path = tmp_path / "axis_results.csv"
     header = P.EXPECTED_HEADERS["axis_results"]
     lines = path.read_text().splitlines()
@@ -106,12 +116,12 @@ def test_a_scored_row_that_does_not_reproduce_is_rejected(tmp_path):
     row[header.index("reproduces_recorded")] = "False"
     lines[1] = ",".join(row)
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    assert any("reproduce" in p for p in P.validate_candidates(tmp_path))
+    assert any("reproduce" in p for p in P.structural_problems(tmp_path))
 
 
 def test_a_deferred_row_with_blank_reproduces_is_fine(tmp_path):
     """Deferred results carry an empty reproduces_recorded and must NOT trip the dual-run gate."""
-    _valid_candidates(tmp_path)
+    _synthetic_candidates(tmp_path)
     path = tmp_path / "axis_results.csv"
     header = P.EXPECTED_HEADERS["axis_results"]
     lines = path.read_text().splitlines()
@@ -121,32 +131,143 @@ def test_a_deferred_row_with_blank_reproduces_is_fine(tmp_path):
     row[header.index("deferral_reason")] = "no_recipe"
     lines[1] = ",".join(row)
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    assert P.validate_candidates(tmp_path) == []
+    assert P.structural_problems(tmp_path) == []
 
 
 def test_grain_uniqueness_is_enforced(tmp_path):
-    _valid_candidates(tmp_path)
+    _synthetic_candidates(tmp_path)
     path = tmp_path / "axis_results.csv"
     lines = path.read_text().splitlines()
     path.write_text("\n".join(lines + [lines[1]]) + "\n", encoding="utf-8")  # duplicate the one result
-    assert any("grain" in p for p in P.validate_candidates(tmp_path))
+    assert any("grain" in p for p in P.structural_problems(tmp_path))
 
 
 def test_a_fact_with_no_result_row_is_rejected(tmp_path):
-    _valid_candidates(tmp_path)
+    _synthetic_candidates(tmp_path)
     path = tmp_path / "axis_facts.csv"
     lines = path.read_text().splitlines()
     row = lines[1].split(",")
     row[2] = "orphan"  # product_slug not present in axis_results
     path.write_text("\n".join(lines + [",".join(row)]) + "\n", encoding="utf-8")
-    assert any("no axis_results row" in p for p in P.validate_candidates(tmp_path))
+    assert any("no axis_results row" in p for p in P.structural_problems(tmp_path))
 
 
-# --- --plan / --dry-run write nothing --------------------------------------------
+# --- canonical equivalence: the authority (built from the REAL builder) ----------
+
+
+@pytest.fixture(scope="module")
+def real_dir(tmp_path_factory):
+    """The genuine trace this repository produces, written once through the real writer.
+
+    allow_dirty=True so the fixture is independent of the working-tree state during development;
+    every canonical check below reruns the builder with the same flag, so the identities agree.
+    """
+    from build.axis_scoring_trace import TABLES as SPEC
+    from build.axis_scoring_trace import resolve
+    from build.serialize_registry import write_tables
+
+    out = tmp_path_factory.mktemp("real-trace")
+    write_tables(resolve(allow_dirty=True), out, SPEC)
+    return out
+
+
+def _copy_real(real_dir, dest):
+    for table in P.TRACE_TABLES:
+        shutil.copy(real_dir / f"{table}.csv", dest / f"{table}.csv")
+    return dest
+
+
+def _rows(path):
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.reader(handle))
+
+
+def _write_rows(path, rows):
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        csv.writer(handle).writerows(rows)
+
+
+def test_the_real_builder_output_passes_full_validation(real_dir):
+    assert P.validate_candidates(real_dir, allow_dirty=True) == []
+
+
+def test_a_truncated_but_consistent_candidate_is_rejected(tmp_path):
+    """The headline: the tiny 1/1/1 subset that passes every structural check is NOT publishable."""
+    _synthetic_candidates(tmp_path)
+    assert P.structural_problems(tmp_path) == []
+    problems = P.validate_candidates(tmp_path, allow_dirty=True)
+    assert any("canonical trace" in p for p in problems)
+
+
+def test_an_omitted_result_row_is_rejected(real_dir, tmp_path):
+    d = _copy_real(real_dir, tmp_path)
+    rows = _rows(d / "axis_results.csv")
+    _write_rows(d / "axis_results.csv", rows[:-1])  # drop one real result
+    assert any("axis_results" in p and "missing" in p
+               for p in P.canonical_equivalence_problems(d, allow_dirty=True))
+
+
+def test_an_omitted_fact_is_rejected(real_dir, tmp_path):
+    d = _copy_real(real_dir, tmp_path)
+    rows = _rows(d / "axis_facts.csv")
+    _write_rows(d / "axis_facts.csv", rows[:-1])
+    assert any("axis_facts" in p and "missing" in p
+               for p in P.canonical_equivalence_problems(d, allow_dirty=True))
+
+
+def test_an_omitted_rule_match_is_rejected(real_dir, tmp_path):
+    d = _copy_real(real_dir, tmp_path)
+    rows = _rows(d / "axis_rule_matches.csv")
+    _write_rows(d / "axis_rule_matches.csv", rows[:-1])
+    assert any("axis_rule_matches" in p and "missing" in p
+               for p in P.canonical_equivalence_problems(d, allow_dirty=True))
+
+
+def test_a_fabricated_but_constant_identity_is_rejected(real_dir, tmp_path):
+    """A constant declaration_version_id passes the structural identity check but is not authentic."""
+    d = _copy_real(real_dir, tmp_path)
+    for table in P.TRACE_TABLES:
+        rows = _rows(d / f"{table}.csv")
+        col = rows[0].index("declaration_version_id")
+        for row in rows[1:]:
+            row[col] = "f" * 64
+        _write_rows(d / f"{table}.csv", rows)
+    assert P.structural_problems(d) == []           # constant + equal across files: structurally fine
+    assert P.canonical_equivalence_problems(d, allow_dirty=True)  # but not this repository's id
+
+
+def test_a_changed_value_with_valid_grain_and_flags_is_rejected(real_dir, tmp_path):
+    """A tampered non-grain value, grain and reproduces_recorded left intact, is caught by canonical."""
+    d = _copy_real(real_dir, tmp_path)
+    rows = _rows(d / "axis_results.csv")
+    col = rows[0].index("raw_license")
+    rows[1][col] = (rows[1][col] or "X") + "-tampered"
+    _write_rows(d / "axis_results.csv", rows)
+    assert P.structural_problems(d) == []
+    assert any("axis_results" in p for p in P.canonical_equivalence_problems(d, allow_dirty=True))
+
+
+def test_canonical_rebuild_over_a_dirty_tree_without_allow_dirty_is_reported(real_dir, tmp_path, monkeypatch):
+    """If the builder cannot produce a reproducible id (dirty tree, no opt-in), that is a problem,
+    not a crash — so a candidate is never published against an unrebuildably-dirty repo."""
+    d = _copy_real(real_dir, tmp_path)
+
+    def _raise(root, allow_dirty=False):
+        raise RuntimeError("DirtyWorktreeError: HEAD disagrees with the worktree")
+
+    monkeypatch.setattr("build.axis_scoring_trace.resolve", _raise)
+    problems = P.canonical_equivalence_problems(d, allow_dirty=False)
+    assert any("clean commit" in p for p in problems)
+
+
+# --- --plan / --dry-run write nothing (canonical authority stubbed) --------------
+# These exercise the no-write / no-mutation mechanics, not authenticity, so the repo rebuild is
+# stubbed and the structural checks still run over the synthetic candidate.
 
 
 def test_plan_validates_offline_and_writes_nothing(tmp_path, monkeypatch):
-    _valid_candidates(tmp_path)
+    _synthetic_candidates(tmp_path)
+    monkeypatch.setattr(P, "canonical_equivalence_problems", lambda *a, **k: [])
 
     def _no_network(*a, **k):
         raise AssertionError("--plan must not hit the network")
@@ -159,7 +280,8 @@ def test_plan_validates_offline_and_writes_nothing(tmp_path, monkeypatch):
 
 
 def test_dry_run_with_credentials_makes_no_mutation_and_no_write(tmp_path, monkeypatch):
-    _valid_candidates(tmp_path)
+    _synthetic_candidates(tmp_path)
+    monkeypatch.setattr(P, "canonical_equivalence_problems", lambda *a, **k: [])
     monkeypatch.setenv("OSO_API_KEY", "test-token")
     monkeypatch.setenv("OSO_ORG_ID", "test-org")
 
@@ -181,7 +303,8 @@ def test_dry_run_with_credentials_makes_no_mutation_and_no_write(tmp_path, monke
 
 
 def test_publish_without_credentials_refuses(tmp_path, monkeypatch):
-    _valid_candidates(tmp_path)
+    _synthetic_candidates(tmp_path)
+    monkeypatch.setattr(P, "canonical_equivalence_problems", lambda *a, **k: [])
     monkeypatch.delenv("OSO_API_KEY", raising=False)
     monkeypatch.delenv("OSO_ORG_ID", raising=False)
 
@@ -198,7 +321,7 @@ def test_missing_csv_is_a_loud_failure(tmp_path, monkeypatch):
     assert P.main() == 2
 
 
-# --- per-model run requests, exact-group polling, fail-fast ----------------------
+# --- per-model run requests, exact-group polling, fail-fast (validation stubbed) --
 
 
 def _platform_graphql(requested):
@@ -221,19 +344,24 @@ def _platform_graphql(requested):
     return fake_graphql
 
 
-def test_load_run_is_requested_once_per_model_with_static_model_id(tmp_path, monkeypatch):
-    _valid_candidates(tmp_path)
-    requested: list[dict] = []
+def _wire(monkeypatch, requested):
     fake = _platform_graphql(requested)
+    monkeypatch.setattr(P, "canonical_equivalence_problems", lambda *a, **k: [])
     monkeypatch.setattr(P, "graphql", fake)
     monkeypatch.setattr(PR, "graphql", fake)
     monkeypatch.setattr(PE, "graphql", fake)
     monkeypatch.setattr(P, "upload", lambda path, url: None)
+    monkeypatch.setenv("OSO_API_KEY", "tok")
+    monkeypatch.setenv("OSO_ORG_ID", "org")
+
+
+def test_load_run_is_requested_once_per_model_with_static_model_id(tmp_path, monkeypatch):
+    _synthetic_candidates(tmp_path)
+    requested: list[dict] = []
+    _wire(monkeypatch, requested)
     monkeypatch.setattr(P, "poll_run_group", lambda gid, token, timeout=1800.0: "SUCCESS")
     monkeypatch.setattr(P, "deployed_table_state", lambda dataset, table: {"rows": 0, "columns": []})
     monkeypatch.setattr(P, "deployment_mismatches", lambda expected, deployed: ["stop here"])
-    monkeypatch.setenv("OSO_API_KEY", "tok")
-    monkeypatch.setenv("OSO_ORG_ID", "org")
     monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dir", str(tmp_path)])
 
     assert P.main() == 2  # stopped at the injected mismatch, after all three runs were requested
@@ -245,14 +373,10 @@ def test_load_run_is_requested_once_per_model_with_static_model_id(tmp_path, mon
 
 
 def test_the_publisher_polls_the_exact_run_group_the_mutation_returned(tmp_path, monkeypatch):
-    _valid_candidates(tmp_path)
+    _synthetic_candidates(tmp_path)
     requested: list[dict] = []
     polled: list[str] = []
-    fake = _platform_graphql(requested)
-    monkeypatch.setattr(P, "graphql", fake)
-    monkeypatch.setattr(PR, "graphql", fake)
-    monkeypatch.setattr(PE, "graphql", fake)
-    monkeypatch.setattr(P, "upload", lambda path, url: None)
+    _wire(monkeypatch, requested)
 
     def record_poll(gid, token, timeout=1800.0):
         polled.append(gid)
@@ -261,8 +385,6 @@ def test_the_publisher_polls_the_exact_run_group_the_mutation_returned(tmp_path,
     monkeypatch.setattr(P, "poll_run_group", record_poll)
     monkeypatch.setattr(P, "deployed_table_state", lambda dataset, table: {"rows": 0, "columns": []})
     monkeypatch.setattr(P, "deployment_mismatches", lambda expected, deployed: ["stop here"])
-    monkeypatch.setenv("OSO_API_KEY", "tok")
-    monkeypatch.setenv("OSO_ORG_ID", "org")
     monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dir", str(tmp_path)])
 
     assert P.main() == 2
@@ -270,21 +392,15 @@ def test_the_publisher_polls_the_exact_run_group_the_mutation_returned(tmp_path,
 
 
 def test_a_failed_run_stops_the_deploy_before_the_next_model(tmp_path, monkeypatch):
-    _valid_candidates(tmp_path)
+    _synthetic_candidates(tmp_path)
     requested: list[dict] = []
-    fake = _platform_graphql(requested)
-    monkeypatch.setattr(P, "graphql", fake)
-    monkeypatch.setattr(PR, "graphql", fake)
-    monkeypatch.setattr(PE, "graphql", fake)
-    monkeypatch.setattr(P, "upload", lambda path, url: None)
+    _wire(monkeypatch, requested)
     monkeypatch.setattr(P, "poll_run_group", lambda gid, token, timeout=1800.0: "FAILED")
 
     def boom(dataset, table):
         raise AssertionError("must not read deployed state when a run failed")
 
     monkeypatch.setattr(P, "deployed_table_state", boom)
-    monkeypatch.setenv("OSO_API_KEY", "tok")
-    monkeypatch.setenv("OSO_ORG_ID", "org")
     monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dir", str(tmp_path)])
 
     assert P.main() == 2
@@ -306,7 +422,7 @@ def test_deployment_mismatches_catches_row_and_schema_drift():
 
 
 def test_deployment_archive_is_immutable_and_in_its_own_subdir(tmp_path):
-    _valid_candidates(tmp_path)
+    _synthetic_candidates(tmp_path)
     receipt = P.build_receipt(tmp_path)
     archive = P.archive_deployment(tmp_path, receipt)
     assert archive.exists() and (archive / "receipt.json").exists()


### PR DESCRIPTION
## What

Phase 6's scoring-trace deploy had **no publisher**. `docs/operations/deploy-scoring-trace.md` §3 named wiring one "mirroring `build/publish_evaluation.py`" as the prerequisite follow-up; until then a deploy meant hand-running raw GraphQL mutations — the exact unsafe path #380 was about. This adds `build/publish_scoring_trace.py`, born with the correct run-group-bound polling, so the three trace tables deploy the same disciplined way registry and evaluation do.

It mirrors `build/publish_evaluation.py` and **reuses** its generic machinery (`csv_provenance`, `deployed_table_state`, `run_groups_all_succeeded`, `resolve_evaluation_dataset`) and the shared run-group-bound `poll_run_group` from `build/publish_registry.py` — so the three publishers cannot drift.

## Candidate validation — two layers, canonical equivalence is the authority

Structural checks run first for legible messages; **canonical equivalence is the final authority**.

- **Structural** (`structural_problems`): headers pinned to the builder's `COLUMNS`; non-empty; declaration-only identity (§4.4) — `declaration_version_id` + `source_git_sha` constant within each file and equal across all three, no `observation_snapshot_id`/`release_id`; per-table grain uniqueness; the ADR-001 dual-run gate (every **scored** `axis_results` row reproduces the recorded score, or the candidate is refused); product/category coherence.
- **Canonical equivalence** (`canonical_equivalence_problems`, the authority): before any mutation the publisher re-runs the builder in memory (`build.axis_scoring_trace.resolve()`) and requires the candidate to be **byte-for-byte** that output — expected rows written through the same `write_tables` and read back with the same reader, compared as an order-independent multiset of `canonical_row` strings. This proves, in one gate: exact **complete** population (no omitted/invented product, fact, or rule), every value and result disposition and `reproduces_recorded` flag, and the **current, authentic** `declaration_version_id` + `source_git_sha` (columns on every row, so a stale or fabricated id mismatches every row) — with **no second evaluation** that could drift from the builder. A dirty tree with no `--allow-dirty` opt-in is reported ("publish from a clean commit"), not a crash.

This closes the two review gaps: a truncated-but-consistent subset (1 product/1 fact/1 rule/1 result) and a constant-but-fabricated identity both pass the structural checks and are caught here.

## Publish mechanics

Per-model `{datasetId, staticModelId}` requests, serialized, each polling the **exact** run group the mutation returned, fail-fast; deployed row/schema read-back via `pyoso`; immutable SUCCESS-gated archive in its **own** subdirectory `build/evaluation/scoring-trace-deployments/`, never the evaluation publisher's `deployments/`.

## Verification

- `--plan` / `--dry-run` verified against the **real** built CSVs (`axis_facts` 2,284 / `axis_rule_matches` 2,734 / `axis_results` 522): dataset resolves, all three report would-create-and-upload, **no archive written**. Independently confirmed the authority rejects a candidate built at a prior commit and accepts the rebuild at HEAD.
- 27 tests in `tests/test_publish_scoring_trace.py`, including the reviewer's five canonical rejections (omitted result / fact / rule-match row, constant-but-fabricated identity, changed value with valid grain + flags) and the truncated-subset headline.
- Full suite green (**1085 passed**); `build.validate` prints `0 error(s)`.

## Scope

Deploy prerequisite only — no platform write on its own. The live deploy (run this for real; reconcile inventory + DAG + docs) and the separate, gated `evaluator_version` cutover are follow-ups, not folded in here. A known non-blocking archive-root/`--dir` rollback limitation (shared with `publish_evaluation.py`) is recorded as an in-code follow-up.

## Checklist

- [x] `uv run python -m build.validate` prints `0 error(s)`
- [ ] N/A: no new/changed scores (publish CLI + its test + runbook only)
- [x] I did not edit `build/notebook_data.json` or `notebooks/ai-stack-map.py`
- [ ] N/A: no product/roster changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)