### PR TITLE
Plan: the evaluator_version cutover (decisions settled; review only — no mutation)

### DIFF
--- a/docs/operations/evaluator-version-cutover.md
+++ b/docs/operations/evaluator-version-cutover.md
@@ -1,0 +1,192 @@
+# Plan: the `evaluator_version` cutover (Phase 6 → the sentinel is retired)
+
+**Status: PLAN FOR REVIEW. No platform mutation is authorized by this document.** It resolves the
+open questions the cutover raises and proposes an exact procedure; execution is a separate,
+explicitly-authorized step once this plan and its two open decisions are approved.
+
+## What the cutover is
+
+`build/declaration_version.py:111` pins `EVALUATOR_VERSION = "v0-no-repo-evaluator"` — a sentinel
+recording "scores are curator-recorded, not machine-derived." Phase 6 landed the
+repository-owned evaluator (the `evaluation.axis_*` scoring trace, deployed 2026-08-27). Retiring
+the sentinel — replacing it with a real evaluator version — is what this plan covers.
+
+`declaration_version_id = f(source_git_sha, source_content_digest, evaluator_version)`
+(`build/declaration_version.py`). `evaluator_version` is folded into **every**
+`declaration_version_id`, and the id is **table-independent** — it depends only on the commit, the
+declaration content, and the evaluator version, not on which table carries it. So bumping
+`EVALUATOR_VERSION` re-keys every declaration-keyed table at once, and **rebuilding all candidates
+from one commit collapses them to a single new id** (see §3, §7).
+
+## 1. The complete derived inventory of declaration-keyed tables
+
+Derived from `warehouse/assets.yaml` (every asset whose `grain` names `declaration_version_id`), not
+hand-listed — this is checkable and must be re-derived at execution time, not trusted from here:
+
+| Asset | Dataset | Publisher | State today |
+|---|---|---|---|
+| `evaluation.product_adoption_measurements` | `evaluation` | `build/publish_evaluation.py` | active, deployed |
+| `evaluation.adoption_reconciliation` | `evaluation` | `build/publish_evaluation.py` | active, deployed |
+| `evaluation.axis_facts` | `evaluation` | `build/publish_scoring_trace.py` | active, deployed |
+| `evaluation.axis_rule_matches` | `evaluation` | `build/publish_scoring_trace.py` | active, deployed |
+| `evaluation.axis_results` | `evaluation` | `build/publish_scoring_trace.py` | active, deployed |
+| `registry.axis_assessments` | `registry` | `build/publish_axis_assessments`* (runbook `deploy-axis-assessments.md`) | **staged**, not deployed |
+
+\* `registry.axis_assessments` has no dedicated publisher yet (its runbook still describes the
+mechanics); it also keys on `declaration_version_id`. It is **staged** — no live table — so it is
+**not** part of the live atomic swap. Decision D3 below: deploy it in the same cutover (so the whole
+declaration-keyed surface shares one id from day one) or leave it staged and let it inherit the new
+evaluator whenever it first deploys. Recommended: deploy it in the same pass, for one coherent
+generation.
+
+An execution-time assertion must re-run this derivation and fail if any declaration-keyed asset is
+absent from the cutover set — the cutover must cover the surface completely, or not run.
+
+## 2. The current live generations (the real "old" IDs — not one global value)
+
+Read live via `pyoso` on 2026-08-27:
+
+| Table(s) | Live `declaration_version_id` | Cut at commit |
+|---|---|---|
+| `product_adoption_measurements`, `adoption_reconciliation` | `232015a76ecc…` | `f012d85` |
+| `axis_facts`, `axis_rule_matches`, `axis_results` | `eb828b57b14d…` | `980250b` |
+| `registry.axis_assessments` | — (staged, no live table) | — |
+
+There are **two** live generations, because the eval tables and the trace tables were deployed from
+different commits. Any rollback or transition map must treat these as distinct old IDs (§7, §9).
+
+## 3. One clean cutover commit
+
+All candidates are built from a **single `main` commit** whose only material change is the
+`EVALUATOR_VERSION` bump (plus this plan and any prerequisite code fix from §0), over a **clean
+worktree**. Because the id is commit- and evaluator-scoped and table-independent, one commit + one
+new `evaluator_version` yields **one** new `declaration_version_id` shared by every table (given the
+snapshot decision in §4 holds the observation inputs fixed). This single id is the atomicity anchor
+and the cross-table invariant checked in §8.
+
+## 4. Adoption tables: preserve the observation snapshot, do not refresh it
+
+`product_adoption_measurements` and `adoption_reconciliation` also key on `observation_snapshot_id`
+(currently `9bd4d93a6fc6`); the trace tables do not. **Recommendation: preserve** — rebuild the two
+adoption candidates from the same frozen Phase-2 baseline, so the cutover changes only
+`evaluator_version` (and `source_git_sha`), never the observation content. Refreshing from live
+`observations.product_adoption_current` would fold a data change into the same deploy and make the
+id transition impossible to attribute cleanly to the evaluator bump. **This is open decision D2** —
+confirm preserve, or state the deliberate reason to refresh and record the new snapshot id.
+
+## 5. Handling the non-atomic interval
+
+Static models replace in place and are published sequentially, so mid-cutover some tables carry the
+new id and some the old. There is no release-scoped materialization yet (`releases.*` does not
+exist; atomicity is transitional per `migration-status.md`). Mitigations:
+
+- **Low blast radius today.** Nothing consumes these tables cross-generation on the platform: the
+  Phase-4 gate is disabled and the Phase-7 retirement has not begun, so no live query joins an
+  old-id table to a new-id table. The window is real but currently harms no consumer.
+- **One session, fail-fast.** Run the whole cutover in a single maintainer session; each publisher
+  already polls each run group to terminal `SUCCESS` and exits non-zero on the first failure, so a
+  partial cutover stops loudly rather than silently half-swapping.
+- **Announced window.** Record the start/end and that mixed generations are expected in between.
+- **Post-swap invariant check** (§8, §10): after all deploys, assert every deployed declaration-keyed
+  table carries the *same* new id; a straggler means the swap did not complete.
+
+## 6. Exact deployment order
+
+From the cutover commit, after a full dry-run of every publisher:
+
+1. **`registry.axis_assessments`** (only if D3 = deploy it) — registry dataset.
+2. **Scoring trace** — `build/publish_scoring_trace.py` (`axis_facts`, `axis_rule_matches`,
+   `axis_results`).
+3. **Adoption evaluation** — `build/publish_evaluation.py` (`product_adoption_measurements`, then
+   `adoption_reconciliation`, the order the publisher already uses because reconciliation reads
+   measurements as candidate rows in-repo).
+
+Order is not forced by platform reads (the tables are independent static models), so it is chosen for
+legibility and so the most self-contained set (the trace) swaps first. Each publisher is serialized
+and SUCCESS-gated internally.
+
+## 7. Old → new declaration-ID transition map
+
+The new id is not knowable until `EVALUATOR_VERSION` is chosen and the commit is made; the procedure
+captures it. The transition to record in the deploy note:
+
+| Old generation | Tables | New id |
+|---|---|---|
+| `232015a76ecc…` | measurements, reconciliation | `<new>` (computed at the cutover commit) |
+| `eb828b57b14d…` | axis_facts, axis_rule_matches, axis_results | `<new>` |
+| — (staged) | registry.axis_assessments | `<new>` (if D3 = deploy) |
+
+Capture `SELECT DISTINCT declaration_version_id` per table **before** (done above) and **after**;
+both old generations must map to the single `<new>` id, and no table may retain an old id.
+
+## 8. Pre-flight: counts, schemas, hashes, cross-table invariants
+
+Before any upload, build every candidate at the cutover commit and assert:
+
+- **Row counts** match the builders: adoption 377 / 522 (from the preserved baseline); trace 2,284 /
+  2,734 / 522; `registry.axis_assessments` its builder's count if D3.
+- **Schemas** equal each builder's `COLUMNS` (the publishers already gate this per file).
+- **Per-file authority** — `publish_scoring_trace` canonical-equivalence and `publish_evaluation`
+  `validate_candidates` already prove each file is exactly its builder's output at HEAD.
+- **NEW cross-cutover invariant** — every candidate across all three publishers shares **one**
+  `declaration_version_id` and one `source_git_sha`. This is the check that the single-commit build
+  actually produced a single generation. It does not exist yet and must be added (a small script or
+  test run at execution time), because each publisher only validates its own files today.
+- **Hashes** — record the sha256 of every uploaded CSV in the deploy note (the publishers already
+  archive these in each receipt).
+
+## 9. Rollback — reverse-order, by archived bytes (with a real gap to close first)
+
+Rollback re-uploads the **previous generation's archived bytes** in reverse deploy order
+(adoption → trace → registry), restoring the old ids. Each publisher archives the exact bytes it
+uploaded. **Two gaps must be closed before this is dependable for the cutover:**
+
+- **§0 archive-root bug** (below) — re-publishing from an archive via `--dir` currently nests a new
+  archive and does not update the canonical archive root.
+- **Archive persistence.** Archives live under `build/evaluation/…deployments/` and
+  `build/registry/…`, which are **git-ignored and per-session ephemeral**. In a fresh container the
+  prior archives do not exist, so rollback-by-bytes only works within the same session that deployed
+  — or from archives deliberately preserved. The cutover procedure must **retain the pre-cutover
+  archives** (the two current generations) and the cutover session's own archives somewhere durable,
+  or download the deployed bytes before overwriting them. This must be decided and wired before
+  execution; it is a genuine hole in the rollback story, not a formality.
+
+## 10. Post-deploy verification and lockstep reconciliation
+
+After the swap, in one reconciliation PR (mirroring the Unit-2 reconciliation):
+
+- `pyoso` read-back of every table: row counts and schemas unchanged from the candidates.
+- Assert the single shared new `declaration_version_id` across all deployed declaration-keyed tables
+  (the §8 invariant, now against the platform).
+- Update `assets.yaml` (`verified_at`, and note the new declaration generation), `migration-status.md`
+  (record the id transition table from §7; mark the sentinel retired), `data-architecture.md` §4.5
+  and the "Versioning identities" section (`evaluator_version` is now a real value, with the bump
+  policy from D1), and any `where-scores-live` / DAG counts the change touches.
+
+## Open decisions for the maintainer (blockers on execution)
+
+- **D1 — the new `evaluator_version` value and bump policy.** Proposal: a monotonic string
+  `"v1-openness-<yyyymm>"` (e.g. `v1-openness-202608`) or a bare `"v1"`, with the policy: **bump when
+  the evaluator's scoring logic can change a result** — `build/check_rubric.py`'s ladder walk,
+  license resolution, or recipe interpretation — and *not* for unrelated code. Recorded in a short
+  note beside the constant, and each bump is its own cutover. Alternative considered: embed a hash of
+  the evaluator modules (auto-bumps, but noisy and opaque). **Maintainer picks the value and policy.**
+- **D2 — preserve vs refresh the observation snapshot** (§4). Recommended: preserve `9bd4d93a6fc6`.
+- **D3 — include `registry.axis_assessments`** in the cutover (§1). Recommended: yes, so the whole
+  declaration-keyed surface shares one generation; it needs its publisher wired first (§0).
+
+## §0 — prerequisite code fixes (no platform write; land before execution)
+
+1. **Archive-root / deployment-occurrence** (already flagged in `publish_scoring_trace.py` and
+   shared with `publish_evaluation.py`): decouple the archive root from the read `--dir`. The archive
+   must always be written to (and `latest_archive` read from) a fixed canonical root, so
+   re-publishing a prior archive via `--dir` neither nests a new archive nor leaves the system
+   claiming the superseded deployment is the latest live state. Add tests: publishing from an archive
+   directory writes to the canonical root (or records a rollback occurrence there), and never inside
+   the read directory.
+2. **Cross-cutover identity invariant** (§8): a small checkable step asserting all candidates across
+   the three publishers share one `declaration_version_id` + `source_git_sha`.
+3. **(If D3)** a dedicated `registry.axis_assessments` publisher mirroring the others, or a
+   documented manual path, before it can join the cutover.
+
+Each of these is a normal reviewed code PR with tests, containing no platform mutation.

