### PR TITLE
Content-addressed deployment archive: explicit operations, atomic staging (cutover prerequisite §0.1)

### DIFF
--- a/build/deployment_archive.py
+++ b/build/deployment_archive.py
@@ -172,6 +172,53 @@ def artifact_receipt(archive_root: Path, aid: str) -> dict:
     return json.loads((artifact_dir(archive_root, aid) / RECEIPT).read_text(encoding="utf-8"))
 
 
+def verified_rollback_provenance(
+    archive_root: Path,
+    aid: str,
+    expected_names: set[str],
+    recompute_receipt,
+    recompute_deployment_id,
+) -> tuple[dict, str]:
+    """Gate a rollback: return `(tables, deployment_id)` reconstructed from the VERIFIED archived
+    bytes, or raise.
+
+    `SHA256SUMS` covers only the data files, NOT `receipt.json`, so `receipt.json` cannot be trusted
+    on its own — a tampered `deployment_id`, row count, schema, or `all_null_columns` would otherwise
+    ride a rollback into generation identity and deployed-state verification. This:
+
+    1. verifies the data files against their recorded hashes (`verify_artifact`);
+    2. requires the manifest's filename set to equal the publisher's expected tables — no missing and
+       no unexpected files;
+    3. recomputes the provenance (`recompute_receipt`) and the `deployment_id`
+       (`recompute_deployment_id`) FROM those verified bytes and requires each to equal what
+       `receipt.json` claims, plus the stored `artifact_id` to equal `aid`.
+
+    The returned values are the reconstructed ones, so callers use provenance derived from bytes, not
+    from the (unhashed) receipt.
+    """
+    verify_artifact(archive_root, aid)
+    adir = artifact_dir(archive_root, aid)
+    names = set(read_manifest(adir))
+    if names != set(expected_names):
+        raise RuntimeError(
+            f"artifact {aid} manifest names {sorted(names)} do not equal the expected files "
+            f"{sorted(expected_names)} (missing or unexpected files)"
+        )
+    stored = artifact_receipt(archive_root, aid)
+    if stored.get("artifact_id") != aid:
+        raise RuntimeError(f"receipt artifact_id {stored.get('artifact_id')!r} does not equal {aid}")
+    tables = recompute_receipt(adir)
+    if tables != stored.get("tables"):
+        raise RuntimeError(f"receipt tables do not match the archived bytes for {aid} (tampered receipt?)")
+    deployment_id = recompute_deployment_id(adir)
+    if deployment_id != stored.get("deployment_id"):
+        raise RuntimeError(
+            f"receipt deployment_id {stored.get('deployment_id')!r} does not match the archived bytes "
+            f"({deployment_id!r}) for {aid} (tampered receipt?)"
+        )
+    return tables, deployment_id
+
+
 # --- the append-only occurrence log ----------------------------------------------
 
 

--- a/build/deployment_archive.py
+++ b/build/deployment_archive.py
@@ -1,0 +1,102 @@
+"""The durable, append-only record of what each maintainer publisher deployed — the rollback record.
+
+A static-model publication REPLACES the table in place; the platform keeps no prior-revision list,
+so the only way to roll a table back is to re-upload the exact bytes of a previous deployment. This
+module is that record, shared by `build/publish_evaluation.py` and `build/publish_scoring_trace.py`
+so the two cannot drift.
+
+Two ideas are kept deliberately separate — the conflation of them was the bug this module fixes:
+
+- **Artifact identity.** An immutable per-deployment directory named by the `deployment_id` (the
+  declaration/observation identities the bytes carry). Written **once** and never overwritten — the
+  same identity always names the same bytes.
+- **Deployment occurrence.** An append-only log (`occurrences.jsonl`) of what happened — one line per
+  successful `deploy` or `rollback`, each naming a `deployment_id`. The CURRENT live state is the
+  last occurrence's `deployment_id`; a rollback re-points it at an earlier identity by appending an
+  occurrence, **without** touching the immutable directory. Occurrences — not directory modification
+  times — decide what is live, so "latest" cannot be spoofed by a filesystem touch, and restoring an
+  older archive is a first-class recorded event rather than an out-of-band copy.
+
+The archive root is INDEPENDENT of where candidates are read (a publisher's `--dir`). Publishing from
+archived bytes (`--dir <an-archive>`) still writes its occurrence to the fixed `--archive-root`, so an
+archive is never nested inside another and the canonical root's notion of "live" is always updated.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+OCCURRENCES = "occurrences.jsonl"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def archive_path(archive_root: Path, deployment_id: str) -> Path:
+    """The immutable directory that holds (or will hold) the bytes for this deployment identity."""
+    return archive_root / deployment_id
+
+
+def occurrences(archive_root: Path) -> list[dict]:
+    """Every recorded deploy/rollback, oldest first. Empty (and no directory created) if none yet."""
+    log = archive_root / OCCURRENCES
+    if not log.exists():
+        return []
+    return [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def current_live(archive_root: Path) -> str | None:
+    """The `deployment_id` of the last recorded occurrence — what is live now — or None if none."""
+    log = occurrences(archive_root)
+    return log[-1]["deployment_id"] if log else None
+
+
+def current_live_archive(archive_root: Path) -> Path | None:
+    """The archive directory of the currently-live deployment, or None. Derived from the occurrence
+    log, never from directory mtimes."""
+    live = current_live(archive_root)
+    return archive_path(archive_root, live) if live is not None else None
+
+
+def record_occurrence(archive_root: Path, kind: str, deployment_id: str, at: str | None = None) -> None:
+    """Append one occurrence line. Creates the archive root on first write; never truncates."""
+    if kind not in ("deploy", "rollback"):
+        raise ValueError(f"occurrence kind must be 'deploy' or 'rollback', got {kind!r}")
+    archive_root.mkdir(parents=True, exist_ok=True)
+    line = json.dumps({"kind": kind, "deployment_id": deployment_id, "at": at or _now()}, sort_keys=True)
+    with (archive_root / OCCURRENCES).open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+
+
+def store(
+    archive_root: Path,
+    deployment_id: str,
+    files: dict[str, Path],
+    receipt: dict,
+    at: str | None = None,
+) -> tuple[Path, str]:
+    """Archive a deployment's bytes and record it as an occurrence. Returns (archive_dir, kind).
+
+    A FRESH identity (`archive_path` does not yet exist) is a **deploy**: the immutable directory is
+    created and the CSVs + a completed receipt are copied in. An identity that is ALREADY archived is
+    a **rollback** — the very case of re-uploading a previous deployment's bytes — so the directory is
+    left untouched (it already holds exactly these bytes) and only a rollback occurrence is appended.
+    Either way the occurrence log is what advances "live", so publishing from an old archive updates
+    the canonical root rather than nesting a new archive inside the bytes being restored.
+    """
+    target = archive_path(archive_root, deployment_id)
+    kind = "rollback" if target.exists() else "deploy"
+    if kind == "deploy":
+        target.mkdir(parents=True)
+        for name, path in files.items():
+            shutil.copy2(path, target / name)
+        (target / "receipt.json").write_text(
+            json.dumps({"deployment_id": deployment_id, "tables": receipt}, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+    record_occurrence(archive_root, kind, deployment_id, at)
+    return target, kind

--- a/build/deployment_archive.py
+++ b/build/deployment_archive.py
@@ -1,44 +1,178 @@
-"""The durable, append-only record of what each maintainer publisher deployed — the rollback record.
+"""The durable, content-addressed record of what each maintainer publisher deployed — the rollback record.
 
-A static-model publication REPLACES the table in place; the platform keeps no prior-revision list,
-so the only way to roll a table back is to re-upload the exact bytes of a previous deployment. This
+A static-model publication REPLACES the table in place; the platform keeps no prior-revision list, so
+the only way to roll a table back is to re-upload the exact bytes of a previous deployment. This
 module is that record, shared by `build/publish_evaluation.py` and `build/publish_scoring_trace.py`
 so the two cannot drift.
 
-Two ideas are kept deliberately separate — the conflation of them was the bug this module fixes:
+Three integrity properties it exists to guarantee:
 
-- **Artifact identity.** An immutable per-deployment directory named by the `deployment_id` (the
-  declaration/observation identities the bytes carry). Written **once** and never overwritten — the
-  same identity always names the same bytes.
-- **Deployment occurrence.** An append-only log (`occurrences.jsonl`) of what happened — one line per
-  successful `deploy` or `rollback`, each naming a `deployment_id`. The CURRENT live state is the
-  last occurrence's `deployment_id`; a rollback re-points it at an earlier identity by appending an
-  occurrence, **without** touching the immutable directory. Occurrences — not directory modification
-  times — decide what is live, so "latest" cannot be spoofed by a filesystem touch, and restoring an
-  older archive is a first-class recorded event rather than an out-of-band copy.
+- **Content addressing, not semantic identity.** A `deployment_id` (declaration + observation
+  generation) is NOT a byte identity: the same generation can serialize to different bytes — e.g. a
+  regenerated `evaluated_at` — so it cannot decide whether two deployments are the same artifact. The
+  artifact is addressed by **`artifact_id` = SHA-256 over the canonical `filename → file-sha256`
+  manifest**, and stored under `artifacts/<artifact_id>/`. Every occurrence records BOTH ids, so a
+  new byte-set under an unchanged generation is a distinct artifact and can never be mistaken for one
+  already archived.
 
-The archive root is INDEPENDENT of where candidates are read (a publisher's `--dir`). Publishing from
-archived bytes (`--dir <an-archive>`) still writes its occurrence to the fixed `--archive-root`, so an
-archive is never nested inside another and the canonical root's notion of "live" is always updated.
+- **Explicit operations, never inferred.** Whether a publish is a `deploy` or a `rollback` is stated
+  by the caller, not guessed from whether an archive directory exists. A normal publish is a
+  `deploy`; a `rollback` names an already-archived `artifact_id`, verifies its hashes, and re-uploads
+  it. Re-deploying the currently-live artifact is still a `deploy`. Occurrences carry
+  `operation`, `deployment_id`, `artifact_id`, `previous_artifact_id`, and a timestamp.
+
+- **Atomic artifact, occurrence last.** `ensure_artifact` writes through a staging directory and
+  atomically renames it into place only after every file + receipt + `SHA256SUMS` is written, so an
+  interrupted copy never leaves a directory that verification would accept. The artifact is persisted
+  BEFORE the platform mutation; the occurrence is appended ONLY after the deployed state is verified.
+  An unreferenced staged artifact after a failed deploy is harmless; an occurrence claiming the wrong
+  live state is not.
+
+The archive root is INDEPENDENT of where candidates are read (a publisher's `--dir`), so publishing
+from archived bytes writes its occurrence to the fixed `--archive-root` and never nests. "Live" is
+read from the occurrence log, never from directory modification times.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 
+ARTIFACTS_DIR = "artifacts"
 OCCURRENCES = "occurrences.jsonl"
+SHA256SUMS = "SHA256SUMS"
+RECEIPT = "receipt.json"
+_STAGING_PREFIX = ".staging-"
 
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def archive_path(archive_root: Path, deployment_id: str) -> Path:
-    """The immutable directory that holds (or will hold) the bytes for this deployment identity."""
-    return archive_root / deployment_id
+# --- content addressing ----------------------------------------------------------
+
+
+def file_sha256(path: Path) -> str:
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def manifest(files: dict[str, Path]) -> dict[str, str]:
+    """The `filename → sha256` map over the deployed files — the byte identity of a deployment."""
+    return {name: file_sha256(path) for name, path in sorted(files.items())}
+
+
+def _manifest_digest(m: dict[str, str]) -> str:
+    return hashlib.sha256(json.dumps(m, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def artifact_id(files: dict[str, Path]) -> str:
+    """SHA-256 over the canonical `filename → sha256` manifest.
+
+    Two serializations that differ in any byte (a regenerated `evaluated_at`, a reordered row) get
+    DIFFERENT artifact_ids even under the same `deployment_id`, so a new byte-set is never mistaken
+    for one already archived.
+    """
+    return _manifest_digest(manifest(files))
+
+
+def artifacts_root(archive_root: Path) -> Path:
+    return archive_root / ARTIFACTS_DIR
+
+
+def artifact_dir(archive_root: Path, aid: str) -> Path:
+    return artifacts_root(archive_root) / aid
+
+
+def _sha256sums_text(m: dict[str, str]) -> str:
+    # `sha256␠␠name`, sorted — the familiar coreutils SHA256SUMS shape.
+    return "".join(f"{sha}  {name}\n" for name, sha in sorted(m.items()))
+
+
+def read_manifest(adir: Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for line in (adir / SHA256SUMS).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        sha, name = line.split("  ", 1)
+        out[name] = sha
+    return out
+
+
+def verify_artifact(archive_root: Path, aid: str) -> None:
+    """Raise unless the archived artifact is complete and every byte matches its recorded hash.
+
+    Confirms the directory exists, `SHA256SUMS` is present, the manifest hashes back to `aid` (the
+    directory name is its own content address), and each listed file's live sha256 equals the record.
+    Used to gate a rollback (`rollback with altered bytes must be rejected`) and to make
+    `ensure_artifact` idempotent.
+    """
+    adir = artifact_dir(archive_root, aid)
+    if not adir.is_dir():
+        raise RuntimeError(f"artifact {aid} is not archived at {adir}")
+    if not (adir / SHA256SUMS).exists():
+        raise RuntimeError(f"artifact {aid} has no {SHA256SUMS} — not a complete archive")
+    recorded = read_manifest(adir)
+    if _manifest_digest(recorded) != aid:
+        raise RuntimeError(f"artifact {aid}: {SHA256SUMS} does not hash to the artifact id")
+    for name, sha in recorded.items():
+        f = adir / name
+        if not f.exists():
+            raise RuntimeError(f"artifact {aid} is missing file {name}")
+        actual = file_sha256(f)
+        if actual != sha:
+            raise RuntimeError(f"artifact {aid} file {name} hash mismatch: {actual} != recorded {sha}")
+
+
+def ensure_artifact(archive_root: Path, files: dict[str, Path], receipt: dict, deployment_id: str) -> str:
+    """Content-address and persist the artifact bytes atomically; return its `artifact_id`.
+
+    Idempotent: an artifact already present is verified and left exactly as it is. A fresh artifact is
+    written through a staging directory (`artifacts/.staging-<id>/`) and renamed into place with a
+    single atomic `os.replace` only after every CSV, the receipt, and `SHA256SUMS` are written — so an
+    interrupted write leaves at most an ignored staging directory, never a directory that
+    `verify_artifact` would accept. Persist this BEFORE mutating the platform; record the occurrence
+    only after the deployed state verifies.
+    """
+    aid = artifact_id(files)
+    target = artifact_dir(archive_root, aid)
+    if target.exists():
+        verify_artifact(archive_root, aid)
+        return aid
+    artifacts_root(archive_root).mkdir(parents=True, exist_ok=True)
+    staging = artifacts_root(archive_root) / f"{_STAGING_PREFIX}{aid}"
+    if staging.exists():
+        shutil.rmtree(staging)  # discard a prior interrupted attempt and redo cleanly
+    staging.mkdir()
+    for name, path in files.items():
+        shutil.copy2(path, staging / name)
+    (staging / RECEIPT).write_text(
+        json.dumps(
+            {"deployment_id": deployment_id, "artifact_id": aid, "tables": receipt},
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (staging / SHA256SUMS).write_text(_sha256sums_text(manifest(files)), encoding="utf-8")
+    os.replace(staging, target)  # atomic rename within artifacts/ — the archive appears all-at-once
+    return aid
+
+
+def artifact_files(archive_root: Path, aid: str) -> dict[str, Path]:
+    """The archived data files (everything the manifest lists) — what a rollback re-uploads."""
+    adir = artifact_dir(archive_root, aid)
+    return {name: adir / name for name in read_manifest(adir)}
+
+
+def artifact_receipt(archive_root: Path, aid: str) -> dict:
+    return json.loads((artifact_dir(archive_root, aid) / RECEIPT).read_text(encoding="utf-8"))
+
+
+# --- the append-only occurrence log ----------------------------------------------
 
 
 def occurrences(archive_root: Path) -> list[dict]:
@@ -49,54 +183,38 @@ def occurrences(archive_root: Path) -> list[dict]:
     return [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines() if line.strip()]
 
 
-def current_live(archive_root: Path) -> str | None:
-    """The `deployment_id` of the last recorded occurrence — what is live now — or None if none."""
+def current_live(archive_root: Path) -> dict | None:
+    """The last recorded occurrence — what is live now — or None. From the log, never from mtimes."""
     log = occurrences(archive_root)
-    return log[-1]["deployment_id"] if log else None
+    return log[-1] if log else None
 
 
-def current_live_archive(archive_root: Path) -> Path | None:
-    """The archive directory of the currently-live deployment, or None. Derived from the occurrence
-    log, never from directory mtimes."""
+def current_live_artifact_id(archive_root: Path) -> str | None:
     live = current_live(archive_root)
-    return archive_path(archive_root, live) if live is not None else None
+    return live["artifact_id"] if live else None
 
 
-def record_occurrence(archive_root: Path, kind: str, deployment_id: str, at: str | None = None) -> None:
-    """Append one occurrence line. Creates the archive root on first write; never truncates."""
-    if kind not in ("deploy", "rollback"):
-        raise ValueError(f"occurrence kind must be 'deploy' or 'rollback', got {kind!r}")
+def record_occurrence(
+    archive_root: Path,
+    operation: str,
+    deployment_id: str,
+    artifact_id: str,
+    previous_artifact_id: str | None,
+    at: str | None = None,
+) -> None:
+    """Append one occurrence. `operation` is the caller's explicit choice, never inferred."""
+    if operation not in ("deploy", "rollback"):
+        raise ValueError(f"operation must be 'deploy' or 'rollback', got {operation!r}")
     archive_root.mkdir(parents=True, exist_ok=True)