--- a/docs/operations/evaluator-version-cutover.md
+++ b/docs/operations/evaluator-version-cutover.md
@@ -1,46 +1,69 @@
 # Plan: the `evaluator_version` cutover (Phase 6 → the sentinel is retired)
 
-**Status: PLAN FOR REVIEW. No platform mutation is authorized by this document.** It resolves the
-open questions the cutover raises and proposes an exact procedure; execution is a separate,
-explicitly-authorized step once this plan and its two open decisions are approved.
+**Status: PLAN FOR REVIEW. No platform mutation is authorized by this document.** The three
+decisions the cutover turned on (D1–D3) are now **settled** (below); execution remains unauthorized
+until the §0 prerequisite code fixes, durable archive persistence, and the cross-cutover checks are
+in place.
 
 ## What the cutover is
 
 `build/declaration_version.py:111` pins `EVALUATOR_VERSION = "v0-no-repo-evaluator"` — a sentinel
-recording "scores are curator-recorded, not machine-derived." Phase 6 landed the
-repository-owned evaluator (the `evaluation.axis_*` scoring trace, deployed 2026-08-27). Retiring
-the sentinel — replacing it with a real evaluator version — is what this plan covers.
+recording "scores are curator-recorded, not machine-derived." Phase 6 landed the repository-owned
+evaluator (the `evaluation.axis_*` scoring trace, deployed 2026-08-27). Retiring the sentinel —
+replacing it with a real evaluator version — is what this plan covers.
 
 `declaration_version_id = f(source_git_sha, source_content_digest, evaluator_version)`
 (`build/declaration_version.py`). `evaluator_version` is folded into **every**
 `declaration_version_id`, and the id is **table-independent** — it depends only on the commit, the
 declaration content, and the evaluator version, not on which table carries it. So bumping
 `EVALUATOR_VERSION` re-keys every declaration-keyed table at once, and **rebuilding all candidates
-from one commit collapses them to a single new id** (see §3, §7).
+from one commit collapses them to a single new id** (§3, §7).
 
-## 1. The complete derived inventory of declaration-keyed tables
+## Settled decisions
+
+- **D1 — the new value and bump policy.** `evaluator_version = "v1-repo-openness-evaluator"`.
+  - **Bump** when evaluator *code* can change any canonical scoring-trace output for identical
+    declarations — a normalized fact, license resolution, a rule outcome, a disposition, or a final
+    score.
+  - **Do not bump** for rubric or source changes: those already move `source_content_digest`.
+  - **Do not bump** for behavior-preserving refactors *proven* by corpus-wide canonical equivalence.
+  - **No date-based versions** — `source_git_sha` already carries chronology; the evaluator version
+    names a behavior generation, not a time.
+- **D2 — preserve the observation snapshot.** Rebuild the two adoption candidates from the same
+  frozen Phase-2 baseline, holding `observation_snapshot_id = 9bd4d93a6fc6…`. See §4 for the precise
+  reason this matters (and what it does *not* do).
+- **D3 — leave `registry.axis_assessments` staged; exclude it from this cutover.** It has **no live
+  identity to re-key**. Including it would widen the cutover, require standing up a new publisher,
+  and deploy an unconsumed table. Note that "all tables share one id" is only a **cutover-moment
+  invariant**, not a durable property: any later refresh of any table from a newer commit mints
+  another declaration generation, because `source_git_sha` is part of the id. So its eventual first
+  deployment is handled independently, whenever it happens, and simply inherits the evaluator version
+  in force then.
+
+## 1. The declaration-keyed surface: 6 in the architecture, 5 in this cutover, 1 excluded
 
 Derived from `warehouse/assets.yaml` (every asset whose `grain` names `declaration_version_id`), not