-    line = json.dumps({"kind": kind, "deployment_id": deployment_id, "at": at or _now()}, sort_keys=True)
+    line = json.dumps(
+        {
+            "operation": operation,
+            "deployment_id": deployment_id,
+            "artifact_id": artifact_id,
+            "previous_artifact_id": previous_artifact_id,
+            "at": at or _now(),
+        },
+        sort_keys=True,
+    )
     with (archive_root / OCCURRENCES).open("a", encoding="utf-8") as handle:
         handle.write(line + "\n")
-
-
-def store(
-    archive_root: Path,
-    deployment_id: str,
-    files: dict[str, Path],
-    receipt: dict,
-    at: str | None = None,
-) -> tuple[Path, str]:
-    """Archive a deployment's bytes and record it as an occurrence. Returns (archive_dir, kind).
-
-    A FRESH identity (`archive_path` does not yet exist) is a **deploy**: the immutable directory is
-    created and the CSVs + a completed receipt are copied in. An identity that is ALREADY archived is
-    a **rollback** — the very case of re-uploading a previous deployment's bytes — so the directory is
-    left untouched (it already holds exactly these bytes) and only a rollback occurrence is appended.
-    Either way the occurrence log is what advances "live", so publishing from an old archive updates
-    the canonical root rather than nesting a new archive inside the bytes being restored.
-    """
-    target = archive_path(archive_root, deployment_id)
-    kind = "rollback" if target.exists() else "deploy"
-    if kind == "deploy":
-        target.mkdir(parents=True)
-        for name, path in files.items():
-            shutil.copy2(path, target / name)
-        (target / "receipt.json").write_text(
-            json.dumps({"deployment_id": deployment_id, "tables": receipt}, indent=2, sort_keys=True),
-            encoding="utf-8",
-        )
-    record_occurrence(archive_root, kind, deployment_id, at)
-    return target, kind

--- a/build/publish_evaluation.py
+++ b/build/publish_evaluation.py
@@ -24,18 +24,20 @@ rejected here rather than published.
 plan and perform NO mutation and NO local write. The only filesystem write this tool makes is the
 immutable deployment archive, and only after a real, successful upload.
 
-## Rollback is by BYTES — an immutable archive of what was deployed
+## Rollback is by BYTES — an immutable archive keyed by identity, live-state from an occurrence log
 
 A static-model publication REPLACES the table in place; the platform exposes no prior-revision list,
 and `observations.product_adoption_current` may have changed since, so regenerating from an old
 commit does not reproduce a previous table. So after a successful deployment this tool archives the
 exact bytes it uploaded, plus a completed receipt (row counts, column schema, SHA-256), under an
-immutable per-deployment directory `build/evaluation/deployments/<deployment_id>/` — keyed on the
-declaration and observation identities. It REFUSES to overwrite an existing archive (a deployment id
-is written once). To roll back a later bad deployment, re-run this tool pointed at the PRIOR
-deployment archive; before deploying, the tool prints that prior archive as the rollback target.
-The candidate CSVs under `build/evaluation/` are never the rollback record — only a completed
-deployment archive is.
+immutable per-deployment directory `<archive-root>/<deployment_id>/` — keyed on the declaration and
+observation identities and written once. The archive root (`--archive-root`, default
+`build/evaluation/deployments/`) is independent of `--dir`, so re-publishing from an archive never
+nests. What is "live" is read from an append-only occurrence log, not directory mtimes: a fresh
+identity records a `deploy`; re-uploading a prior archive (`--dir <that-archive>`) records a
+`rollback` without rewriting the immutable bytes. Before deploying, the tool prints the currently-live
+archive as the rollback target. The mechanism is `build/deployment_archive.py`, shared with the
+scoring-trace publisher. The candidate CSVs under `build/evaluation/` are never the rollback record.
 
 Environment:
     OSO_API_KEY   required (except for --plan)
@@ -54,12 +56,11 @@ from __future__ import annotations
 import argparse
 import csv
 import hashlib
-import json
 import os
-import shutil
 import sys
 from pathlib import Path
 
+from build import deployment_archive as archive
 from build.adoption_measurements import COLUMNS as MEASUREMENTS_COLUMNS
 from build.adoption_reconciliation import COLUMNS as RECONCILIATION_COLUMNS
 from build.publish_registry import (
@@ -78,11 +79,9 @@ from build.publish_registry import (
 ROOT = Path(__file__).resolve().parents[1]
 OUT_DIR = ROOT / "build" / "evaluation"
 DEFAULT_DATASET = "evaluation"
-
-
-def deployments_dir(out_dir: Path) -> Path:
-    """Where completed, immutable deployment archives live — beside the candidate CSVs."""
-    return out_dir / "deployments"
+# The durable archive root — the rollback record — is independent of `--dir` (where candidates are
+# read), so publishing from an archive never nests a new archive inside it. See build/deployment_archive.py.
+DEFAULT_ARCHIVE_ROOT = OUT_DIR / "deployments"
 
 # table -> (csv basename, expected header columns). The header is exactly the builder's COLUMNS.
 EVAL_TABLES: tuple[str, ...] = ("product_adoption_measurements", "adoption_reconciliation")
@@ -204,36 +203,16 @@ def deployment_id(out_dir: Path = OUT_DIR) -> str:
     return f"{dvid[:12]}-{osid[:12]}"
 
 
-def archive_deployment(out_dir: Path, receipt: dict) -> Path:
-    """Copy the just-deployed CSVs + completed receipt into an immutable per-deployment directory.
-
-    Refuses to overwrite an existing archive: a deployment id is written exactly once, so the record
-    of what was live cannot be clobbered by a later (possibly failed) publish.
-    """
-    target = deployments_dir(out_dir) / deployment_id(out_dir)
-    if target.exists():
-        raise RuntimeError(
-            f"deployment archive {target} already exists — a deployment id is immutable and is "
-            f"never overwritten. If you are re-publishing identical bytes, the previous archive "
-            f"already records them; if not, the identities would have changed."
-        )
-    target.mkdir(parents=True)
-    for table in EVAL_TABLES:
-        shutil.copy2(out_dir / f"{table}.csv", target / f"{table}.csv")
-    (target / "receipt.json").write_text(
-        json.dumps({"deployment_id": target.name, "tables": receipt}, indent=2, sort_keys=True),
-        encoding="utf-8",
-    )
-    return target
+def archived_files(out_dir: Path = OUT_DIR) -> dict[str, Path]:
+    """The candidate files to archive, keyed by their archived name."""
+    return {f"{table}.csv": out_dir / f"{table}.csv" for table in EVAL_TABLES}
 
 
-def latest_archive(out_dir: Path) -> Path | None:
-    """The most recently written deployment archive, if any — the rollback target for the next deploy."""
-    root = deployments_dir(out_dir)
-    if not root.exists():
-        return None
-    archives = [p for p in root.iterdir() if p.is_dir() and (p / "receipt.json").exists()]
-    return max(archives, key=lambda p: p.stat().st_mtime) if archives else None
+# The immutable per-deployment archive and the append-only occurrence log that decides what is live
+# both live in build/deployment_archive.py, shared with build/publish_scoring_trace.py so the two
+# publishers cannot drift. `deployment_id` above names the archive directory; `archive.store` writes
+# it (a fresh identity) or records a rollback (an identity already archived), and `archive.current_live_archive`
+# reads the live state from the occurrence log rather than directory mtimes.
 
 
 # A run request is only ACCEPTED synchronously; materialization happens asynchronously, so the
@@ -349,7 +328,10 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--plan", action="store_true", help="validate + print the plan; no network, no creds, no write")
     parser.add_argument("--dry-run", action="store_true", help="validate + resolve ids read-only; no mutation, no write")
-    parser.add_argument("--dir", type=Path, default=OUT_DIR)
+    parser.add_argument("--dir", type=Path, default=OUT_DIR, help="where candidate CSVs are read")
+    parser.add_argument("--archive-root", type=Path, default=DEFAULT_ARCHIVE_ROOT,
+                        help="the durable archive + occurrence log (independent of --dir, so publishing "
+                             "from an archive never nests)")
     args = parser.parse_args()
 
     dataset_name = os.environ.get("OSO_DATASET", DEFAULT_DATASET)
@@ -380,7 +362,7 @@ def main() -> int:
               file=sys.stderr)
         return 2
 
-    rollback_target = latest_archive(args.dir)
+    rollback_target = archive.current_live_archive(args.archive_root)
     if rollback_target is not None:
         print(f"rollback target if this deploy is bad: {rollback_target}")
 
@@ -445,9 +427,10 @@ def main() -> int:
             print(f"  ! {mismatch}", file=sys.stderr)
         return 2
 
-    archive = archive_deployment(args.dir, receipt)
-    print(f"\nevery load run SUCCESS and deployed data verified; archived this deployment (immutable) at "
-          f"{archive} — the rollback target for the next deploy")
+    target, kind = archive.store(args.archive_root, deployment_id(args.dir), archived_files(args.dir), receipt)
+    verb = "archived this deployment (immutable)" if kind == "deploy" else "recorded a rollback to the archived deployment"
+    print(f"\nevery load run SUCCESS and deployed data verified; {verb} at "
+          f"{target} — now the live state in {args.archive_root}")
     return 0
 
 

--- a/build/publish_evaluation.py
+++ b/build/publish_evaluation.py
@@ -24,20 +24,22 @@ rejected here rather than published.
 plan and perform NO mutation and NO local write. The only filesystem write this tool makes is the
 immutable deployment archive, and only after a real, successful upload.
 
-## Rollback is by BYTES — an immutable archive keyed by identity, live-state from an occurrence log
+## Rollback is by BYTES — a content-addressed archive, live-state from an occurrence log
 
 A static-model publication REPLACES the table in place; the platform exposes no prior-revision list,
 and `observations.product_adoption_current` may have changed since, so regenerating from an old
-commit does not reproduce a previous table. So after a successful deployment this tool archives the
-exact bytes it uploaded, plus a completed receipt (row counts, column schema, SHA-256), under an
-immutable per-deployment directory `<archive-root>/<deployment_id>/` — keyed on the declaration and
-observation identities and written once. The archive root (`--archive-root`, default
-`build/evaluation/deployments/`) is independent of `--dir`, so re-publishing from an archive never
-nests. What is "live" is read from an append-only occurrence log, not directory mtimes: a fresh
-identity records a `deploy`; re-uploading a prior archive (`--dir <that-archive>`) records a
-`rollback` without rewriting the immutable bytes. Before deploying, the tool prints the currently-live
-archive as the rollback target. The mechanism is `build/deployment_archive.py`, shared with the
-scoring-trace publisher. The candidate CSVs under `build/evaluation/` are never the rollback record.
+commit does not reproduce a previous table. So a successful deploy persists the exact bytes it
+uploaded — content-addressed by `artifact_id` (SHA-256 over the file manifest), so a regenerated
+`evaluated_at` is a DISTINCT artifact under the same `deployment_id` and is never confused with one
+already archived — plus a receipt and `SHA256SUMS`, under `<archive-root>/artifacts/<artifact_id>/`.
+The archive root (`--archive-root`, default `build/evaluation/deployments/`) is independent of
+`--dir`, so re-publishing from an archive never nests. What is "live" is read from an append-only
+occurrence log (each line: operation, `deployment_id`, `artifact_id`, `previous_artifact_id`,
+timestamp), not directory mtimes. The operation is EXPLICIT: a normal publish records a `deploy`;
+`--rollback <artifact_id>` re-uploads an already-archived artifact after verifying its recorded
+hashes and records a `rollback`. The bytes are persisted BEFORE the platform mutation and the
+occurrence is appended only AFTER the deployed state verifies. The mechanism is
+`build/deployment_archive.py`, shared with the scoring-trace publisher.
 
 Environment:
     OSO_API_KEY   required (except for --plan)
@@ -324,33 +326,98 @@ def resolve_evaluation_dataset(name: str, org_id: str, token: str, create: bool)
     return created["createDataset"]["dataset"]["id"]
 
 
+def materialize(dataset_id, models, tables, src_dir, token, dataset_name, receipt, mismatches_fn) -> int:
+    """Upload each table, request+await ONE run group per model (serialized, run-group-bound,
+    fail-fast), then verify the deployed row count/schema via pyoso. Returns 0 iff every model
+    reached terminal SUCCESS and the deployed data matches; nonzero otherwise. Shared by the deploy
+    and rollback paths, and (imported) by the scoring-trace publisher, so the sequence cannot drift.
+
+    `CreateStaticModelRunRequestInput` takes (datasetId, staticModelId), one model per request;
+    naming N models fans out into N runs and returns one run group that cannot certify its siblings,
+    and the sibling loads race to create the dataset's Trino schema. So each request names one model
+    and polls the EXACT run group it returned — never a model's "latest run" — with a generous 1800s
+    budget; the first non-SUCCESS stops the run.
+    """
+    for table in tables:
+        path = src_dir / f"{table}.csv"
+        url = graphql(M_URL, {"staticModelId": models[table][0]}, token)["createStaticModelUploadUrl"]
+        upload(path, url)
+        print(f"  uploaded {table}.csv ({path.stat().st_size:,} bytes, {receipt[table]['rows']:,} rows)")
+
+    statuses: dict[str, tuple[str, str]] = {}
+    for table in tables:
+        run_group = graphql(
+            M_RUN, {"input": {"datasetId": dataset_id, "staticModelId": models[table][0]}}, token,
+        )["createStaticModelRunRequest"]["runGroup"]
+        status = poll_run_group(run_group["id"], token, timeout=1800.0)
+        statuses[table] = (run_group["id"], status)
+        print(f"  {table}: run group {run_group['id']} finished {status}")
+        if status != GROUP_SUCCESS:
+            break
+    problems = run_groups_all_succeeded(statuses)
+    if problems:
+        print("deployment did not succeed — recording no occurrence:", file=sys.stderr)
+        for problem in problems:
+            print(f"  ! {problem}", file=sys.stderr)
+        return 2
+
+    deployed = {t: deployed_table_state(dataset_name, t) for t in tables}
+    mismatches = mismatches_fn(receipt, deployed)
+    if mismatches:
+        print("deployed data does not match the candidate — recording no occurrence:", file=sys.stderr)
+        for mismatch in mismatches:
+            print(f"  ! {mismatch}", file=sys.stderr)
+        return 2
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--plan", action="store_true", help="validate + print the plan; no network, no creds, no write")
     parser.add_argument("--dry-run", action="store_true", help="validate + resolve ids read-only; no mutation, no write")
-    parser.add_argument("--dir", type=Path, default=OUT_DIR, help="where candidate CSVs are read")
+    parser.add_argument("--dir", type=Path, default=OUT_DIR, help="where candidate CSVs are read (a deploy)")
     parser.add_argument("--archive-root", type=Path, default=DEFAULT_ARCHIVE_ROOT,
                         help="the durable archive + occurrence log (independent of --dir, so publishing "
                              "from an archive never nests)")
+    parser.add_argument("--rollback", metavar="ARTIFACT_ID",
+                        help="re-upload an already-archived artifact by its artifact_id; verifies its "
+                             "recorded hashes and records a rollback, not a deploy")
     args = parser.parse_args()
 
     dataset_name = os.environ.get("OSO_DATASET", DEFAULT_DATASET)
-    missing = [t for t in EVAL_TABLES if not (args.dir / f"{t}.csv").exists()]
-    if missing:
-        print(f"missing CSVs: {missing}. Run `uv run python -m build.serialize_evaluation --live` first.",
-              file=sys.stderr)
-        return 2
 
-    receipt = build_receipt(args.dir)
-    print_plan(receipt, dataset_name)
-
-    # Validate BEFORE any mutation — and in --plan / --dry-run too.
-    problems = validate_candidates(args.dir, ROOT)
-    if problems:
-        print("candidate validation failed:", file=sys.stderr)
-        for problem in problems:
-            print(f"  ! {problem}", file=sys.stderr)
-        return 2
+    # The operation is EXPLICIT: --rollback re-uploads verified archived bytes; otherwise a deploy
+    # builds and validates candidates from --dir at HEAD. Neither is inferred from the archive.
+    if args.rollback:
+        operation = "rollback"
+        aid = args.rollback
+        try:
+            archive.verify_artifact(args.archive_root, aid)
+        except RuntimeError as exc:
+            print(f"cannot roll back to {aid}: {exc}", file=sys.stderr)
+            return 2
+        stored = archive.artifact_receipt(args.archive_root, aid)
+        receipt, deployment = stored["tables"], stored["deployment_id"]
+        src_dir = archive.artifact_dir(args.archive_root, aid)
+        print(f"rollback: artifact {aid} (generation {deployment}) verified against its recorded hashes")
+        print_plan(receipt, dataset_name)
+    else:
+        operation = "deploy"
+        missing = [t for t in EVAL_TABLES if not (args.dir / f"{t}.csv").exists()]
+        if missing:
+            print(f"missing CSVs: {missing}. Run `uv run python -m build.serialize_evaluation --live` first.",
+                  file=sys.stderr)
+            return 2
+        src_dir = args.dir
+        receipt = build_receipt(src_dir)
+        print_plan(receipt, dataset_name)
+        problems = validate_candidates(src_dir, ROOT)  # structural + canonical, BEFORE any mutation
+        if problems:
+            print("candidate validation failed:", file=sys.stderr)
+            for problem in problems:
+                print(f"  ! {problem}", file=sys.stderr)
+            return 2
+        deployment, aid = deployment_id(src_dir), None  # aid is set when the bytes are persisted
 
     if args.plan:
         return 0
@@ -362,9 +429,9 @@ def main() -> int:
               file=sys.stderr)
         return 2
 