-hand-listed — this is checkable and must be re-derived at execution time, not trusted from here:
+hand-listed:
 
-| Asset | Dataset | Publisher | State today |
+**Six declaration-keyed assets in the architecture:**
+
+| Asset | Dataset | Publisher | In this cutover? |
 |---|---|---|---|
-| `evaluation.product_adoption_measurements` | `evaluation` | `build/publish_evaluation.py` | active, deployed |
-| `evaluation.adoption_reconciliation` | `evaluation` | `build/publish_evaluation.py` | active, deployed |
-| `evaluation.axis_facts` | `evaluation` | `build/publish_scoring_trace.py` | active, deployed |
-| `evaluation.axis_rule_matches` | `evaluation` | `build/publish_scoring_trace.py` | active, deployed |
-| `evaluation.axis_results` | `evaluation` | `build/publish_scoring_trace.py` | active, deployed |
-| `registry.axis_assessments` | `registry` | `build/publish_axis_assessments`* (runbook `deploy-axis-assessments.md`) | **staged**, not deployed |
+| `evaluation.product_adoption_measurements` | `evaluation` | `build/publish_evaluation.py` | ✅ deployed |
+| `evaluation.adoption_reconciliation` | `evaluation` | `build/publish_evaluation.py` | ✅ deployed |
+| `evaluation.axis_facts` | `evaluation` | `build/publish_scoring_trace.py` | ✅ deployed |
+| `evaluation.axis_rule_matches` | `evaluation` | `build/publish_scoring_trace.py` | ✅ deployed |
+| `evaluation.axis_results` | `evaluation` | `build/publish_scoring_trace.py` | ✅ deployed |
+| `registry.axis_assessments` | `registry` | (none yet) | ❌ **staged, excluded (D3)** |
 
-\* `registry.axis_assessments` has no dedicated publisher yet (its runbook still describes the
-mechanics); it also keys on `declaration_version_id`. It is **staged** — no live table — so it is
-**not** part of the live atomic swap. Decision D3 below: deploy it in the same cutover (so the whole
-declaration-keyed surface shares one id from day one) or leave it staged and let it inherit the new
-evaluator whenever it first deploys. Recommended: deploy it in the same pass, for one coherent
-generation.
+**Five currently deployed** (`status: active` / `materialized: true`) are the cutover set. **One
+staged** asset is explicitly excluded — it has no live table to re-key.
 
-An execution-time assertion must re-run this derivation and fail if any declaration-keyed asset is
-absent from the cutover set — the cutover must cover the surface completely, or not run.
+**Runtime completeness assertion:** re-derive the declaration-keyed set at execution time and require
+the cutover to cover **every `active`/`materialized` declaration-keyed asset** — no more, no fewer.
+It must *not* force `staged` assets into service; a staged asset that is somehow marked
+active/materialized without being in the cutover set is the failure this catches, and a
+still-staged asset is simply outside the set. Cover the live surface completely, or do not run.
 
 ## 2. The current live generations (the real "old" IDs — not one global value)
 
@@ -50,35 +73,37 @@ Read live via `pyoso` on 2026-08-27:
 |---|---|---|
 | `product_adoption_measurements`, `adoption_reconciliation` | `232015a76ecc…` | `f012d85` |
 | `axis_facts`, `axis_rule_matches`, `axis_results` | `eb828b57b14d…` | `980250b` |
-| `registry.axis_assessments` | — (staged, no live table) | — |
 
 There are **two** live generations, because the eval tables and the trace tables were deployed from
-different commits. Any rollback or transition map must treat these as distinct old IDs (§7, §9).
+different commits. The rollback and transition map treat these as distinct old IDs (§7, §9).
+`registry.axis_assessments` has no live id (staged) and does not appear.
 
 ## 3. One clean cutover commit
 
 All candidates are built from a **single `main` commit** whose only material change is the
-`EVALUATOR_VERSION` bump (plus this plan and any prerequisite code fix from §0), over a **clean
-worktree**. Because the id is commit- and evaluator-scoped and table-independent, one commit + one
-new `evaluator_version` yields **one** new `declaration_version_id` shared by every table (given the
-snapshot decision in §4 holds the observation inputs fixed). This single id is the atomicity anchor
-and the cross-table invariant checked in §8.
+`EVALUATOR_VERSION` bump (plus this plan and the §0 prerequisite fixes), over a **clean worktree**.
+Because the id is commit- and evaluator-scoped and **table-independent**, one commit + one new
+`evaluator_version` yields **one** new `declaration_version_id` shared by every table in the cutover
+set. `observation_snapshot_id` does **not** enter `declaration_version_id`, so preserving the
+snapshot (D2) is not what makes the id shared — the single commit and single evaluator version are.
+What preserving the snapshot buys is separate and is covered in §4.
 
-## 4. Adoption tables: preserve the observation snapshot, do not refresh it
+## 4. What preserving the observation snapshot actually does (D2)
 
 `product_adoption_measurements` and `adoption_reconciliation` also key on `observation_snapshot_id`
-(currently `9bd4d93a6fc6`); the trace tables do not. **Recommendation: preserve** — rebuild the two
-adoption candidates from the same frozen Phase-2 baseline, so the cutover changes only
-`evaluator_version` (and `source_git_sha`), never the observation content. Refreshing from live
-`observations.product_adoption_current` would fold a data change into the same deploy and make the
-id transition impossible to attribute cleanly to the evaluator bump. **This is open decision D2** —
-confirm preserve, or state the deliberate reason to refresh and record the new snapshot id.
+(currently `9bd4d93a6fc6`); the trace tables do not, and `observation_snapshot_id` is **not** part of
+`declaration_version_id`. Preserving the snapshot therefore does not affect the shared id. What it
+does is hold the adoption **content** fixed: rebuilt from the same frozen baseline, the two adoption
+tables' rows are identical to what is deployed except for the identity columns — which is exactly
+what the semantic no-change invariant in §8 verifies. Refreshing from live
+`observations.product_adoption_current` would change adoption content in the same deploy and defeat
+that invariant, making the id transition impossible to attribute to the evaluator bump alone.
 
 ## 5. Handling the non-atomic interval
 
 Static models replace in place and are published sequentially, so mid-cutover some tables carry the
-new id and some the old. There is no release-scoped materialization yet (`releases.*` does not
-exist; atomicity is transitional per `migration-status.md`). Mitigations:
+new id and some the old. There is no release-scoped materialization yet (`releases.*` does not exist;
+atomicity is transitional per `migration-status.md`). Mitigations:
 
 - **Low blast radius today.** Nothing consumes these tables cross-generation on the platform: the
   Phase-4 gate is disabled and the Phase-7 retirement has not begun, so no live query joins an
@@ -86,70 +111,75 @@ exist; atomicity is transitional per `migration-status.md`). Mitigations:
 - **One session, fail-fast.** Run the whole cutover in a single maintainer session; each publisher
   already polls each run group to terminal `SUCCESS` and exits non-zero on the first failure, so a
   partial cutover stops loudly rather than silently half-swapping.
-- **Announced window.** Record the start/end and that mixed generations are expected in between.
-- **Post-swap invariant check** (§8, §10): after all deploys, assert every deployed declaration-keyed
-  table carries the *same* new id; a straggler means the swap did not complete.
+- **Announced window**, and a **post-swap invariant check** (§8, §10): after all deploys, assert
+  every deployed declaration-keyed table carries the *same* new id; a straggler means the swap did
+  not complete.
 
-## 6. Exact deployment order
+## 6. Deployment order
 
-From the cutover commit, after a full dry-run of every publisher:
+From the cutover commit, after a full dry-run of both publishers:
 