-    rollback_target = archive.current_live_archive(args.archive_root)
-    if rollback_target is not None:
-        print(f"rollback target if this deploy is bad: {rollback_target}")
+    previous = archive.current_live_artifact_id(args.archive_root)
+    if previous is not None:
+        print(f"currently live artifact (the rollback target if this is bad): {previous}")
 
     dataset_id = resolve_evaluation_dataset(dataset_name, org_id, token, create=not args.dry_run)
     if dataset_id is None:
@@ -381,56 +448,19 @@ def main() -> int:
             print(f"  {verb} {table}.csv ({receipt[table]['rows']:,} rows) -> {model_id}")
         return 0  # NO write on a dry run
 
-    for table in EVAL_TABLES:
-        path = args.dir / f"{table}.csv"
-        model_id = models[table][0]
-        url = graphql(M_URL, {"staticModelId": model_id}, token)["createStaticModelUploadUrl"]
-        upload(path, url)
-        print(f"  uploaded {table}.csv ({path.stat().st_size:,} bytes, {receipt[table]['rows']:,} rows)")
+    # DEPLOY: persist the candidate bytes content-addressed BEFORE mutating the platform. A rollback's
+    # bytes are already archived (and were hash-verified above), so aid is known.
+    if operation == "deploy":
+        aid = archive.ensure_artifact(args.archive_root, archived_files(src_dir), receipt, deployment)
 
-    # ONE RUN REQUEST PER MODEL, awaited in turn — the same discipline `build/publish_registry.py`
-    # uses, down to its shared run-group-bound `poll_run_group`. `CreateStaticModelRunRequestInput`
-    # takes (datasetId, staticModelId), one model per request; a request naming N models would fan
-    # out into N runs and return only one run group, which cannot certify its siblings, and the
-    # sibling loads would RACE to create the dataset's Trino schema. Both were observed on the first
-    # publish (2026-08-25). Serialize, and poll the EXACT run group this request returned — never a
-    # model's "latest run", which could be an earlier unrelated success that would pass the poll
-    # before this run has even appeared. The 1800s budget keeps the more generous patience this
-    # maintainer deploy has always allowed while sharing the one helper. Fail fast: the first model
-    # that does not reach SUCCESS stops the deploy rather than uploading over a table whose sibling
-    # is already broken.
-    statuses: dict[str, tuple[str, str]] = {}
-    for table in EVAL_TABLES:
-        run_group = graphql(
-            M_RUN,
-            {"input": {"datasetId": dataset_id, "staticModelId": models[table][0]}},
-            token,
-        )["createStaticModelRunRequest"]["runGroup"]
-        # A run request is only ACCEPTED here; wait for THIS run group to reach a terminal state.
-        status = poll_run_group(run_group["id"], token, timeout=1800.0)
-        statuses[table] = (run_group["id"], status)
-        print(f"  {table}: run group {run_group['id']} finished {status}")
-        if status != GROUP_SUCCESS:
-            break
-    problems = run_groups_all_succeeded(statuses)
-    if problems:
-        print("deployment did not succeed — not archiving:", file=sys.stderr)
-        for problem in problems:
-            print(f"  ! {problem}", file=sys.stderr)
+    if materialize(dataset_id, models, EVAL_TABLES, src_dir, token, dataset_name, receipt, deployment_mismatches):
         return 2
 
-    deployed = {t: deployed_table_state(dataset_name, t) for t in EVAL_TABLES}
-    mismatches = deployment_mismatches(receipt, deployed)
-    if mismatches:
-        print("deployed data does not match the candidate — not archiving:", file=sys.stderr)
-        for mismatch in mismatches:
-            print(f"  ! {mismatch}", file=sys.stderr)
-        return 2
-
-    target, kind = archive.store(args.archive_root, deployment_id(args.dir), archived_files(args.dir), receipt)
-    verb = "archived this deployment (immutable)" if kind == "deploy" else "recorded a rollback to the archived deployment"
-    print(f"\nevery load run SUCCESS and deployed data verified; {verb} at "
-          f"{target} — now the live state in {args.archive_root}")
+    # Occurrence LAST — only after the deployed state verified. A failed deploy leaves at most an
+    # unreferenced staged artifact (harmless); it never records a wrong live state.
+    archive.record_occurrence(args.archive_root, operation, deployment, aid, previous)
+    print(f"\nevery load run SUCCESS and deployed data verified; recorded {operation} of artifact {aid} "
+          f"(generation {deployment}) — now the live state in {args.archive_root}")
     return 0
 
 

--- a/build/publish_evaluation.py
+++ b/build/publish_evaluation.py
@@ -20,9 +20,10 @@ rejected here rather than published.
 
 ## No writes before the dry-run returns
 
-`--plan` (offline, no credentials) and `--dry-run` (read-only id resolution) validate and print the
-plan and perform NO mutation and NO local write. The only filesystem write this tool makes is the
-immutable deployment archive, and only after a real, successful upload.
+`--plan` (offline, no credentials) and `--dry-run` (read-only id resolution, `create=False`) validate
+and print the plan and perform NO mutation, NO create, and NO local write. On a real publish the
+candidate bytes are archived to disk BEFORE any create-capable call (so nothing is created before the
+artifact exists), and the occurrence is recorded only after a successful, verified upload.
 
 ## Rollback is by BYTES — a content-addressed archive, live-state from an occurrence log
 
@@ -392,12 +393,14 @@ def main() -> int:
         operation = "rollback"
         aid = args.rollback
         try:
-            archive.verify_artifact(args.archive_root, aid)
+            # Provenance is reconstructed from the VERIFIED bytes and required to equal receipt.json,
+            # which SHA256SUMS does not cover — a tampered receipt cannot ride the rollback.
+            receipt, deployment = archive.verified_rollback_provenance(
+                args.archive_root, aid, {f"{t}.csv" for t in EVAL_TABLES}, build_receipt, deployment_id,
+            )
         except RuntimeError as exc:
             print(f"cannot roll back to {aid}: {exc}", file=sys.stderr)
             return 2
-        stored = archive.artifact_receipt(args.archive_root, aid)
-        receipt, deployment = stored["tables"], stored["deployment_id"]
         src_dir = archive.artifact_dir(args.archive_root, aid)
         print(f"rollback: artifact {aid} (generation {deployment}) verified against its recorded hashes")
         print_plan(receipt, dataset_name)
@@ -433,25 +436,29 @@ def main() -> int:
     if previous is not None:
         print(f"currently live artifact (the rollback target if this is bad): {previous}")
 
-    dataset_id = resolve_evaluation_dataset(dataset_name, org_id, token, create=not args.dry_run)
-    if dataset_id is None:
-        print(f"would create dataset {dataset_name}, then create + upload {list(EVAL_TABLES)}")
-        return 0  # dry-run only reaches here; no write
-
-    models = resolve_static_models(dataset_id, org_id, token, EVAL_TABLES, create=not args.dry_run)
-    print(f"dataset {dataset_name} = {dataset_id}")
-
     if args.dry_run:
+        # READ-ONLY resolution — create=False — so a dry run creates NOTHING and writes nothing.
+        dataset_id = resolve_evaluation_dataset(dataset_name, org_id, token, create=False)
+        if dataset_id is None:
+            print(f"would create dataset {dataset_name}, then create + upload {list(EVAL_TABLES)}")
+            return 0
+        models = resolve_static_models(dataset_id, org_id, token, EVAL_TABLES, create=False)
+        print(f"dataset {dataset_name} = {dataset_id}")
         for table in EVAL_TABLES:
             model_id = models[table][0]
             verb = "would upload" if model_id else "would create + upload"
             print(f"  {verb} {table}.csv ({receipt[table]['rows']:,} rows) -> {model_id}")
-        return 0  # NO write on a dry run
+        return 0  # NO write, NO create
 
-    # DEPLOY: persist the candidate bytes content-addressed BEFORE mutating the platform. A rollback's
-    # bytes are already archived (and were hash-verified above), so aid is known.
+    # REAL publish. Persist the candidate bytes content-addressed BEFORE any create-capable platform
+    # call — `resolve_*` with create=True can create the dataset or static models, so the artifact
+    # must already exist on disk first. A rollback's bytes are already archived (verified above).
     if operation == "deploy":
         aid = archive.ensure_artifact(args.archive_root, archived_files(src_dir), receipt, deployment)
+
+    dataset_id = resolve_evaluation_dataset(dataset_name, org_id, token, create=True)
+    models = resolve_static_models(dataset_id, org_id, token, EVAL_TABLES, create=True)
+    print(f"dataset {dataset_name} = {dataset_id}")
 
     if materialize(dataset_id, models, EVAL_TABLES, src_dir, token, dataset_name, receipt, deployment_mismatches):
         return 2