-1. **`registry.axis_assessments`** (only if D3 = deploy it) — registry dataset.
-2. **Scoring trace** — `build/publish_scoring_trace.py` (`axis_facts`, `axis_rule_matches`,
+1. **Scoring trace** — `build/publish_scoring_trace.py` (`axis_facts`, `axis_rule_matches`,
    `axis_results`).
-3. **Adoption evaluation** — `build/publish_evaluation.py` (`product_adoption_measurements`, then
+2. **Adoption evaluation** — `build/publish_evaluation.py` (`product_adoption_measurements`, then
    `adoption_reconciliation`, the order the publisher already uses because reconciliation reads
    measurements as candidate rows in-repo).
 
-Order is not forced by platform reads (the tables are independent static models), so it is chosen for
-legibility and so the most self-contained set (the trace) swaps first. Each publisher is serialized
-and SUCCESS-gated internally.
+**Deploy: trace → adoption.** Order is not forced by platform reads (the tables are independent
+static models); the most self-contained set (the trace) swaps first. Each publisher is serialized
+and SUCCESS-gated internally. `registry.axis_assessments` is not in this sequence (D3).
 
 ## 7. Old → new declaration-ID transition map
 
-The new id is not knowable until `EVALUATOR_VERSION` is chosen and the commit is made; the procedure
-captures it. The transition to record in the deploy note:
+The new id is not knowable until `EVALUATOR_VERSION` is bumped and the commit is made; the procedure
+captures it. `SELECT DISTINCT declaration_version_id` per table **before** (done above) and
+**after**; both old generations must map to the single `<new>` id, and no table may retain an old id.
 
 | Old generation | Tables | New id |
 |---|---|---|
 | `232015a76ecc…` | measurements, reconciliation | `<new>` (computed at the cutover commit) |
 | `eb828b57b14d…` | axis_facts, axis_rule_matches, axis_results | `<new>` |
-| — (staged) | registry.axis_assessments | `<new>` (if D3 = deploy) |
 
-Capture `SELECT DISTINCT declaration_version_id` per table **before** (done above) and **after**;
-both old generations must map to the single `<new>` id, and no table may retain an old id.
-
-## 8. Pre-flight: counts, schemas, hashes, cross-table invariants
+## 8. Pre-flight invariants: counts, schemas, single identity, and semantic no-change
 
 Before any upload, build every candidate at the cutover commit and assert:
 
 - **Row counts** match the builders: adoption 377 / 522 (from the preserved baseline); trace 2,284 /
-  2,734 / 522; `registry.axis_assessments` its builder's count if D3.
+  2,734 / 522.
 - **Schemas** equal each builder's `COLUMNS` (the publishers already gate this per file).
 - **Per-file authority** — `publish_scoring_trace` canonical-equivalence and `publish_evaluation`
   `validate_candidates` already prove each file is exactly its builder's output at HEAD.
-- **NEW cross-cutover invariant** — every candidate across all three publishers shares **one**
-  `declaration_version_id` and one `source_git_sha`. This is the check that the single-commit build
-  actually produced a single generation. It does not exist yet and must be added (a small script or
-  test run at execution time), because each publisher only validates its own files today.
-- **Hashes** — record the sha256 of every uploaded CSV in the deploy note (the publishers already
-  archive these in each receipt).
+- **Single-identity invariant (new).** Every candidate across both publishers shares **one**
+  `declaration_version_id` and one `source_git_sha`. This proves the single-commit build produced a
+  single generation. It does not exist yet and must be added (§0.2).
+- **Semantic no-change invariant (new, and the important one).** The cutover must change **identity
+  only** — not facts, rule matches, scores, routes, statuses, or reconciliation results. For each of
+  the five live tables, project out the fields expected to change — `declaration_version_id`,
+  `source_git_sha` where present, and any explicitly non-content build/deployment timestamp (e.g.
+  `evaluated_at` on the adoption tables; the exact non-content column set is enumerated per table at
+  execution time) — and require the **new candidate rows to equal the currently-deployed rows
+  canonically** (order-independent multiset). Any difference outside the projected-out identity
+  columns fails the cutover: it would mean the evaluator bump is smuggling a content change, which
+  D1's bump policy forbids without its own justified generation.
+- **Hashes** — record the sha256 of every uploaded CSV in the deploy note (the publishers archive
+  these in each receipt).
 
-## 9. Rollback — reverse-order, by archived bytes (with a real gap to close first)
+## 9. Rollback — reverse-order, by archived bytes (with real gaps to close first)
 
-Rollback re-uploads the **previous generation's archived bytes** in reverse deploy order
-(adoption → trace → registry), restoring the old ids. Each publisher archives the exact bytes it
-uploaded. **Two gaps must be closed before this is dependable for the cutover:**
+Rollback re-uploads the **previous generation's archived bytes** in reverse deploy order —
+**adoption → trace** — restoring the old ids. Each publisher archives the exact bytes it uploaded.
+**Two gaps must be closed before this is dependable for the cutover:**
 
-- **§0 archive-root bug** (below) — re-publishing from an archive via `--dir` currently nests a new
-  archive and does not update the canonical archive root.
-- **Archive persistence.** Archives live under `build/evaluation/…deployments/` and
-  `build/registry/…`, which are **git-ignored and per-session ephemeral**. In a fresh container the
-  prior archives do not exist, so rollback-by-bytes only works within the same session that deployed
-  — or from archives deliberately preserved. The cutover procedure must **retain the pre-cutover
-  archives** (the two current generations) and the cutover session's own archives somewhere durable,
-  or download the deployed bytes before overwriting them. This must be decided and wired before
-  execution; it is a genuine hole in the rollback story, not a formality.
+- **§0.1 archive-root bug** — re-publishing from an archive via `--dir` currently nests a new archive
+  and does not update the canonical archive root.
+- **Archive persistence.** Archives live under `build/evaluation/…deployments/`, which is
+  **git-ignored and per-session ephemeral**. In a fresh container the prior archives do not exist, so
+  rollback-by-bytes only works within the deploying session unless the archives are deliberately
+  retained. **Recommendation: durable immutable object storage, or release assets, with a recorded
+  SHA-256 for each archived file.** Ordinary CI artifacts, with finite retention, are **not
+  sufficient** for a rollback the cutover must be able to rely on. This is a separate prerequisite
+  from §0.1 and must be settled before execution: retain the two pre-cutover generations and the
+  cutover session's own archives durably, or download the deployed bytes before overwriting them.
 
 ## 10. Post-deploy verification and lockstep reconciliation
 
@@ -157,36 +187,33 @@ After the swap, in one reconciliation PR (mirroring the Unit-2 reconciliation):
 
 - `pyoso` read-back of every table: row counts and schemas unchanged from the candidates.
 - Assert the single shared new `declaration_version_id` across all deployed declaration-keyed tables
-  (the §8 invariant, now against the platform).
-- Update `assets.yaml` (`verified_at`, and note the new declaration generation), `migration-status.md`
-  (record the id transition table from §7; mark the sentinel retired), `data-architecture.md` §4.5
-  and the "Versioning identities" section (`evaluator_version` is now a real value, with the bump
-  policy from D1), and any `where-scores-live` / DAG counts the change touches.
+  in the cutover set (the §8 single-identity invariant, now against the platform).
+- Update `assets.yaml` (`verified_at`, note the new declaration generation), `migration-status.md`
+  (record the §7 transition table; mark the sentinel retired), `data-architecture.md` §4.5 and the
+  "Versioning identities" section (`evaluator_version` is now `v1-repo-openness-evaluator`, with the
+  D1 bump policy), and any `where-scores-live` / DAG counts the change touches.
 
-## Open decisions for the maintainer (blockers on execution)
+## §0 — prerequisite code fixes (no platform write; land and review before execution)
 
-- **D1 — the new `evaluator_version` value and bump policy.** Proposal: a monotonic string
-  `"v1-openness-<yyyymm>"` (e.g. `v1-openness-202608`) or a bare `"v1"`, with the policy: **bump when
-  the evaluator's scoring logic can change a result** — `build/check_rubric.py`'s ladder walk,
-  license resolution, or recipe interpretation — and *not* for unrelated code. Recorded in a short
-  note beside the constant, and each bump is its own cutover. Alternative considered: embed a hash of
-  the evaluator modules (auto-bumps, but noisy and opaque). **Maintainer picks the value and policy.**
-- **D2 — preserve vs refresh the observation snapshot** (§4). Recommended: preserve `9bd4d93a6fc6`.
-- **D3 — include `registry.axis_assessments`** in the cutover (§1). Recommended: yes, so the whole
-  declaration-keyed surface shares one generation; it needs its publisher wired first (§0).
+1. **Archive-root / deployment-occurrence.** Rework the archive mechanism in **both**
+   `build/publish_evaluation.py` and `build/publish_scoring_trace.py` so it:
+   - separates the read `--dir` (where candidates are read) from a fixed `--archive-root` (where the
+     durable archive lives);
+   - stores immutable content archives keyed by content/deployment identity;
+   - records each successful deployment **or rollback** as a distinct **append-only occurrence**;
+   - determines the current and prior live states from those **occurrences**, not from directory
+     modification times;
+   - **never nests** an archive when publishing from archived bytes;
+   - applies consistently across the evaluation and scoring-trace publishers.
+   Tests only; no platform mutation.
+2. **Cross-cutover identity + semantic no-change checks** (§8): a checkable step asserting all
+   candidates across both publishers share one `declaration_version_id` + `source_git_sha`, and that
+   each live table's candidate equals the deployed rows canonically once identity/timestamp columns
+   are projected out.
 
-## §0 — prerequisite code fixes (no platform write; land before execution)
+(There is deliberately **no** `registry.axis_assessments` publisher item here — D3 excludes it from
+the cutover; its eventual first deployment is a separate, independent step.)
 
-1. **Archive-root / deployment-occurrence** (already flagged in `publish_scoring_trace.py` and
-   shared with `publish_evaluation.py`): decouple the archive root from the read `--dir`. The archive
-   must always be written to (and `latest_archive` read from) a fixed canonical root, so
-   re-publishing a prior archive via `--dir` neither nests a new archive nor leaves the system
-   claiming the superseded deployment is the latest live state. Add tests: publishing from an archive
-   directory writes to the canonical root (or records a rollback occurrence there), and never inside
-   the read directory.
-2. **Cross-cutover identity invariant** (§8): a small checkable step asserting all candidates across
-   the three publishers share one `declaration_version_id` + `source_git_sha`.
-3. **(If D3)** a dedicated `registry.axis_assessments` publisher mirroring the others, or a
-   documented manual path, before it can join the cutover.
-
-Each of these is a normal reviewed code PR with tests, containing no platform mutation.
+Each of these is a normal reviewed code PR with tests, containing no platform mutation. The evaluator
+cutover itself stays unauthorized until §0.1, §0.2, and durable archive persistence (§9) are all in
+place.


### PR DESCRIPTION
## What

A written plan (`docs/operations/evaluator-version-cutover.md`) for retiring the `EVALUATOR_VERSION` sentinel (`v0-no-repo-evaluator`) — the corpus-wide re-key Phase 6 deferred. **No platform mutation and no code change here — plan only.** The three decisions the cutover turned on are now **settled**; execution stays unauthorized until the §0 code fixes, durable archive persistence, and the cross-cutover checks are in place.

## Settled decisions

- **D1** — `evaluator_version = "v1-repo-openness-evaluator"`. Bump only when evaluator *code* can change a canonical trace output (fact / license resolution / rule outcome / disposition / score); **not** for rubric/source changes (those move `source_content_digest`); **not** for behavior-preserving refactors proven by canonical equivalence; **no date-based versions** (the Git SHA already carries chronology).
- **D2** — preserve `observation_snapshot_id = 9bd4d93a6fc6…`.
- **D3** — leave `registry.axis_assessments` **staged and excluded**; it has no live identity to re-key, and "all tables share one id" is a cutover-moment invariant, not a durable property (any later refresh from a newer commit mints another generation via the Git SHA).

## Key findings (grounded in live state)

- The declaration-keyed surface is **6 assets in the architecture, 5 deployed in this cutover, 1 staged excluded** — derived from `assets.yaml` grains; the completeness assertion covers every `active`/`materialized` declaration-keyed asset and never forces a staged asset into service.
- **Two live generations, not one global old id**: `232015a76ecc` (measurements + reconciliation, cut at `f012d85`) and `eb828b57b14d` (the three `axis_*`, cut at `980250b`).
- `declaration_version_id` is table-independent, so one cutover commit + one new evaluator version collapses them to a single new id — the atomicity anchor.

## Corrections applied since the first draft

Decisions settled (three, not open); the 6/5/1 distinction and a completeness assertion that never forces staged into service; **deploy trace → adoption, rollback adoption → trace** (`axis_assessments` removed from both); corrected §3 (the snapshot is *not* part of the id — the single commit + evaluator version are); and a new **semantic no-change invariant** — each live table's new candidate must equal the deployed rows canonically once `declaration_version_id`/`source_git_sha`/non-content timestamps are projected out, so the cutover changes **identity only**.

## Two prerequisites before rollback can be trusted

- **§0.1 archive-root fix** (both publishers): separate `--dir` from a fixed `--archive-root`; immutable content archives keyed by identity; each deploy/rollback an append-only **occurrence**; live state read from occurrences, not directory mtime; never nest when publishing from archived bytes. Tests only.
- **Archive persistence** (§9): durable immutable object storage or release assets with recorded SHA-256s — finite-retention CI artifacts are not sufficient.

## Next steps (agreed)

Merge this plan → implement the §0.1 archive-root fix as the next reviewed code PR (tests only, no platform write). The cutover itself stays unauthorized until §0.1, the §0.2 checks, and durable archive persistence are all in place.

## Checklist

- [x] `uv run python -m build.validate` prints `0 error(s)`
- [ ] N/A: no new/changed scores (planning doc only)
- [x] I did not edit `build/notebook_data.json` or `notebooks/ai-stack-map.py`
- [ ] N/A: no product/roster changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)