--- a/build/publish_scoring_trace.py
+++ b/build/publish_scoring_trace.py
@@ -38,13 +38,15 @@ Like the evaluation publisher: `--plan` (offline) and `--dry-run` (read-only id 
 and print the plan and perform NO mutation and NO local write. A real publish uploads, requests one
 run per model with `{datasetId, staticModelId}` and awaits each run group to terminal `SUCCESS`
 (polling the exact group the mutation returned), verifies the deployed row count and column schema
-via `pyoso`, and only then archives the exact bytes it uploaded — an immutable per-deployment
-directory `<archive-root>/<deployment_id>/` (default `--archive-root`
-`build/evaluation/scoring-trace-deployments/`, kept separate from the evaluation publisher's
-`deployments/` so neither reads the other's archives), plus an append-only occurrence log that
-decides what is live. The archive root is independent of `--dir`, so re-publishing a prior archive
-(`--dir <that-archive>`) records a `rollback` occurrence without nesting or rewriting the immutable
-bytes. The mechanism is `build/deployment_archive.py`, shared with the evaluation publisher.
+via `pyoso`, and only then records the occurrence. The bytes are persisted BEFORE the platform
+mutation, content-addressed by `artifact_id` (SHA-256 over the file manifest) under
+`<archive-root>/artifacts/<artifact_id>/` (default `--archive-root`
+`build/evaluation/scoring-trace-deployments/`, separate from the evaluation publisher's
+`deployments/` so neither reads the other's archives); the append-only occurrence log — not
+directory mtimes — decides what is live. The operation is EXPLICIT: a normal publish is a `deploy`;
+`--rollback <artifact_id>` re-uploads an already-archived artifact after verifying its recorded
+hashes. The archive root is independent of `--dir`, so publishing from an archive never nests. The
+mechanism is `build/deployment_archive.py`, shared with the evaluation publisher.
 
 Environment:
     OSO_API_KEY   required (except for --plan)
@@ -70,6 +72,7 @@ from build.axis_scoring_trace import TABLES as TRACE_SPEC
 from build.publish_evaluation import (
     csv_provenance,
     deployed_table_state,
+    materialize,
     resolve_evaluation_dataset,
     run_groups_all_succeeded,
 )
@@ -331,25 +334,45 @@ def main() -> int:
     parser.add_argument("--archive-root", type=Path, default=DEFAULT_ARCHIVE_ROOT,
                         help="the durable archive + occurrence log (independent of --dir, so publishing "
                              "from an archive never nests)")
+    parser.add_argument("--rollback", metavar="ARTIFACT_ID",
+                        help="re-upload an already-archived artifact by its artifact_id; verifies its "
+                             "recorded hashes and records a rollback, not a deploy")
     args = parser.parse_args()
 
     dataset_name = os.environ.get("OSO_DATASET", DEFAULT_DATASET)
-    missing = [t for t in TRACE_TABLES if not (args.dir / f"{t}.csv").exists()]
-    if missing:
-        print(f"missing CSVs: {missing}. Run `uv run python -m build.axis_scoring_trace --out {args.dir}` first.",
-              file=sys.stderr)
-        return 2
 
-    receipt = build_receipt(args.dir)
-    print_plan(receipt, dataset_name)
-
-    # Validate BEFORE any mutation — and in --plan / --dry-run too.
-    problems = validate_candidates(args.dir)
-    if problems:
-        print("candidate validation failed:", file=sys.stderr)
-        for problem in problems:
-            print(f"  ! {problem}", file=sys.stderr)
-        return 2
+    # The operation is EXPLICIT: --rollback re-uploads verified archived bytes; otherwise a deploy
+    # builds and canonically validates candidates from --dir at HEAD. Neither is inferred.
+    if args.rollback:
+        operation = "rollback"
+        aid = args.rollback
+        try:
+            archive.verify_artifact(args.archive_root, aid)
+        except RuntimeError as exc:
+            print(f"cannot roll back to {aid}: {exc}", file=sys.stderr)
+            return 2
+        stored = archive.artifact_receipt(args.archive_root, aid)
+        receipt, deployment = stored["tables"], stored["deployment_id"]
+        src_dir = archive.artifact_dir(args.archive_root, aid)
+        print(f"rollback: artifact {aid} (generation {deployment}) verified against its recorded hashes")
+        print_plan(receipt, dataset_name)
+    else:
+        operation = "deploy"
+        missing = [t for t in TRACE_TABLES if not (args.dir / f"{t}.csv").exists()]
+        if missing:
+            print(f"missing CSVs: {missing}. Run `uv run python -m build.axis_scoring_trace --out {args.dir}` first.",
+                  file=sys.stderr)
+            return 2
+        src_dir = args.dir
+        receipt = build_receipt(src_dir)
+        print_plan(receipt, dataset_name)
+        problems = validate_candidates(src_dir)  # structural + canonical equivalence, BEFORE any mutation
+        if problems:
+            print("candidate validation failed:", file=sys.stderr)
+            for problem in problems:
+                print(f"  ! {problem}", file=sys.stderr)
+            return 2
+        deployment, aid = deployment_id(src_dir), None  # aid is set when the bytes are persisted
 
     if args.plan:
         return 0
@@ -361,9 +384,9 @@ def main() -> int:
               file=sys.stderr)
         return 2
 
-    rollback_target = archive.current_live_archive(args.archive_root)
-    if rollback_target is not None:
-        print(f"rollback target if this deploy is bad: {rollback_target}")
+    previous = archive.current_live_artifact_id(args.archive_root)
+    if previous is not None:
+        print(f"currently live artifact (the rollback target if this is bad): {previous}")
 
     dataset_id = resolve_evaluation_dataset(dataset_name, org_id, token, create=not args.dry_run)
     if dataset_id is None:
@@ -380,50 +403,18 @@ def main() -> int:
             print(f"  {verb} {table}.csv ({receipt[table]['rows']:,} rows) -> {model_id}")
         return 0  # NO write on a dry run
 
-    for table in TRACE_TABLES:
-        path = args.dir / f"{table}.csv"
-        model_id = models[table][0]
-        url = graphql(M_URL, {"staticModelId": model_id}, token)["createStaticModelUploadUrl"]
-        upload(path, url)
-        print(f"  uploaded {table}.csv ({path.stat().st_size:,} bytes, {receipt[table]['rows']:,} rows)")
+    # DEPLOY: persist the candidate bytes content-addressed BEFORE mutating the platform (a rollback's
+    # bytes are already archived and were hash-verified above). Then upload/run/verify via the shared
+    # `materialize`, and record the occurrence LAST — only after the deployed state verified.
+    if operation == "deploy":
+        aid = archive.ensure_artifact(args.archive_root, archived_files(src_dir), receipt, deployment)
 
-    # ONE RUN REQUEST PER MODEL, awaited in turn — the same discipline the registry and evaluation
-    # publishers use, down to their shared run-group-bound `poll_run_group`.
-    # `CreateStaticModelRunRequestInput` takes (datasetId, staticModelId), one model per request; a
-    # request naming N models would fan out into N runs and return one run group, and the sibling
-    # loads would race to create the dataset's Trino schema. Serialize, poll the EXACT run group this
-    # request returned (never a model's "latest run"), and fail fast on the first non-SUCCESS group.
-    statuses: dict[str, tuple[str, str]] = {}
-    for table in TRACE_TABLES:
-        run_group = graphql(
-            M_RUN,
-            {"input": {"datasetId": dataset_id, "staticModelId": models[table][0]}},
-            token,
-        )["createStaticModelRunRequest"]["runGroup"]
-        status = poll_run_group(run_group["id"], token, timeout=1800.0)
-        statuses[table] = (run_group["id"], status)
-        print(f"  {table}: run group {run_group['id']} finished {status}")
-        if status != GROUP_SUCCESS:
-            break
-    problems = run_groups_all_succeeded(statuses)
-    if problems:
-        print("deployment did not succeed — not archiving:", file=sys.stderr)
-        for problem in problems:
-            print(f"  ! {problem}", file=sys.stderr)
+    if materialize(dataset_id, models, TRACE_TABLES, src_dir, token, dataset_name, receipt, deployment_mismatches):
         return 2
 
-    deployed = {t: deployed_table_state(dataset_name, t) for t in TRACE_TABLES}
-    mismatches = deployment_mismatches(receipt, deployed)
-    if mismatches:
-        print("deployed data does not match the candidate — not archiving:", file=sys.stderr)
-        for mismatch in mismatches:
-            print(f"  ! {mismatch}", file=sys.stderr)
-        return 2
-
-    target, kind = archive.store(args.archive_root, deployment_id(args.dir), archived_files(args.dir), receipt)
-    verb = "archived this deployment (immutable)" if kind == "deploy" else "recorded a rollback to the archived deployment"
-    print(f"\nevery load run SUCCESS and deployed data verified; {verb} at "
-          f"{target} — now the live state in {args.archive_root}")
+    archive.record_occurrence(args.archive_root, operation, deployment, aid, previous)
+    print(f"\nevery load run SUCCESS and deployed data verified; recorded {operation} of artifact {aid} "
+          f"(generation {deployment}) — now the live state in {args.archive_root}")
     return 0
 
 

--- a/build/publish_scoring_trace.py
+++ b/build/publish_scoring_trace.py
@@ -38,10 +38,13 @@ Like the evaluation publisher: `--plan` (offline) and `--dry-run` (read-only id 
 and print the plan and perform NO mutation and NO local write. A real publish uploads, requests one
 run per model with `{datasetId, staticModelId}` and awaits each run group to terminal `SUCCESS`
 (polling the exact group the mutation returned), verifies the deployed row count and column schema
-via `pyoso`, and only then writes an immutable per-deployment archive of the exact bytes it uploaded
-— under `build/evaluation/scoring-trace-deployments/<deployment_id>/`, kept separate from the
-evaluation publisher's `deployments/` so neither reads the other's archives. It REFUSES to overwrite
-an existing archive.
+via `pyoso`, and only then archives the exact bytes it uploaded — an immutable per-deployment
+directory `<archive-root>/<deployment_id>/` (default `--archive-root`
+`build/evaluation/scoring-trace-deployments/`, kept separate from the evaluation publisher's
+`deployments/` so neither reads the other's archives), plus an append-only occurrence log that
+decides what is live. The archive root is independent of `--dir`, so re-publishing a prior archive
+(`--dir <that-archive>`) records a `rollback` occurrence without nesting or rewriting the immutable
+bytes. The mechanism is `build/deployment_archive.py`, shared with the evaluation publisher.
 
 Environment:
     OSO_API_KEY   required (except for --plan)
@@ -58,12 +61,11 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import json
 import os
-import shutil
 import sys
 from pathlib import Path
 
+from build import deployment_archive as archive
 from build.axis_scoring_trace import TABLES as TRACE_SPEC
 from build.publish_evaluation import (
     csv_provenance,
@@ -85,6 +87,9 @@ from build.publish_registry import (
 ROOT = Path(__file__).resolve().parents[1]
 OUT_DIR = ROOT / "build" / "evaluation"
 DEFAULT_DATASET = "evaluation"
+# Its OWN archive root — never the evaluation publisher's `deployments/` — and independent of `--dir`,
+# so publishing from an archive never nests. The occurrence log lives here too. See build/deployment_archive.py.
+DEFAULT_ARCHIVE_ROOT = OUT_DIR / "scoring-trace-deployments"
 
 # The three trace tables, in a stable publish order, and their exact expected headers.
 TRACE_TABLES: tuple[str, ...] = tuple(TRACE_SPEC)
@@ -103,16 +108,6 @@ _GRAIN: dict[str, tuple[str, ...]] = {
         "dimension", "part_index", "fact_kind",
     ),
 }
-
-
-def deployments_dir(out_dir: Path) -> Path:
-    """Where completed, immutable trace-deployment archives live.
-
-    Deliberately NOT `deployments/` — that belongs to `build/publish_evaluation.py`, which shares
-    this `build/evaluation` directory. A separate subdirectory keeps each publisher's `latest_archive`
-    scan blind to the other's archives (a trace archive has no evaluation CSVs, and vice versa).
-    """
-    return out_dir / "scoring-trace-deployments"
 
 
 def build_receipt(out_dir: Path = OUT_DIR) -> dict:
@@ -285,43 +280,14 @@ def deployment_id(out_dir: Path = OUT_DIR) -> str:
     return f"{dvid[:12]}-{sha[:12]}"
 
 
-def archive_deployment(out_dir: Path, receipt: dict) -> Path:
-    """Copy the just-deployed CSVs + completed receipt into an immutable per-deployment directory.
-
-    Refuses to overwrite an existing archive: a deployment id is written exactly once.
-
-    KNOWN LIMITATION (non-blocking; shared with build/publish_evaluation.py, follow-up before the
-    rollback workflow is relied on): the archive root is derived from `out_dir`, so re-publishing a
-    prior archive's bytes with `--dir <that-archive>` would nest a new archive *inside* it and would
-    not update the canonical `build/evaluation/scoring-trace-deployments/` root's notion of what is
-    live. Deployment identity (the declaration) and deployment occurrence (a publish event) are
-    conflated. First deploys are unaffected; a rollback-from-archive flow needs the archive root
-    decoupled from the read `--dir` first.
-    """
-    target = deployments_dir(out_dir) / deployment_id(out_dir)
-    if target.exists():
-        raise RuntimeError(
-            f"deployment archive {target} already exists — a deployment id is immutable and is "
-            f"never overwritten. If you are re-publishing identical bytes, the previous archive "
-            f"already records them; if not, the declaration identity would have changed."
-        )
-    target.mkdir(parents=True)
-    for table in TRACE_TABLES:
-        shutil.copy2(out_dir / f"{table}.csv", target / f"{table}.csv")
-    (target / "receipt.json").write_text(
-        json.dumps({"deployment_id": target.name, "tables": receipt}, indent=2, sort_keys=True),
-        encoding="utf-8",
-    )
-    return target
+def archived_files(out_dir: Path = OUT_DIR) -> dict[str, Path]:
+    """The candidate files to archive, keyed by their archived name."""
+    return {f"{table}.csv": out_dir / f"{table}.csv" for table in TRACE_TABLES}
 
 
-def latest_archive(out_dir: Path) -> Path | None:
-    """The most recently written trace-deployment archive, if any — the next deploy's rollback target."""
-    root = deployments_dir(out_dir)
-    if not root.exists():
-        return None
-    archives = [p for p in root.iterdir() if p.is_dir() and (p / "receipt.json").exists()]
-    return max(archives, key=lambda p: p.stat().st_mtime) if archives else None
+# The immutable per-deployment archive and the append-only occurrence log that decides what is live
+# both live in build/deployment_archive.py, shared with build/publish_evaluation.py (each publisher
+# passing its own --archive-root) so the two cannot drift and neither reads the other's archives.
 
 
 def deployment_mismatches(expected: dict, deployed: dict) -> list[str]:
@@ -361,7 +327,10 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--plan", action="store_true", help="validate + print the plan; no network, no creds, no write")
     parser.add_argument("--dry-run", action="store_true", help="validate + resolve ids read-only; no mutation, no write")
-    parser.add_argument("--dir", type=Path, default=OUT_DIR)
+    parser.add_argument("--dir", type=Path, default=OUT_DIR, help="where candidate CSVs are read")
+    parser.add_argument("--archive-root", type=Path, default=DEFAULT_ARCHIVE_ROOT,
+                        help="the durable archive + occurrence log (independent of --dir, so publishing "
+                             "from an archive never nests)")
     args = parser.parse_args()
 
     dataset_name = os.environ.get("OSO_DATASET", DEFAULT_DATASET)
@@ -392,7 +361,7 @@ def main() -> int:
               file=sys.stderr)
         return 2
 
-    rollback_target = latest_archive(args.dir)
+    rollback_target = archive.current_live_archive(args.archive_root)
     if rollback_target is not None:
         print(f"rollback target if this deploy is bad: {rollback_target}")
 
@@ -451,9 +420,10 @@ def main() -> int:
             print(f"  ! {mismatch}", file=sys.stderr)
         return 2
 
-    archive = archive_deployment(args.dir, receipt)
-    print(f"\nevery load run SUCCESS and deployed data verified; archived this deployment (immutable) at "
-          f"{archive} — the rollback target for the next deploy")
+    target, kind = archive.store(args.archive_root, deployment_id(args.dir), archived_files(args.dir), receipt)
+    verb = "archived this deployment (immutable)" if kind == "deploy" else "recorded a rollback to the archived deployment"
+    print(f"\nevery load run SUCCESS and deployed data verified; {verb} at "
+          f"{target} — now the live state in {args.archive_root}")
     return 0
 
 

--- a/build/publish_scoring_trace.py
+++ b/build/publish_scoring_trace.py
@@ -347,12 +347,14 @@ def main() -> int:
         operation = "rollback"
         aid = args.rollback
         try:
-            archive.verify_artifact(args.archive_root, aid)
+            # Provenance is reconstructed from the VERIFIED bytes and required to equal receipt.json,
+            # which SHA256SUMS does not cover — a tampered receipt cannot ride the rollback.
+            receipt, deployment = archive.verified_rollback_provenance(
+                args.archive_root, aid, {f"{t}.csv" for t in TRACE_TABLES}, build_receipt, deployment_id,
+            )
         except RuntimeError as exc:
             print(f"cannot roll back to {aid}: {exc}", file=sys.stderr)
             return 2
-        stored = archive.artifact_receipt(args.archive_root, aid)
-        receipt, deployment = stored["tables"], stored["deployment_id"]
         src_dir = archive.artifact_dir(args.archive_root, aid)
         print(f"rollback: artifact {aid} (generation {deployment}) verified against its recorded hashes")
         print_plan(receipt, dataset_name)
@@ -388,26 +390,29 @@ def main() -> int:
     if previous is not None:
         print(f"currently live artifact (the rollback target if this is bad): {previous}")
 
-    dataset_id = resolve_evaluation_dataset(dataset_name, org_id, token, create=not args.dry_run)
-    if dataset_id is None:
-        print(f"would create dataset {dataset_name}, then create + upload {list(TRACE_TABLES)}")
-        return 0  # dry-run only reaches here; no write
-
-    models = resolve_static_models(dataset_id, org_id, token, TRACE_TABLES, create=not args.dry_run)
-    print(f"dataset {dataset_name} = {dataset_id}")
-
     if args.dry_run:
+        # READ-ONLY resolution — create=False — so a dry run creates NOTHING and writes nothing.
+        dataset_id = resolve_evaluation_dataset(dataset_name, org_id, token, create=False)
+        if dataset_id is None:
+            print(f"would create dataset {dataset_name}, then create + upload {list(TRACE_TABLES)}")
+            return 0
+        models = resolve_static_models(dataset_id, org_id, token, TRACE_TABLES, create=False)
+        print(f"dataset {dataset_name} = {dataset_id}")
         for table in TRACE_TABLES:
             model_id = models[table][0]
             verb = "would upload" if model_id else "would create + upload"
             print(f"  {verb} {table}.csv ({receipt[table]['rows']:,} rows) -> {model_id}")
-        return 0  # NO write on a dry run
+        return 0  # NO write, NO create
 
-    # DEPLOY: persist the candidate bytes content-addressed BEFORE mutating the platform (a rollback's
-    # bytes are already archived and were hash-verified above). Then upload/run/verify via the shared
-    # `materialize`, and record the occurrence LAST — only after the deployed state verified.
+    # REAL publish. Persist the candidate bytes content-addressed BEFORE any create-capable platform
+    # call — `resolve_*` with create=True can create the dataset or static models, so the artifact
+    # must already exist on disk first. A rollback's bytes are already archived (verified above).
     if operation == "deploy":
         aid = archive.ensure_artifact(args.archive_root, archived_files(src_dir), receipt, deployment)
+
+    dataset_id = resolve_evaluation_dataset(dataset_name, org_id, token, create=True)
+    models = resolve_static_models(dataset_id, org_id, token, TRACE_TABLES, create=True)
+    print(f"dataset {dataset_name} = {dataset_id}")
 
     if materialize(dataset_id, models, TRACE_TABLES, src_dir, token, dataset_name, receipt, deployment_mismatches):
         return 2

--- a/tests/test_deployment_archive.py
+++ b/tests/test_deployment_archive.py
@@ -138,3 +138,76 @@ def test_bad_operation_is_rejected(tmp_path):
         assert "deploy" in str(exc)
     else:
         raise AssertionError("record_occurrence must reject an unknown operation")
+
+
+# --- rollback provenance: receipt.json is not covered by SHA256SUMS, so reconstruct + require ------
+
+import json  # noqa: E402
+
+
+def _recompute_tables(adir):
+    return {name: {"rows": 1, "sha256": A.file_sha256(adir / name)} for name in A.read_manifest(adir)}
+
+
+def _recompute_did(adir):
+    return "gen-" + A.file_sha256(adir / "t.csv")[:8]
+
+
+def _archived(tmp_path):
+    root = tmp_path / "archive"
+    files = _files(tmp_path)
+    tables = {name: {"rows": 1, "sha256": A.file_sha256(p)} for name, p in files.items()}
+    aid = A.ensure_artifact(root, files, tables, "gen-" + A.file_sha256(files["t.csv"])[:8])
+    return root, aid
+
+
+def test_verified_rollback_provenance_passes_for_an_intact_artifact(tmp_path):
+    root, aid = _archived(tmp_path)
+    tables, did = A.verified_rollback_provenance(root, aid, {"t.csv"}, _recompute_tables, _recompute_did)
+    assert did == _recompute_did(A.artifact_dir(root, aid))
+    assert tables == _recompute_tables(A.artifact_dir(root, aid))
+
+
+def _expect_rejected(root, aid, expected_names=frozenset({"t.csv"})):
+    try:
+        A.verified_rollback_provenance(root, aid, set(expected_names), _recompute_tables, _recompute_did)
+    except RuntimeError:
+        return
+    raise AssertionError("verified_rollback_provenance should have rejected this artifact")
+
+
+def test_rollback_rejects_a_tampered_receipt_deployment_id(tmp_path):
+    root, aid = _archived(tmp_path)
+    rj = A.artifact_dir(root, aid) / A.RECEIPT
+    doc = json.loads(rj.read_text()); doc["deployment_id"] = "forged-generation"
+    rj.write_text(json.dumps(doc), encoding="utf-8")
+    _expect_rejected(root, aid)
+
+
+def test_rollback_rejects_a_tampered_receipt_row_count(tmp_path):
+    root, aid = _archived(tmp_path)
+    rj = A.artifact_dir(root, aid) / A.RECEIPT
+    doc = json.loads(rj.read_text()); doc["tables"]["t.csv"]["rows"] = 999
+    rj.write_text(json.dumps(doc), encoding="utf-8")
+    _expect_rejected(root, aid)
+
+
+def test_rollback_rejects_a_tampered_receipt_artifact_id(tmp_path):
+    root, aid = _archived(tmp_path)
+    rj = A.artifact_dir(root, aid) / A.RECEIPT
+    doc = json.loads(rj.read_text()); doc["artifact_id"] = "0" * 64
+    rj.write_text(json.dumps(doc), encoding="utf-8")
+    _expect_rejected(root, aid)
+
+
+def test_rollback_rejects_altered_bytes(tmp_path):
+    root, aid = _archived(tmp_path)
+    (A.artifact_dir(root, aid) / "t.csv").write_text("declaration_version_id,x\nabc,999\n", encoding="utf-8")
+    _expect_rejected(root, aid)  # verify_artifact inside the gate catches the hash mismatch
+
+
+def test_rollback_rejects_an_unexpected_or_missing_manifest_file(tmp_path):
+    root, aid = _archived(tmp_path)
+    # The manifest names {"t.csv"} but the publisher expects a different file set.
+    _expect_rejected(root, aid, expected_names={"t.csv", "extra.csv"})
+    _expect_rejected(root, aid, expected_names={"other.csv"})

--- a/tests/test_deployment_archive.py
+++ b/tests/test_deployment_archive.py
@@ -1,98 +1,140 @@
-"""The shared deployment archive: immutable identity + append-only occurrence log.
+"""The shared deployment archive: content addressing, explicit operations, atomic staging.
 
 `build/deployment_archive.py` is the rollback record shared by the evaluation and scoring-trace
-publishers. These tests pin the properties the cutover plan depends on: live state is read from the
-occurrence log (never directory mtimes), a rollback is an occurrence rather than a rewrite, and
-publishing from an archive never nests a new archive inside the bytes being restored.
+publishers. These pin the integrity properties: a byte identity distinct from the semantic
+generation, hash-verified artifacts, an atomic archive that survives interruption, and live-state
+from an append-only occurrence log rather than directory mtimes.
 """
 
 import build.deployment_archive as A
 
 
-def _candidate(tmp_path, name, text="a,b\n1,2\n"):
-    p = tmp_path / name
-    p.write_text(text, encoding="utf-8")
-    return p
+def _csv(path, text):
+    path.write_text(text, encoding="utf-8")
+    return path
 
 
-def _files(tmp_path):
-    return {"t.csv": _candidate(tmp_path, "t.csv")}
+def _files(tmp_path, text="declaration_version_id,x\nabc,1\n"):
+    return {"t.csv": _csv(tmp_path / "t.csv", text)}
+
+
+# --- content addressing: artifact_id is a byte identity, not the semantic generation --------------
+
+
+def test_same_generation_different_bytes_are_different_artifacts(tmp_path):
+    """The core of review point 1: identical declaration/observation ids but different bytes (a
+    regenerated evaluated_at) must yield different artifact_ids — never mistaken for the same."""
+    a = {"t.csv": _csv(tmp_path / "a.csv", "declaration_version_id,evaluated_at\nabc,2026-08-27T10:00:00\n")}
+    b = {"t.csv": _csv(tmp_path / "b.csv", "declaration_version_id,evaluated_at\nabc,2026-08-27T11:00:00\n")}
+    assert A.artifact_id(a) != A.artifact_id(b)
+    # ...and identical bytes are the same artifact.
+    c = {"t.csv": _csv(tmp_path / "c.csv", "declaration_version_id,evaluated_at\nabc,2026-08-27T10:00:00\n")}
+    assert A.artifact_id(a) == A.artifact_id(c)
+
+
+def test_ensure_artifact_is_content_addressed_and_idempotent(tmp_path):
+    root = tmp_path / "archive"
+    aid = A.ensure_artifact(root, _files(tmp_path), {"t.csv": {"rows": 1}}, "gen-1")
+    adir = A.artifact_dir(root, aid)
+    assert adir.name == aid and (adir / "t.csv").exists()
+    assert (adir / A.RECEIPT).exists() and (adir / A.SHA256SUMS).exists()
+    written = adir.stat().st_mtime_ns
+    # Re-ensuring the same bytes verifies and returns the same id without rewriting.
+    assert A.ensure_artifact(root, _files(tmp_path), {"t.csv": {"rows": 1}}, "gen-1") == aid
+    assert adir.stat().st_mtime_ns == written
+
+
+# --- exact hash verification ----------------------------------------------------------------------
+
+
+def test_verify_artifact_passes_for_intact_and_raises_for_tampered(tmp_path):
+    root = tmp_path / "archive"
+    aid = A.ensure_artifact(root, _files(tmp_path), {}, "gen-1")
+    A.verify_artifact(root, aid)  # intact: no raise
+
+    # Tamper with an archived byte; verification must catch it (rollback-with-altered-bytes rejected).
+    (A.artifact_dir(root, aid) / "t.csv").write_text("declaration_version_id,x\nabc,999\n", encoding="utf-8")
+    try:
+        A.verify_artifact(root, aid)
+    except RuntimeError as exc:
+        assert "hash mismatch" in str(exc)
+    else:
+        raise AssertionError("verify_artifact must reject an artifact whose bytes were altered")
+
+
+def test_verify_artifact_raises_for_absent(tmp_path):
+    try:
+        A.verify_artifact(tmp_path / "archive", "0" * 64)
+    except RuntimeError as exc:
+        assert "not archived" in str(exc)
+    else:
+        raise AssertionError("verify_artifact must reject an id that is not archived")
+
+
+# --- atomic staging: an interrupted write leaves no valid artifact and no occurrence --------------
+
+
+def test_interrupted_archive_creation_leaves_no_valid_artifact(tmp_path):
+    root = tmp_path / "archive"
+    aid = A.artifact_id(_files(tmp_path))
+    # Simulate an interrupted write: a partial staging directory under the eventual artifact id.
+    staging = A.artifacts_root(root) / f"{A._STAGING_PREFIX}{aid}"
+    staging.mkdir(parents=True)
+    (staging / "t.csv").write_text("partial", encoding="utf-8")  # no receipt, no SHA256SUMS
+
+    # The real artifact does not exist, verification refuses it, and nothing is live.
+    assert not A.artifact_dir(root, aid).exists()
+    try:
+        A.verify_artifact(root, aid)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("a partial staging dir must not verify as an artifact")
+    assert A.current_live(root) is None
+
+    # A subsequent ensure discards the stale staging and completes atomically.
+    assert A.ensure_artifact(root, _files(tmp_path), {}, "gen-1") == aid
+    A.verify_artifact(root, aid)
+
+
+# --- the append-only occurrence log ---------------------------------------------------------------
 
 
 def test_empty_root_reads_as_no_live_state_and_creates_nothing(tmp_path):
     root = tmp_path / "archive"
     assert A.occurrences(root) == []
     assert A.current_live(root) is None
-    assert A.current_live_archive(root) is None
-    assert not root.exists(), "reading live state must not create the archive root"
+    assert A.current_live_artifact_id(root) is None
+    assert not root.exists()
 
 
-def test_a_fresh_identity_is_a_deploy_and_becomes_live(tmp_path):
+def test_occurrences_record_operation_ids_and_previous(tmp_path):
     root = tmp_path / "archive"
-    target, kind = A.store(root, "id-A", _files(tmp_path), {"t": {"rows": 1}}, at="2026-01-01T00:00:00+00:00")
-    assert kind == "deploy"
-    assert target == A.archive_path(root, "id-A")
-    assert (target / "t.csv").exists() and (target / "receipt.json").exists()
-    assert A.current_live(root) == "id-A"
+    A.record_occurrence(root, "deploy", "gen-1", "aid-1", None, at="2026-01-01T00:00:00+00:00")
+    A.record_occurrence(root, "deploy", "gen-2", "aid-2", "aid-1", at="2026-01-02T00:00:00+00:00")
+    A.record_occurrence(root, "rollback", "gen-1", "aid-1", "aid-2", at="2026-01-03T00:00:00+00:00")
+    occ = A.occurrences(root)
+    assert [o["operation"] for o in occ] == ["deploy", "deploy", "rollback"]
+    assert [o["artifact_id"] for o in occ] == ["aid-1", "aid-2", "aid-1"]
+    assert [o["previous_artifact_id"] for o in occ] == [None, "aid-1", "aid-2"]
+    assert A.current_live_artifact_id(root) == "aid-1"  # the rollback re-pointed live
 
 
-def test_a_new_identity_advances_live_and_both_are_deploys(tmp_path):
+def test_live_state_is_from_occurrences_not_directory_mtime(tmp_path):
     root = tmp_path / "archive"
-    A.store(root, "id-A", _files(tmp_path), {}, at="2026-01-01T00:00:00+00:00")
-    A.store(root, "id-B", _files(tmp_path), {}, at="2026-01-02T00:00:00+00:00")
-    assert [o["kind"] for o in A.occurrences(root)] == ["deploy", "deploy"]
-    assert [o["deployment_id"] for o in A.occurrences(root)] == ["id-A", "id-B"]
-    assert A.current_live(root) == "id-B"
+    a1 = A.ensure_artifact(root, {"t.csv": _csv(tmp_path / "a.csv", "declaration_version_id,x\nabc,1\n")}, {}, "gen-1")
+    a2 = A.ensure_artifact(root, {"t.csv": _csv(tmp_path / "b.csv", "declaration_version_id,x\nabc,2\n")}, {}, "gen-2")
+    A.record_occurrence(root, "deploy", "gen-1", a1, None, at="2026-01-01T00:00:00+00:00")
+    A.record_occurrence(root, "deploy", "gen-2", a2, a1, at="2026-01-02T00:00:00+00:00")
+    # Make a1 the newest directory by mtime; the occurrence log still says a2 is live.
+    (A.artifact_dir(root, a1) / "touch").write_text("x", encoding="utf-8")
+    assert A.current_live_artifact_id(root) == a2
 
 
-def test_rollback_to_a_prior_identity_is_an_occurrence_not_a_rewrite(tmp_path):
-    root = tmp_path / "archive"
-    a_target, _ = A.store(root, "id-A", _files(tmp_path), {}, at="2026-01-01T00:00:00+00:00")
-    A.store(root, "id-B", _files(tmp_path), {}, at="2026-01-02T00:00:00+00:00")
-    a_written = a_target.stat().st_mtime_ns
-
-    target, kind = A.store(root, "id-A", _files(tmp_path), {}, at="2026-01-03T00:00:00+00:00")
-    assert kind == "rollback"
-    assert target == a_target
-    assert a_target.stat().st_mtime_ns == a_written, "the immutable archive was rewritten on rollback"
-    assert [o["kind"] for o in A.occurrences(root)] == ["deploy", "deploy", "rollback"]
-    assert A.current_live(root) == "id-A", "rollback re-points live at the restored identity"
-
-
-def test_live_state_comes_from_occurrences_not_directory_mtime(tmp_path):
-    root = tmp_path / "archive"
-    a_target, _ = A.store(root, "id-A", _files(tmp_path), {}, at="2026-01-01T00:00:00+00:00")
-    A.store(root, "id-B", _files(tmp_path), {}, at="2026-01-02T00:00:00+00:00")
-    # Make id-A the newest directory by mtime; the occurrence log still says id-B is live.
-    (a_target / "touch").write_text("x", encoding="utf-8")
-    assert A.current_live(root) == "id-B"
-    assert A.current_live_archive(root) == A.archive_path(root, "id-B")
-
-
-def test_publishing_from_an_archive_never_nests(tmp_path):
-    """Republishing a prior archive's bytes writes its occurrence to the fixed root, not inside the
-    archive directory it is reading from."""
-    root = tmp_path / "archive"
-    a_target, _ = A.store(root, "id-A", _files(tmp_path), {}, at="2026-01-01T00:00:00+00:00")
-    A.store(root, "id-B", _files(tmp_path), {}, at="2026-01-02T00:00:00+00:00")
-
-    # "Publish from the archive": the candidate files are read from inside id-A's archive dir, but
-    # the archive root is the fixed canonical root — so id-A is restored as a rollback occurrence and
-    # nothing is written inside a_target.
-    before = set(a_target.iterdir())
-    _, kind = A.store(root, "id-A", {"t.csv": a_target / "t.csv"}, {}, at="2026-01-03T00:00:00+00:00")
-    assert kind == "rollback"
-    assert set(a_target.iterdir()) == before, "an archive was nested inside the bytes being restored"
-    assert not A.archive_path(a_target, "id-A").exists()
-    assert not (a_target / A.OCCURRENCES).exists()
-    assert A.current_live(root) == "id-A"
-
-
-def test_bad_occurrence_kind_is_rejected(tmp_path):
-    root = tmp_path / "archive"
+def test_bad_operation_is_rejected(tmp_path):
     try:
-        A.record_occurrence(root, "sideways", "id-A")
+        A.record_occurrence(tmp_path / "archive", "sideways", "gen", "aid", None)
     except ValueError as exc:
         assert "deploy" in str(exc)
     else:
-        raise AssertionError("record_occurrence must reject an unknown kind")
+        raise AssertionError("record_occurrence must reject an unknown operation")

--- a/tests/test_deployment_archive.py
+++ b/tests/test_deployment_archive.py
@@ -1,0 +1,98 @@
+"""The shared deployment archive: immutable identity + append-only occurrence log.
+
+`build/deployment_archive.py` is the rollback record shared by the evaluation and scoring-trace
+publishers. These tests pin the properties the cutover plan depends on: live state is read from the
+occurrence log (never directory mtimes), a rollback is an occurrence rather than a rewrite, and
+publishing from an archive never nests a new archive inside the bytes being restored.
+"""
+
+import build.deployment_archive as A
+
+
+def _candidate(tmp_path, name, text="a,b\n1,2\n"):
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def _files(tmp_path):
+    return {"t.csv": _candidate(tmp_path, "t.csv")}
+
+
+def test_empty_root_reads_as_no_live_state_and_creates_nothing(tmp_path):
+    root = tmp_path / "archive"
+    assert A.occurrences(root) == []
+    assert A.current_live(root) is None
+    assert A.current_live_archive(root) is None
+    assert not root.exists(), "reading live state must not create the archive root"
+
+
+def test_a_fresh_identity_is_a_deploy_and_becomes_live(tmp_path):
+    root = tmp_path / "archive"
+    target, kind = A.store(root, "id-A", _files(tmp_path), {"t": {"rows": 1}}, at="2026-01-01T00:00:00+00:00")
+    assert kind == "deploy"
+    assert target == A.archive_path(root, "id-A")
+    assert (target / "t.csv").exists() and (target / "receipt.json").exists()
+    assert A.current_live(root) == "id-A"
+
+
+def test_a_new_identity_advances_live_and_both_are_deploys(tmp_path):
+    root = tmp_path / "archive"
+    A.store(root, "id-A", _files(tmp_path), {}, at="2026-01-01T00:00:00+00:00")
+    A.store(root, "id-B", _files(tmp_path), {}, at="2026-01-02T00:00:00+00:00")
+    assert [o["kind"] for o in A.occurrences(root)] == ["deploy", "deploy"]
+    assert [o["deployment_id"] for o in A.occurrences(root)] == ["id-A", "id-B"]
+    assert A.current_live(root) == "id-B"
+
+
+def test_rollback_to_a_prior_identity_is_an_occurrence_not_a_rewrite(tmp_path):
+    root = tmp_path / "archive"
+    a_target, _ = A.store(root, "id-A", _files(tmp_path), {}, at="2026-01-01T00:00:00+00:00")
+    A.store(root, "id-B", _files(tmp_path), {}, at="2026-01-02T00:00:00+00:00")
+    a_written = a_target.stat().st_mtime_ns
+
+    target, kind = A.store(root, "id-A", _files(tmp_path), {}, at="2026-01-03T00:00:00+00:00")
+    assert kind == "rollback"
+    assert target == a_target
+    assert a_target.stat().st_mtime_ns == a_written, "the immutable archive was rewritten on rollback"
+    assert [o["kind"] for o in A.occurrences(root)] == ["deploy", "deploy", "rollback"]
+    assert A.current_live(root) == "id-A", "rollback re-points live at the restored identity"
+
+
+def test_live_state_comes_from_occurrences_not_directory_mtime(tmp_path):
+    root = tmp_path / "archive"
+    a_target, _ = A.store(root, "id-A", _files(tmp_path), {}, at="2026-01-01T00:00:00+00:00")
+    A.store(root, "id-B", _files(tmp_path), {}, at="2026-01-02T00:00:00+00:00")
+    # Make id-A the newest directory by mtime; the occurrence log still says id-B is live.
+    (a_target / "touch").write_text("x", encoding="utf-8")
+    assert A.current_live(root) == "id-B"
+    assert A.current_live_archive(root) == A.archive_path(root, "id-B")
+
+
+def test_publishing_from_an_archive_never_nests(tmp_path):
+    """Republishing a prior archive's bytes writes its occurrence to the fixed root, not inside the
+    archive directory it is reading from."""
+    root = tmp_path / "archive"
+    a_target, _ = A.store(root, "id-A", _files(tmp_path), {}, at="2026-01-01T00:00:00+00:00")
+    A.store(root, "id-B", _files(tmp_path), {}, at="2026-01-02T00:00:00+00:00")
+
+    # "Publish from the archive": the candidate files are read from inside id-A's archive dir, but
+    # the archive root is the fixed canonical root — so id-A is restored as a rollback occurrence and
+    # nothing is written inside a_target.
+    before = set(a_target.iterdir())
+    _, kind = A.store(root, "id-A", {"t.csv": a_target / "t.csv"}, {}, at="2026-01-03T00:00:00+00:00")
+    assert kind == "rollback"
+    assert set(a_target.iterdir()) == before, "an archive was nested inside the bytes being restored"
+    assert not A.archive_path(a_target, "id-A").exists()
+    assert not (a_target / A.OCCURRENCES).exists()
+    assert A.current_live(root) == "id-A"
+
+
+def test_bad_occurrence_kind_is_rejected(tmp_path):
+    root = tmp_path / "archive"
+    try:
+        A.record_occurrence(root, "sideways", "id-A")
+    except ValueError as exc:
+        assert "deploy" in str(exc)
+    else:
+        raise AssertionError("record_occurrence must reject an unknown kind")

--- a/tests/test_publish_evaluation.py
+++ b/tests/test_publish_evaluation.py
@@ -311,6 +311,76 @@ def test_rollback_with_altered_bytes_is_rejected_and_records_nothing(tmp_path, m
     assert P.archive.occurrences(root) == [], "a rejected rollback records no occurrence"
 
 
+def test_dataset_and_model_creation_cannot_precede_artifact_persistence(tmp_path, monkeypatch):
+    """The candidate bytes must be archived BEFORE any create-capable platform call — resolve_* with
+    create=True can create the dataset or static models."""
+    _valid_candidates(tmp_path)
+    root = tmp_path / "archive"
+    order: list[str] = []
+    real_ensure = P.archive.ensure_artifact
+
+    def spy_ensure(*a, **k):
+        order.append("ensure-artifact")
+        return real_ensure(*a, **k)
+
+    def fake_dataset(name, org_id, token, create):
+        if create:
+            order.append("create-dataset")
+        return "ds-eval"
+
+    def fake_models(dataset_id, org_id, token, tables, create):
+        if create:
+            order.append("create-models")
+        return {t: (f"id-{t}", True) for t in P.EVAL_TABLES}
+
+    monkeypatch.setattr(P.archive, "ensure_artifact", spy_ensure)
+    monkeypatch.setattr(P, "resolve_evaluation_dataset", fake_dataset)
+    monkeypatch.setattr(P, "resolve_static_models", fake_models)
+    fake = _fake_platform([])
+    monkeypatch.setattr(P, "graphql", fake)
+    monkeypatch.setattr(PR, "graphql", fake)
+    monkeypatch.setattr(P, "upload", lambda path, url: None)
+    monkeypatch.setattr(P, "poll_run_group", lambda gid, token, timeout=1800.0: "SUCCESS")
+    monkeypatch.setattr(P, "deployed_table_state", lambda dataset, table: _deployed_matching(tmp_path)[table])
+    monkeypatch.setenv("OSO_API_KEY", "tok")
+    monkeypatch.setenv("OSO_ORG_ID", "org")
+    monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--dir", str(tmp_path), "--archive-root", str(root)])
+
+    assert P.main() == 0
+    assert order and order[0] == "ensure-artifact", f"artifact must be persisted before any create: {order}"
+    assert "create-dataset" in order and "create-models" in order
+
+
+def test_rollback_rejects_a_tampered_receipt_before_touching_the_platform(tmp_path, monkeypatch):
+    """A forged receipt (deployment_id or all_null_columns) is caught by provenance reconstruction
+    from the verified bytes — before any network call."""
+    import json
+
+    _valid_candidates(tmp_path)
+
+    def _no_network(*a, **k):
+        raise AssertionError("a rejected rollback must not touch the platform")
+
+    for tamper in ("deployment_id", "all_null_columns"):
+        root = tmp_path / f"archive-{tamper}"  # isolate: a fresh, untampered archive per case
+        aid = P.archive.ensure_artifact(root, P.archived_files(tmp_path), P.build_receipt(tmp_path),
+                                        P.deployment_id(tmp_path))
+        rj = P.archive.artifact_dir(root, aid) / P.archive.RECEIPT
+        doc = json.loads(rj.read_text())
+        if tamper == "deployment_id":
+            doc["deployment_id"] = "forged-generation"
+        else:  # suppress a would-be missing-column failure by forging the all-null set
+            doc["tables"]["adoption_reconciliation"]["all_null_columns"] = ["declaration_version_id"]
+        rj.write_text(json.dumps(doc), encoding="utf-8")
+
+        monkeypatch.setattr(P, "graphql", _no_network)
+        monkeypatch.setenv("OSO_API_KEY", "tok")
+        monkeypatch.setenv("OSO_ORG_ID", "org")
+        monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--rollback", aid, "--archive-root", str(root)])
+        assert P.main() == 2, f"a receipt tampered on {tamper} must be rejected"
+        assert P.archive.occurrences(root) == [], "a rejected rollback records no occurrence"
+
+
 def test_load_run_is_requested_once_per_model_and_awaited(tmp_path, monkeypatch):
     """Each table gets its OWN run request, naming exactly one model, and is awaited in turn.
 

--- a/tests/test_publish_evaluation.py
+++ b/tests/test_publish_evaluation.py
@@ -92,7 +92,7 @@ def test_plan_validates_offline_and_writes_nothing(tmp_path, monkeypatch):
         raise AssertionError("--plan must not hit the network")
 
     monkeypatch.setattr(P, "graphql", _no_network)
-    monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--plan", "--dir", str(tmp_path)])
+    monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--plan", "--dir", str(tmp_path), "--archive-root", str(tmp_path / "archive")])
     before = set(tmp_path.iterdir())
     assert P.main() == 0
     assert set(tmp_path.iterdir()) == before  # no deployments dir, no receipt
@@ -113,11 +113,11 @@ def test_dry_run_with_credentials_makes_no_mutation_and_no_write(tmp_path, monke
 
     monkeypatch.setattr(P, "graphql", fake_graphql)
     monkeypatch.setattr(PR, "graphql", fake_graphql)  # resolve_static_models uses publish_registry's
-    monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--dry-run", "--dir", str(tmp_path)])
+    monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--dry-run", "--dir", str(tmp_path), "--archive-root", str(tmp_path / "archive")])
     before = set(tmp_path.iterdir())
     assert P.main() == 0
     assert set(tmp_path.iterdir()) == before
-    assert not P.deployments_dir(tmp_path).exists()
+    assert not (tmp_path / "archive").exists()  # a dry run writes no archive and no occurrence log
 
 
 def test_publish_without_credentials_refuses(tmp_path, monkeypatch):
@@ -129,12 +129,12 @@ def test_publish_without_credentials_refuses(tmp_path, monkeypatch):
         raise AssertionError("must not hit the network without credentials")
 
     monkeypatch.setattr(P, "graphql", _no_network)
-    monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--dry-run", "--dir", str(tmp_path)])
+    monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--dry-run", "--dir", str(tmp_path), "--archive-root", str(tmp_path / "archive")])
     assert P.main() == 2
 
 
 def test_missing_csv_is_a_loud_failure(tmp_path, monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--plan", "--dir", str(tmp_path)])
+    monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--plan", "--dir", str(tmp_path), "--archive-root", str(tmp_path / "archive")])
     assert P.main() == 2
 
 
@@ -204,7 +204,7 @@ def test_the_publisher_polls_the_exact_run_group_the_mutation_returned(tmp_path,
     monkeypatch.setattr(P, "deployment_mismatches", lambda expected, deployed: ["stop here"])
     monkeypatch.setenv("OSO_API_KEY", "tok")
     monkeypatch.setenv("OSO_ORG_ID", "org")
-    monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--dir", str(tmp_path)])
+    monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--dir", str(tmp_path), "--archive-root", str(tmp_path / "archive")])
 
     assert P.main() == 2  # stopped at the injected mismatch, after polling every group
     assert polled == [f"grp-for-id-{t}" for t in P.EVAL_TABLES]
@@ -213,21 +213,29 @@ def test_the_publisher_polls_the_exact_run_group_the_mutation_returned(tmp_path,
 # --- the immutable deployment archive --------------------------------------------
 
 
-def test_deployment_archive_is_immutable(tmp_path):
+def test_deployment_archive_is_immutable_and_rollback_is_an_occurrence(tmp_path):
     _valid_candidates(tmp_path)
     receipt = P.build_receipt(tmp_path)
-    archive = P.archive_deployment(tmp_path, receipt)
-    assert archive.exists() and (archive / "receipt.json").exists()
+    root = tmp_path / "archive"
+    did = P.deployment_id(tmp_path)
+
+    # First store of a fresh identity is a deploy: the immutable dir + receipt + CSVs are written.
+    target, kind = P.archive.store(root, did, P.archived_files(tmp_path), receipt)
+    assert kind == "deploy"
+    assert target.exists() and (target / "receipt.json").exists()
     for table in P.EVAL_TABLES:
-        assert (archive / f"{table}.csv").exists()
-    assert P.latest_archive(tmp_path) == archive
-    # A second archive of the same identities is refused — the record is written once.
-    try:
-        P.archive_deployment(tmp_path, receipt)
-    except RuntimeError as exc:
-        assert "already exists" in str(exc)
-    else:
-        raise AssertionError("archive_deployment must refuse to overwrite an existing deployment id")
+        assert (target / f"{table}.csv").exists()
+    assert P.archive.current_live_archive(root) == target
+    written = target.stat().st_mtime_ns
+
+    # Re-storing the SAME identity (re-publishing archived bytes) is a rollback: the immutable dir is
+    # NOT rewritten, and an occurrence is appended — live-state comes from the log, not mtimes.
+    target2, kind2 = P.archive.store(root, did, P.archived_files(tmp_path), receipt)
+    assert kind2 == "rollback" and target2 == target
+    assert target.stat().st_mtime_ns == written, "the immutable archive was rewritten"
+    occ = P.archive.occurrences(root)
+    assert [o["kind"] for o in occ] == ["deploy", "rollback"]
+    assert P.archive.current_live(root) == did
 
 
 def test_load_run_is_requested_once_per_model_and_awaited(tmp_path, monkeypatch):
@@ -269,7 +277,7 @@ def test_load_run_is_requested_once_per_model_and_awaited(tmp_path, monkeypatch)
     monkeypatch.setattr(P, "deployment_mismatches", lambda expected, deployed: ["stop here"])
     monkeypatch.setenv("OSO_API_KEY", "tok")
     monkeypatch.setenv("OSO_ORG_ID", "org")
-    monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--dir", str(tmp_path)])
+    monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--dir", str(tmp_path), "--archive-root", str(tmp_path / "archive")])
 
     assert P.main() == 2  # stopped at the injected mismatch, after both runs were requested
 
@@ -311,11 +319,11 @@ def test_a_failed_run_stops_the_deploy_before_the_next_model(tmp_path, monkeypat
     monkeypatch.setattr(P, "deployed_table_state", boom)
     monkeypatch.setenv("OSO_API_KEY", "tok")
     monkeypatch.setenv("OSO_ORG_ID", "org")
-    monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--dir", str(tmp_path)])
+    monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--dir", str(tmp_path), "--archive-root", str(tmp_path / "archive")])
 
     assert P.main() == 2
     assert len(requested) == 1, "the second model is not requested after the first fails"
-    assert P.latest_archive(tmp_path) is None, "a failed deploy archives nothing"
+    assert P.archive.current_live(tmp_path / "archive") is None, "a failed deploy records no occurrence"
 
 
 # --- the deployed-schema comparison ----------------------------------------------

--- a/tests/test_publish_evaluation.py
+++ b/tests/test_publish_evaluation.py
@@ -213,29 +213,102 @@ def test_the_publisher_polls_the_exact_run_group_the_mutation_returned(tmp_path,
 # --- the immutable deployment archive --------------------------------------------
 
 
-def test_deployment_archive_is_immutable_and_rollback_is_an_occurrence(tmp_path):
+def test_ensure_artifact_writes_a_verifiable_content_addressed_archive(tmp_path):
     _valid_candidates(tmp_path)
     receipt = P.build_receipt(tmp_path)
     root = tmp_path / "archive"
-    did = P.deployment_id(tmp_path)
-
-    # First store of a fresh identity is a deploy: the immutable dir + receipt + CSVs are written.
-    target, kind = P.archive.store(root, did, P.archived_files(tmp_path), receipt)
-    assert kind == "deploy"
-    assert target.exists() and (target / "receipt.json").exists()
+    aid = P.archive.ensure_artifact(root, P.archived_files(tmp_path), receipt, P.deployment_id(tmp_path))
+    adir = P.archive.artifact_dir(root, aid)
+    assert adir.name == aid
     for table in P.EVAL_TABLES:
-        assert (target / f"{table}.csv").exists()
-    assert P.archive.current_live_archive(root) == target
-    written = target.stat().st_mtime_ns
+        assert (adir / f"{table}.csv").exists()
+    assert (adir / P.archive.RECEIPT).exists() and (adir / P.archive.SHA256SUMS).exists()
+    P.archive.verify_artifact(root, aid)  # the archive is complete and hashes match
+    # ensure_artifact alone records no occurrence — the publisher does that only after verification.
+    assert P.archive.current_live(root) is None
 
-    # Re-storing the SAME identity (re-publishing archived bytes) is a rollback: the immutable dir is
-    # NOT rewritten, and an occurrence is appended — live-state comes from the log, not mtimes.
-    target2, kind2 = P.archive.store(root, did, P.archived_files(tmp_path), receipt)
-    assert kind2 == "rollback" and target2 == target
-    assert target.stat().st_mtime_ns == written, "the immutable archive was rewritten"
+
+def _fake_platform(requested):
+    def fake_graphql(query, variables, token):
+        if query is P.Q_DATASETS:
+            return {"datasets": {"edges": [{"node": {"id": "ds-eval", "name": "evaluation",
+                                                     "type": "STATIC_MODEL"}}]}}
+        if query is PR.Q_STATIC:
+            return {"staticModels": {"edges": [
+                {"node": {"id": f"id-{t}", "name": t, "materializations": {"totalCount": 1}}}
+                for t in P.EVAL_TABLES]}}
+        if query is P.M_URL:
+            return {"createStaticModelUploadUrl": "https://upload.example/put"}
+        if query is P.M_RUN:
+            requested.append(variables["input"])
+            return {"createStaticModelRunRequest":
+                    {"runGroup": {"id": f"group-{len(requested)}", "status": "QUEUED"}}}
+        raise AssertionError(f"unexpected query: {query[:60]}")
+    return fake_graphql
+
+
+def _wire_success(monkeypatch, requested, deployed_rows):
+    fake = _fake_platform(requested)
+    monkeypatch.setattr(P, "graphql", fake)
+    monkeypatch.setattr(PR, "graphql", fake)
+    monkeypatch.setattr(P, "upload", lambda path, url: None)
+    monkeypatch.setattr(P, "poll_run_group", lambda gid, token, timeout=1800.0: "SUCCESS")
+    monkeypatch.setattr(P, "deployed_table_state", lambda dataset, table: deployed_rows[table])
+    monkeypatch.setenv("OSO_API_KEY", "tok")
+    monkeypatch.setenv("OSO_ORG_ID", "org")
+
+
+def _deployed_matching(tmp_path):
+    """Deployed row/column state that matches the candidate, so deployment_mismatches passes."""
+    receipt = P.build_receipt(tmp_path)
+    return {t: {"rows": receipt[t]["rows"], "columns": receipt[t]["columns"]} for t in P.EVAL_TABLES}
+
+
+def test_a_deploy_records_a_deploy_occurrence_after_verification(tmp_path, monkeypatch):
+    _valid_candidates(tmp_path)
+    root = tmp_path / "archive"
+    _wire_success(monkeypatch, [], _deployed_matching(tmp_path))
+    monkeypatch.setattr(sys, "argv", ["publish_evaluation", "--dir", str(tmp_path), "--archive-root", str(root)])
+    assert P.main() == 0
     occ = P.archive.occurrences(root)
-    assert [o["kind"] for o in occ] == ["deploy", "rollback"]
-    assert P.archive.current_live(root) == did
+    assert len(occ) == 1 and occ[0]["operation"] == "deploy"
+    assert occ[0]["previous_artifact_id"] is None
+    live = P.archive.current_live_artifact_id(root)
+    assert occ[0]["artifact_id"] == live
+    P.archive.verify_artifact(root, live)  # the live artifact is archived and intact
+
+
+def test_explicit_rollback_reuploads_a_verified_artifact_and_records_rollback(tmp_path, monkeypatch):
+    _valid_candidates(tmp_path)
+    root = tmp_path / "archive"
+    # Pre-archive an artifact to roll back to.
+    aid = P.archive.ensure_artifact(root, P.archived_files(tmp_path), P.build_receipt(tmp_path), P.deployment_id(tmp_path))
+    _wire_success(monkeypatch, [], _deployed_matching(tmp_path))
+    monkeypatch.setattr(sys, "argv",
+                        ["publish_evaluation", "--rollback", aid, "--archive-root", str(root)])
+    assert P.main() == 0
+    occ = P.archive.occurrences(root)
+    assert [o["operation"] for o in occ] == ["rollback"]
+    assert occ[0]["artifact_id"] == aid
+
+
+def test_rollback_with_altered_bytes_is_rejected_and_records_nothing(tmp_path, monkeypatch):
+    _valid_candidates(tmp_path)
+    root = tmp_path / "archive"
+    aid = P.archive.ensure_artifact(root, P.archived_files(tmp_path), P.build_receipt(tmp_path), P.deployment_id(tmp_path))
+    # Tamper with an archived byte after the fact.
+    (P.archive.artifact_dir(root, aid) / "adoption_reconciliation.csv").write_text("x,y\n1,2\n", encoding="utf-8")
+
+    def _no_network(*a, **k):
+        raise AssertionError("a rejected rollback must not touch the platform")
+
+    monkeypatch.setattr(P, "graphql", _no_network)
+    monkeypatch.setenv("OSO_API_KEY", "tok")
+    monkeypatch.setenv("OSO_ORG_ID", "org")
+    monkeypatch.setattr(sys, "argv",
+                        ["publish_evaluation", "--rollback", aid, "--archive-root", str(root)])
+    assert P.main() == 2
+    assert P.archive.occurrences(root) == [], "a rejected rollback records no occurrence"
 
 
 def test_load_run_is_requested_once_per_model_and_awaited(tmp_path, monkeypatch):

--- a/tests/test_publish_scoring_trace.py
+++ b/tests/test_publish_scoring_trace.py
@@ -350,7 +350,7 @@ def _wire(monkeypatch, requested):
     monkeypatch.setattr(P, "graphql", fake)
     monkeypatch.setattr(PR, "graphql", fake)
     monkeypatch.setattr(PE, "graphql", fake)
-    monkeypatch.setattr(P, "upload", lambda path, url: None)
+    monkeypatch.setattr(PE, "upload", lambda path, url: None)
     monkeypatch.setenv("OSO_API_KEY", "tok")
     monkeypatch.setenv("OSO_ORG_ID", "org")
 
@@ -359,8 +359,8 @@ def test_load_run_is_requested_once_per_model_with_static_model_id(tmp_path, mon
     _synthetic_candidates(tmp_path)
     requested: list[dict] = []
     _wire(monkeypatch, requested)
-    monkeypatch.setattr(P, "poll_run_group", lambda gid, token, timeout=1800.0: "SUCCESS")
-    monkeypatch.setattr(P, "deployed_table_state", lambda dataset, table: {"rows": 0, "columns": []})
+    monkeypatch.setattr(PE, "poll_run_group", lambda gid, token, timeout=1800.0: "SUCCESS")
+    monkeypatch.setattr(PE, "deployed_table_state", lambda dataset, table: {"rows": 0, "columns": []})
     monkeypatch.setattr(P, "deployment_mismatches", lambda expected, deployed: ["stop here"])
     monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dir", str(tmp_path), "--archive-root", str(tmp_path / "archive")])
 
@@ -382,8 +382,8 @@ def test_the_publisher_polls_the_exact_run_group_the_mutation_returned(tmp_path,
         polled.append(gid)
         return "SUCCESS"
 
-    monkeypatch.setattr(P, "poll_run_group", record_poll)
-    monkeypatch.setattr(P, "deployed_table_state", lambda dataset, table: {"rows": 0, "columns": []})
+    monkeypatch.setattr(PE, "poll_run_group", record_poll)
+    monkeypatch.setattr(PE, "deployed_table_state", lambda dataset, table: {"rows": 0, "columns": []})
     monkeypatch.setattr(P, "deployment_mismatches", lambda expected, deployed: ["stop here"])
     monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dir", str(tmp_path), "--archive-root", str(tmp_path / "archive")])
 
@@ -395,12 +395,12 @@ def test_a_failed_run_stops_the_deploy_before_the_next_model(tmp_path, monkeypat
     _synthetic_candidates(tmp_path)
     requested: list[dict] = []
     _wire(monkeypatch, requested)
-    monkeypatch.setattr(P, "poll_run_group", lambda gid, token, timeout=1800.0: "FAILED")
+    monkeypatch.setattr(PE, "poll_run_group", lambda gid, token, timeout=1800.0: "FAILED")
 
     def boom(dataset, table):
         raise AssertionError("must not read deployed state when a run failed")
 
-    monkeypatch.setattr(P, "deployed_table_state", boom)
+    monkeypatch.setattr(PE, "deployed_table_state", boom)
     monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dir", str(tmp_path), "--archive-root", str(tmp_path / "archive")])
 
     assert P.main() == 2
@@ -421,25 +421,17 @@ def test_deployment_mismatches_catches_row_and_schema_drift():
     assert any("columns" in m for m in P.deployment_mismatches(expected, wrong_cols))
 
 
-def test_deployment_archive_is_immutable_and_rollback_is_an_occurrence(tmp_path):
+def test_ensure_artifact_writes_a_verifiable_content_addressed_archive(tmp_path):
     _synthetic_candidates(tmp_path)
-    receipt = P.build_receipt(tmp_path)
     root = tmp_path / "archive"
-    did = P.deployment_id(tmp_path)
-
-    target, kind = P.archive.store(root, did, P.archived_files(tmp_path), receipt)
-    assert kind == "deploy"
-    assert target.exists() and (target / "receipt.json").exists()
+    aid = P.archive.ensure_artifact(root, P.archived_files(tmp_path), P.build_receipt(tmp_path), P.deployment_id(tmp_path))
+    adir = P.archive.artifact_dir(root, aid)
+    assert adir.name == aid
     for table in P.TRACE_TABLES:
-        assert (target / f"{table}.csv").exists()
-    assert P.archive.current_live_archive(root) == target
-    written = target.stat().st_mtime_ns
-
-    # Re-storing the same identity is a rollback occurrence, not a rewrite.
-    target2, kind2 = P.archive.store(root, did, P.archived_files(tmp_path), receipt)
-    assert kind2 == "rollback" and target2 == target
-    assert target.stat().st_mtime_ns == written
-    assert [o["kind"] for o in P.archive.occurrences(root)] == ["deploy", "rollback"]
+        assert (adir / f"{table}.csv").exists()
+    assert (adir / P.archive.RECEIPT).exists() and (adir / P.archive.SHA256SUMS).exists()
+    P.archive.verify_artifact(root, aid)
+    assert P.archive.current_live(root) is None  # ensure_artifact alone records no occurrence
 
 
 def test_the_trace_archive_root_is_its_own_never_the_evaluation_publishers(tmp_path):

--- a/tests/test_publish_scoring_trace.py
+++ b/tests/test_publish_scoring_trace.py
@@ -273,7 +273,7 @@ def test_plan_validates_offline_and_writes_nothing(tmp_path, monkeypatch):
         raise AssertionError("--plan must not hit the network")
 
     monkeypatch.setattr(P, "graphql", _no_network)
-    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--plan", "--dir", str(tmp_path)])
+    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--plan", "--dir", str(tmp_path), "--archive-root", str(tmp_path / "archive")])
     before = set(tmp_path.iterdir())
     assert P.main() == 0
     assert set(tmp_path.iterdir()) == before
@@ -295,11 +295,11 @@ def test_dry_run_with_credentials_makes_no_mutation_and_no_write(tmp_path, monke
     monkeypatch.setattr(P, "graphql", fake_graphql)
     monkeypatch.setattr(PR, "graphql", fake_graphql)
     monkeypatch.setattr(PE, "graphql", fake_graphql)  # resolve_evaluation_dataset uses PE's graphql
-    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dry-run", "--dir", str(tmp_path)])
+    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dry-run", "--dir", str(tmp_path), "--archive-root", str(tmp_path / "archive")])
     before = set(tmp_path.iterdir())
     assert P.main() == 0
     assert set(tmp_path.iterdir()) == before
-    assert not P.deployments_dir(tmp_path).exists()
+    assert not (tmp_path / "archive").exists()  # a dry run writes no archive and no occurrence log
 
 
 def test_publish_without_credentials_refuses(tmp_path, monkeypatch):
@@ -312,12 +312,12 @@ def test_publish_without_credentials_refuses(tmp_path, monkeypatch):
         raise AssertionError("must not hit the network without credentials")
 
     monkeypatch.setattr(P, "graphql", _no_network)
-    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dry-run", "--dir", str(tmp_path)])
+    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dry-run", "--dir", str(tmp_path), "--archive-root", str(tmp_path / "archive")])
     assert P.main() == 2
 
 
 def test_missing_csv_is_a_loud_failure(tmp_path, monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--plan", "--dir", str(tmp_path)])
+    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--plan", "--dir", str(tmp_path), "--archive-root", str(tmp_path / "archive")])
     assert P.main() == 2
 
 
@@ -362,7 +362,7 @@ def test_load_run_is_requested_once_per_model_with_static_model_id(tmp_path, mon
     monkeypatch.setattr(P, "poll_run_group", lambda gid, token, timeout=1800.0: "SUCCESS")
     monkeypatch.setattr(P, "deployed_table_state", lambda dataset, table: {"rows": 0, "columns": []})
     monkeypatch.setattr(P, "deployment_mismatches", lambda expected, deployed: ["stop here"])
-    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dir", str(tmp_path)])
+    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dir", str(tmp_path), "--archive-root", str(tmp_path / "archive")])
 
     assert P.main() == 2  # stopped at the injected mismatch, after all three runs were requested
     assert len(requested) == len(P.TRACE_TABLES), "one run request per model"
@@ -385,7 +385,7 @@ def test_the_publisher_polls_the_exact_run_group_the_mutation_returned(tmp_path,
     monkeypatch.setattr(P, "poll_run_group", record_poll)
     monkeypatch.setattr(P, "deployed_table_state", lambda dataset, table: {"rows": 0, "columns": []})
     monkeypatch.setattr(P, "deployment_mismatches", lambda expected, deployed: ["stop here"])
-    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dir", str(tmp_path)])
+    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dir", str(tmp_path), "--archive-root", str(tmp_path / "archive")])
 
     assert P.main() == 2
     assert polled == [f"grp-for-id-{t}" for t in P.TRACE_TABLES]
@@ -401,11 +401,11 @@ def test_a_failed_run_stops_the_deploy_before_the_next_model(tmp_path, monkeypat
         raise AssertionError("must not read deployed state when a run failed")
 
     monkeypatch.setattr(P, "deployed_table_state", boom)
-    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dir", str(tmp_path)])
+    monkeypatch.setattr(sys, "argv", ["publish_scoring_trace", "--dir", str(tmp_path), "--archive-root", str(tmp_path / "archive")])
 
     assert P.main() == 2
     assert len(requested) == 1, "the second model is not requested after the first fails"
-    assert P.latest_archive(tmp_path) is None, "a failed deploy archives nothing"
+    assert P.archive.current_live(tmp_path / "archive") is None, "a failed deploy records no occurrence"
 
 
 # --- the deployed-schema comparison and the immutable archive --------------------
@@ -421,20 +421,28 @@ def test_deployment_mismatches_catches_row_and_schema_drift():
     assert any("columns" in m for m in P.deployment_mismatches(expected, wrong_cols))
 
 
-def test_deployment_archive_is_immutable_and_in_its_own_subdir(tmp_path):
+def test_deployment_archive_is_immutable_and_rollback_is_an_occurrence(tmp_path):
     _synthetic_candidates(tmp_path)
     receipt = P.build_receipt(tmp_path)
-    archive = P.archive_deployment(tmp_path, receipt)
-    assert archive.exists() and (archive / "receipt.json").exists()
+    root = tmp_path / "archive"
+    did = P.deployment_id(tmp_path)
+
+    target, kind = P.archive.store(root, did, P.archived_files(tmp_path), receipt)
+    assert kind == "deploy"
+    assert target.exists() and (target / "receipt.json").exists()
     for table in P.TRACE_TABLES:
-        assert (archive / f"{table}.csv").exists()
-    # Its own subdirectory — never the evaluation publisher's `deployments/`.
-    assert P.deployments_dir(tmp_path).name == "scoring-trace-deployments"
-    assert P.deployments_dir(tmp_path) != PE.deployments_dir(tmp_path)
-    assert P.latest_archive(tmp_path) == archive
-    try:
-        P.archive_deployment(tmp_path, receipt)
-    except RuntimeError as exc:
-        assert "already exists" in str(exc)
-    else:
-        raise AssertionError("archive_deployment must refuse to overwrite an existing deployment id")
+        assert (target / f"{table}.csv").exists()
+    assert P.archive.current_live_archive(root) == target
+    written = target.stat().st_mtime_ns
+
+    # Re-storing the same identity is a rollback occurrence, not a rewrite.
+    target2, kind2 = P.archive.store(root, did, P.archived_files(tmp_path), receipt)
+    assert kind2 == "rollback" and target2 == target
+    assert target.stat().st_mtime_ns == written
+    assert [o["kind"] for o in P.archive.occurrences(root)] == ["deploy", "rollback"]
+
+
+def test_the_trace_archive_root_is_its_own_never_the_evaluation_publishers(tmp_path):
+    # Default archive roots are distinct, so neither publisher reads the other's archives.
+    assert P.DEFAULT_ARCHIVE_ROOT.name == "scoring-trace-deployments"
+    assert P.DEFAULT_ARCHIVE_ROOT != PE.DEFAULT_ARCHIVE_ROOT


### PR DESCRIPTION
## What

Reworks the maintainer publishers' archive into `build/deployment_archive.py` (shared by `publish_evaluation.py` and `publish_scoring_trace.py`), fixing five integrity issues review surfaced over two rounds. §0.1 prerequisite for the `evaluator_version` cutover. **Tests only — no platform mutation.**

## Round 1 — the archive model

1. **`deployment_id` is not a byte identity.** The artifact is content-addressed: `artifact_id` = SHA-256 over the canonical `filename → file-sha256` manifest, stored under `artifacts/<artifact_id>/` with `SHA256SUMS`. A regenerated `evaluated_at` is a distinct artifact, never mistaken for one archived. Occurrences record both ids.
2. **Operations are explicit, never inferred.** Normal publish records a `deploy`; `--rollback <artifact_id>` re-uploads an already-archived artifact after verifying its hashes and records a `rollback`. Occurrences carry `operation`, `deployment_id`, `artifact_id`, `previous_artifact_id`, timestamp.
3. **Atomic artifact.** `ensure_artifact` writes through a staging dir and atomically renames after all files + receipt + `SHA256SUMS` are written; an interrupted copy never leaves a directory `verify_artifact` accepts. Live state is read from the occurrence log, not directory mtimes.

## Round 2 — remaining integrity blockers

4. **Persist BEFORE any platform mutation.** `resolve_*(create=True)` previously ran before `ensure_artifact`, so a create could precede persistence. `main()` now splits: a dry run resolves read-only (`create=False`) and creates/writes nothing; a real publish calls `ensure_artifact` **first**, then resolves with `create=True`.
5. **`receipt.json` is integrity-checked against the bytes.** `SHA256SUMS` covers only the CSVs, so a forged receipt (`deployment_id`, row count, schema, `all_null_columns`) survived `verify_artifact` and was trusted on rollback. New `verified_rollback_provenance` reconstructs the provenance and `deployment_id` **from the verified bytes**, requires exact agreement with `receipt.json`, requires the stored `artifact_id` to equal the id, and requires the manifest's filename set to equal the publisher's expected tables (no missing/unexpected files). Rollback uses the reconstructed provenance, not the receipt's claims.

Both publishers gain `--rollback` and share `materialize()` (upload → per-model run-group-bound poll → deployed verify).

## Tests

`tests/test_deployment_archive.py` + both publisher suites: content-addressing (same generation/different bytes → different id); hash verification (intact/tampered/absent); interrupted staging leaves nothing valid; occurrence schema + live-from-log-not-mtime; **creation cannot precede artifact persistence** (call-order spy); **receipt tampering rejected before any network call** (`deployment_id`, `all_null_columns`); missing/unexpected manifest files rejected; altered `deployment_id` / rows / `artifact_id` / bytes rejected; a deploy records a `deploy` occurrence after verification; explicit `--rollback` records `rollback`; rollback with altered bytes rejected; platform failure records no occurrence; publishing from an archive never nests; dry-run write-free.

Full suite green (**1106 passed**); `build.validate` prints `0 error(s)`.

## Scope

§0.1 prerequisite. **GitHub Release persistence** (durable bytes as release assets with `SHA256SUMS`; occurrences committed as append-only files in the reconciliation PR) is the next, separate step, where both currently-live generations get recoverable artifacts before any cutover. No cutover is authorized by this change.

## Checklist

- [x] `uv run python -m build.validate` prints `0 error(s)`
- [ ] N/A: no new/changed scores (publish CLIs + shared module + tests)
- [x] I did not edit `build/notebook_data.json` or `notebooks/ai-stack-map.py`
- [ ] N/A: no product/roster changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)