### PR TITLE
Cutover pre-flight: single-identity + semantic no-change invariants (§0.2)

### DIFF
--- a/build/cutover_preflight.py
+++ b/build/cutover_preflight.py
@@ -1,0 +1,255 @@
+"""Cross-cutover pre-flight invariants for the `evaluator_version` cutover (§0.2 / §8).
+
+The cutover bumps `EVALUATOR_VERSION`, rebuilds every declaration-keyed candidate from ONE clean
+commit, and re-uploads them so all five live tables move to a single new `declaration_version_id` in
+one coordinated pass (`docs/operations/evaluator-version-cutover.md`). Two invariants make that swap
+safe, and this module is both — as PURE functions plus an offline CLI, with no platform mutation:
+
+- **Single identity.** Every candidate across BOTH publishers must share one `declaration_version_id`
+  (and, on the tables that carry it, one `source_git_sha`). That proves the single-commit build
+  collapsed to one generation rather than smuggling two.
+
+- **Semantic no-change.** The cutover must change **identity only** — not a fact, rule match, score,
+  route, status, or reconciliation result. For each live table, the non-content columns
+  (`declaration_version_id`, `source_git_sha` where present, and any non-content build timestamp such
+  as `adoption_reconciliation.evaluated_at`) are projected out, and the new candidate rows must equal
+  the currently-deployed rows as an order-independent multiset. Any difference outside the projected
+  columns fails the cutover — it would mean the evaluator bump carried a content change, which D1's
+  bump policy forbids without its own justified generation.
+
+The semantic comparison is a pure multiset over canonicalized rows, so the deployed rows can come from
+an exported CSV (offline, the reviewed path) or from a read-only `pyoso` query (`--live`). Neither
+writes anything; the cutover itself stays unauthorized.
+
+Usage:
+    uv run python -m build.cutover_preflight --dir build/evaluation            # single-identity, offline
+    uv run python -m build.cutover_preflight --dir build/evaluation \
+        --deployed-dir exported/                                               # + semantic vs CSV export
+    uv run python -m build.cutover_preflight --dir build/evaluation --live     # + semantic vs pyoso (read-only)
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT_DIR = ROOT / "build" / "evaluation"
+DEFAULT_DATASET = "evaluation"
+
+# The five live declaration-keyed tables in the cutover set (registry.axis_assessments is excluded by
+# D3 — it has no live identity to re-key). Read the authoritative membership from assets.yaml at
+# execution time (§1); this constant is the pre-flight's own expectation of what it compares.
+CUTOVER_TABLES: tuple[str, ...] = (
+    "product_adoption_measurements",
+    "adoption_reconciliation",
+    "axis_facts",
+    "axis_rule_matches",
+    "axis_results",
+)
+
+IDENTITY_COLUMN = "declaration_version_id"
+SOURCE_SHA_COLUMN = "source_git_sha"
+
+# The non-content columns projected out before the semantic multiset comparison, per table. Everything
+# NOT listed here is content and must be reproduced byte-identically (modulo CSV/loader canonicalization)
+# across the cutover. `source_git_sha` is on the trace tables only; `evaluated_at` (a build timestamp,
+# not a measurement) is on adoption_reconciliation only. The set is stated here and re-affirmed at
+# execution time — a column that should be content must never be silently projected away.
+NON_CONTENT_COLUMNS: dict[str, tuple[str, ...]] = {
+    "product_adoption_measurements": (IDENTITY_COLUMN,),
+    "adoption_reconciliation": (IDENTITY_COLUMN, "evaluated_at"),
+    "axis_facts": (IDENTITY_COLUMN, SOURCE_SHA_COLUMN),
+    "axis_rule_matches": (IDENTITY_COLUMN, SOURCE_SHA_COLUMN),
+    "axis_results": (IDENTITY_COLUMN, SOURCE_SHA_COLUMN),
+}
+
+
+def _read_csv(path: Path) -> list[dict]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def read_candidates(src_dir: Path, tables: tuple[str, ...] = CUTOVER_TABLES) -> dict[str, list[dict]]:
+    """Every cutover candidate present under `src_dir`, keyed by table name (missing files omitted)."""
+    return {t: _read_csv(src_dir / f"{t}.csv") for t in tables if (src_dir / f"{t}.csv").exists()}
+
+
+def completeness_problems(candidates: dict[str, list[dict]], tables: tuple[str, ...] = CUTOVER_TABLES) -> list[str]:
+    """The cutover set must be built completely — cover every table, or do not run."""
+    missing = [t for t in tables if t not in candidates]
+    return [f"missing cutover candidate(s): {missing}"] if missing else []
+
+
+def single_identity_problems(candidates: dict[str, list[dict]]) -> list[str]:
+    """Every candidate across both publishers must share one `declaration_version_id`, and (on the
+    tables that carry it) one `source_git_sha`. Returns a list of problems (empty = ok)."""
+    problems: list[str] = []
+    all_dvids: set[str] = set()
+    all_shas: set[str] = set()
+    for table, rows in candidates.items():
+        if not rows:
+            problems.append(f"{table}: no candidate rows to check identity")
+            continue
+        columns = rows[0].keys()
+        if IDENTITY_COLUMN not in columns:
+            problems.append(f"{table}: missing {IDENTITY_COLUMN}")
+        else:
+            dvids = {r[IDENTITY_COLUMN] for r in rows}
+            if len(dvids) != 1:
+                problems.append(f"{table}: {IDENTITY_COLUMN} is not constant within the file: {sorted(dvids)[:3]}")
+            all_dvids |= dvids
+        if SOURCE_SHA_COLUMN in columns:
+            shas = {r[SOURCE_SHA_COLUMN] for r in rows}
+            if len(shas) != 1:
+                problems.append(f"{table}: {SOURCE_SHA_COLUMN} is not constant within the file: {sorted(shas)[:3]}")
+            all_shas |= shas
+    if len(all_dvids) > 1:
+        problems.append(f"candidates do NOT share one {IDENTITY_COLUMN} (two generations built?): {sorted(all_dvids)}")
+    if len(all_shas) > 1:
+        problems.append(f"candidates do NOT share one {SOURCE_SHA_COLUMN}: {sorted(all_shas)}")
+    return problems
+
+
+def _canonical_scalar(value) -> str:
+    """One canonical string per cell, so a candidate CSV string ("4", "True", "") and the loader's
+    typed round-trip (4, True, None) compare equal. bool is handled before int (a bool IS an int)."""
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "True" if value else "False"
+    return str(value)
+
+
+def _canonical_multiset(rows: list[dict], keep: set[str]) -> Counter:
+    return Counter(
+        tuple(sorted((column, _canonical_scalar(row.get(column))) for column in keep)) for row in rows
+    )
+
+
+def semantic_no_change_problems(
+    table: str, candidate_rows: list[dict], deployed_rows: list[dict], non_content: tuple[str, ...] | None = None
+) -> list[str]:
+    """The candidate must equal the deployed table on CONTENT — identity/timestamp columns projected
+    out — as an order-independent multiset. Returns a list of problems (empty = ok).
+
+    A candidate content column that is empty in every row and absent from the deployed table is the
+    loader's own all-null-column drop (e.g. `adoption_reconciliation.override_id`) and is tolerated; a
+    candidate column that carries data yet is missing downstream, or a deployed content column the
+    candidate never declared, is a real difference. The comparison then runs over the shared content
+    columns; `_dlt_*` loader bookkeeping is always excluded.
+    """
+    drop = set(non_content if non_content is not None else NON_CONTENT_COLUMNS.get(table, (IDENTITY_COLUMN,)))
+    if not candidate_rows:
+        return [f"{table}: no candidate rows"]
+    if not deployed_rows:
+        return [f"{table}: no deployed rows to compare against"]
+
+    candidate_cols = {c for c in candidate_rows[0] if c not in drop and not c.startswith("_dlt_")}
+    deployed_cols = {c for c in deployed_rows[0] if c not in drop and not c.startswith("_dlt_")}
+    problems: list[str] = []
+    for column in sorted(candidate_cols - deployed_cols):
+        if any(_canonical_scalar(r.get(column)) != "" for r in candidate_rows):
+            problems.append(f"{table}: candidate column {column!r} carries data but is absent from the deployed table")
+    only_deployed = deployed_cols - candidate_cols
+    if only_deployed:
+        problems.append(f"{table}: deployed table has content column(s) the candidate does not declare: {sorted(only_deployed)}")
+    if problems:
+        return problems
+
+    compare = candidate_cols & deployed_cols
+    candidate = _canonical_multiset(candidate_rows, compare)
+    deployed = _canonical_multiset(deployed_rows, compare)
+    if candidate == deployed:
+        return []
+    not_reproduced = deployed - candidate
+    invented = candidate - deployed
+    if not_reproduced:
+        problems.append(
+            f"{table}: {sum(not_reproduced.values())} deployed row(s) NOT reproduced by the candidate "
+            f"(e.g. {dict(next(iter(not_reproduced)))})"
+        )
+    if invented:
+        problems.append(
+            f"{table}: {sum(invented.values())} candidate row(s) NOT present in the deployed table "
+            f"(e.g. {dict(next(iter(invented)))})"
+        )
+    return problems
+
+
+def deployed_rows(dataset: str, table: str, timeout: float = 300.0, interval: float = 15.0) -> list[dict]:
+    """Read a deployed table's full rows via `pyoso` — READ-ONLY, no mutation. Retries while the query
+    catalog lags (the same `TablesNotFound` propagation the publishers handle)."""
+    import time
+
+    from build.warehouse import query
+
+    deadline = time.time() + timeout
+    while True:
+        try:
+            rows = query(f"SELECT * FROM currentai.{dataset}.{table}")
+            break
+        except Exception as exc:  # noqa: BLE001 — propagate anything that is not catalog lag
+            if "TablesNotFound" not in str(exc) or time.time() >= deadline:
+                raise
+            time.sleep(interval)
+    return [{k: v for k, v in row.items() if not k.startswith("_dlt_")} for row in rows]
+
+
+def _report(header: str, problems: list[str]) -> None:
+    if problems:
+        print(f"{header}: FAIL", file=sys.stderr)
+        for problem in problems:
+            print(f"  ! {problem}", file=sys.stderr)
+    else:
+        print(f"{header}: ok")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dir", type=Path, default=OUT_DIR, help="where the candidate CSVs are read")
+    parser.add_argument("--deployed-dir", type=Path, default=None,
+                        help="an offline export of the deployed rows (CSV per table) for the semantic check")
+    parser.add_argument("--live", action="store_true",
+                        help="read the deployed rows via pyoso (READ-ONLY) for the semantic check")
+    args = parser.parse_args()
+
+    dataset = None
+    if args.live:
+        import os
+        dataset = os.environ.get("OSO_DATASET", DEFAULT_DATASET)
+
+    candidates = read_candidates(args.dir)
+    problems = completeness_problems(candidates)
+    if problems:
+        _report("completeness", problems)
+        return 2
+    _report("completeness", [])
+
+    identity = single_identity_problems(candidates)
+    _report("single-identity", identity)
+
+    semantic: list[str] = []
+    if args.deployed_dir is not None or args.live:
+        for table in CUTOVER_TABLES:
+            if args.deployed_dir is not None:
+                path = args.deployed_dir / f"{table}.csv"
+                if not path.exists():
+                    semantic.append(f"{table}: no deployed export at {path}")
+                    continue
+                deployed = _read_csv(path)
+            else:
+                deployed = deployed_rows(dataset, table)
+            semantic.extend(semantic_no_change_problems(table, candidates[table], deployed))
+        _report("semantic-no-change", semantic)
+    else:
+        print("semantic-no-change: skipped (no --deployed-dir or --live)")
+
+    return 2 if (identity or semantic) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/cutover_preflight.py
+++ b/build/cutover_preflight.py
@@ -212,10 +212,27 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--dir", type=Path, default=OUT_DIR, help="where the candidate CSVs are read")
     parser.add_argument("--deployed-dir", type=Path, default=None,
-                        help="an offline export of the deployed rows (CSV per table) for the semantic check")
+                        help="an offline export of the deployed rows (CSV per table): runs the semantic check")
     parser.add_argument("--live", action="store_true",
-                        help="read the deployed rows via pyoso (READ-ONLY) for the semantic check")
+                        help="read the deployed rows via pyoso (READ-ONLY): runs the semantic check")
+    parser.add_argument("--identity-only", action="store_true",
+                        help="run ONLY the single-identity check and explicitly SKIP the semantic "
+                             "no-change invariant — the deliberate opt-out, never the default")
     args = parser.parse_args()
+
+    # A semantic source must be chosen explicitly, or the central semantic-no-change invariant be
+    # explicitly waived — the pre-flight must never silently pass with only the identity half. Exactly
+    # one of the three; --deployed-dir and --live cannot combine.
+    active = [name for name, on in (
+        ("--deployed-dir", args.deployed_dir is not None),
+        ("--live", args.live),
+        ("--identity-only", args.identity_only),
+    ) if on]
+    if len(active) != 1:
+        chosen = " and ".join(active) if active else "none"
+        print(f"exactly one of --deployed-dir, --live, or --identity-only is required (got {chosen}); "
+              f"--identity-only explicitly waives the semantic no-change invariant", file=sys.stderr)
+        return 2
 
     dataset = None
     if args.live:
@@ -233,7 +250,9 @@ def main() -> int:
     _report("single-identity", identity)
 
     semantic: list[str] = []
-    if args.deployed_dir is not None or args.live:
+    if args.identity_only:
+        print("semantic-no-change: skipped (--identity-only — the semantic invariant is waived)")
+    else:
         for table in CUTOVER_TABLES:
             if args.deployed_dir is not None:
                 path = args.deployed_dir / f"{table}.csv"
@@ -245,8 +264,6 @@ def main() -> int:
                 deployed = deployed_rows(dataset, table)
             semantic.extend(semantic_no_change_problems(table, candidates[table], deployed))
         _report("semantic-no-change", semantic)
-    else:
-        print("semantic-no-change: skipped (no --deployed-dir or --live)")
 
     return 2 if (identity or semantic) else 0
 

--- a/docs/operations/evaluator-version-cutover.md
+++ b/docs/operations/evaluator-version-cutover.md
@@ -149,18 +149,21 @@ Before any upload, build every candidate at the cutover commit and assert:
 - **Schemas** equal each builder's `COLUMNS` (the publishers already gate this per file).
 - **Per-file authority** — `publish_scoring_trace` canonical-equivalence and `publish_evaluation`
   `validate_candidates` already prove each file is exactly its builder's output at HEAD.
-- **Single-identity invariant (new).** Every candidate across both publishers shares **one**
-  `declaration_version_id` and one `source_git_sha`. This proves the single-commit build produced a
-  single generation. It does not exist yet and must be added (§0.2).
-- **Semantic no-change invariant (new, and the important one).** The cutover must change **identity
-  only** — not facts, rule matches, scores, routes, statuses, or reconciliation results. For each of
-  the five live tables, project out the fields expected to change — `declaration_version_id`,
-  `source_git_sha` where present, and any explicitly non-content build/deployment timestamp (e.g.
-  `evaluated_at` on the adoption tables; the exact non-content column set is enumerated per table at
-  execution time) — and require the **new candidate rows to equal the currently-deployed rows
-  canonically** (order-independent multiset). Any difference outside the projected-out identity
-  columns fails the cutover: it would mean the evaluator bump is smuggling a content change, which
-  D1's bump policy forbids without its own justified generation.
+- **Single-identity invariant.** Every candidate across both publishers shares **one**
+  `declaration_version_id` and one `source_git_sha` (on the tables that carry it). This proves the
+  single-commit build produced a single generation. Implemented as
+  `build.cutover_preflight.single_identity_problems` (§0.2).
+- **Semantic no-change invariant (the important one).** The cutover must change **identity only** —
+  not facts, rule matches, scores, routes, statuses, or reconciliation results. For each of the five
+  live tables, project out the fields expected to change — `declaration_version_id`, `source_git_sha`
+  where present, and any explicitly non-content build/deployment timestamp (`evaluated_at` on
+  `adoption_reconciliation`; the per-table set is `cutover_preflight.NON_CONTENT_COLUMNS`, re-affirmed
+  at execution time) — and require the **new candidate rows to equal the currently-deployed rows
+  canonically** (order-independent multiset, tolerating the loader's all-null-column drop). Any
+  difference outside the projected-out columns fails the cutover: it would mean the evaluator bump is
+  smuggling a content change, which D1's bump policy forbids without its own justified generation.
+  Implemented as `build.cutover_preflight.semantic_no_change_problems` (§0.2); the deployed rows come
+  from an offline CSV export (`--deployed-dir`) or a read-only `pyoso` read (`--live`).
 - **Hashes** — record the sha256 of every uploaded CSV in the deploy note (the publishers archive
   these in each receipt).
 
@@ -230,10 +233,13 @@ After the swap, in one reconciliation PR (mirroring the Unit-2 reconciliation):
    - **never nests** an archive when publishing from archived bytes;
    - applies consistently across the evaluation and scoring-trace publishers.
    Tests only; no platform mutation.
-2. **Cross-cutover identity + semantic no-change checks** (§8): a checkable step asserting all
-   candidates across both publishers share one `declaration_version_id` + `source_git_sha`, and that
-   each live table's candidate equals the deployed rows canonically once identity/timestamp columns
-   are projected out.
+2. **Cross-cutover identity + semantic no-change checks** (§8) — **implemented** in
+   `build/cutover_preflight.py` (tests only, no platform write): `single_identity_problems` asserts
+   all candidates across both publishers share one `declaration_version_id` + `source_git_sha`, and
+   `semantic_no_change_problems` asserts each live table's candidate equals the deployed rows
+   canonically once the per-table non-content columns are projected out. Run offline as
+   `uv run python -m build.cutover_preflight --dir build/evaluation` (single identity), adding
+   `--deployed-dir <export>` or `--live` for the semantic check.
 
 (There is deliberately **no** `registry.axis_assessments` publisher item here — D3 excludes it from
 the cutover; its eventual first deployment is a separate, independent step.)

--- a/docs/operations/evaluator-version-cutover.md
+++ b/docs/operations/evaluator-version-cutover.md
@@ -237,9 +237,18 @@ After the swap, in one reconciliation PR (mirroring the Unit-2 reconciliation):
    `build/cutover_preflight.py` (tests only, no platform write): `single_identity_problems` asserts
    all candidates across both publishers share one `declaration_version_id` + `source_git_sha`, and
    `semantic_no_change_problems` asserts each live table's candidate equals the deployed rows
-   canonically once the per-table non-content columns are projected out. Run offline as
-   `uv run python -m build.cutover_preflight --dir build/evaluation` (single identity), adding
-   `--deployed-dir <export>` or `--live` for the semantic check.
+   canonically once the per-table non-content columns are projected out. The CLI **requires a semantic
+   source** — exactly one of `--deployed-dir <export>`, `--live`, or the explicit opt-out
+   `--identity-only` — so a run can never silently pass on the identity half alone; `--deployed-dir`
+   and `--live` cannot be combined. The cutover command runs the FULL pre-flight against the deployed
+   platform (read-only):
+
+   ```bash
+   uv run python -m build.cutover_preflight --dir build/evaluation --live   # identity + semantic vs pyoso
+   ```
+
+   `--deployed-dir <export>` substitutes an offline CSV export of the deployed rows; `--identity-only`
+   is the deliberate opt-out and is never the cutover default.
 
 (There is deliberately **no** `registry.axis_assessments` publisher item here — D3 excludes it from
 the cutover; its eventual first deployment is a separate, independent step.)

--- a/tests/test_cutover_preflight.py
+++ b/tests/test_cutover_preflight.py
@@ -135,20 +135,36 @@ def _write_candidate_csvs(directory, cands):
             writer.writerows(rows)
 
 
-def test_cli_runs_the_single_identity_check_offline(tmp_path, monkeypatch, capsys):
+def test_cli_requires_a_semantic_source_or_explicit_opt_out(tmp_path, monkeypatch, capsys):
+    """The central bug: with no --deployed-dir / --live / --identity-only, the run must NOT pass —
+    it may not silently skip the semantic no-change invariant."""
     _write_candidate_csvs(tmp_path, _candidates())
     monkeypatch.setattr(sys, "argv", ["cutover_preflight", "--dir", str(tmp_path)])
+    assert CP.main() == 2
+    assert "exactly one of --deployed-dir, --live, or --identity-only" in capsys.readouterr().err
+
+
+def test_cli_rejects_combining_deployed_dir_and_live(tmp_path, monkeypatch):
+    _write_candidate_csvs(tmp_path, _candidates())
+    monkeypatch.setattr(sys, "argv",
+                        ["cutover_preflight", "--dir", str(tmp_path), "--deployed-dir", str(tmp_path), "--live"])
+    assert CP.main() == 2
+
+
+def test_cli_identity_only_runs_identity_and_waives_semantic(tmp_path, monkeypatch, capsys):
+    _write_candidate_csvs(tmp_path, _candidates())
+    monkeypatch.setattr(sys, "argv", ["cutover_preflight", "--dir", str(tmp_path), "--identity-only"])
     assert CP.main() == 0
     out = capsys.readouterr().out
     assert "single-identity: ok" in out
-    assert "semantic-no-change: skipped" in out
+    assert "semantic-no-change: skipped (--identity-only" in out
 
 
-def test_cli_fails_on_a_split_identity(tmp_path, monkeypatch):
+def test_cli_identity_only_still_fails_on_a_split_identity(tmp_path, monkeypatch):
     cands = _candidates()
     cands["axis_results"] = [{**cands["axis_results"][0], "declaration_version_id": "e" * 64}]
     _write_candidate_csvs(tmp_path, cands)
-    monkeypatch.setattr(sys, "argv", ["cutover_preflight", "--dir", str(tmp_path)])
+    monkeypatch.setattr(sys, "argv", ["cutover_preflight", "--dir", str(tmp_path), "--identity-only"])
     assert CP.main() == 2
 
 

--- a/tests/test_cutover_preflight.py
+++ b/tests/test_cutover_preflight.py
@@ -1,0 +1,182 @@
+"""The cutover pre-flight invariants (§0.2 / §8): single identity + semantic no-change.
+
+`build/cutover_preflight.py` proves, before any upload, that the `evaluator_version` cutover changes
+IDENTITY ONLY — every candidate shares one `declaration_version_id` (and one `source_git_sha` where
+carried), and each live table's candidate equals the deployed rows once identity/timestamp columns are
+projected out. Pure functions, exercised here with synthetic rows — no platform read or mutation.
+"""
+
+import sys
+
+import build.cutover_preflight as CP
+
+
+def _candidates(dvid="d" * 64, sha="f012d854eb87"):
+    """One row per cutover table, all sharing the same declaration + source identity."""
+    return {
+        "product_adoption_measurements": [{"declaration_version_id": dvid, "product_slug": "p", "raw_value": "1"}],
+        "adoption_reconciliation": [{"declaration_version_id": dvid, "product_slug": "p",
+                                     "status": "source_unavailable", "evaluated_at": "2026-08-27T00:00:00Z"}],
+        "axis_facts": [{"declaration_version_id": dvid, "source_git_sha": sha, "product_slug": "p", "axis": "openness"}],
+        "axis_rule_matches": [{"declaration_version_id": dvid, "source_git_sha": sha, "product_slug": "p", "rule_index": "0"}],
+        "axis_results": [{"declaration_version_id": dvid, "source_git_sha": sha, "product_slug": "p", "result_score": "4"}],
+    }
+
+
+# --- single identity -----------------------------------------------------------------------------
+
+
+def test_shared_identity_passes():
+    assert CP.single_identity_problems(_candidates()) == []
+
+
+def test_a_second_declaration_id_across_tables_is_rejected():
+    cands = _candidates()
+    cands["axis_results"] = [{**cands["axis_results"][0], "declaration_version_id": "e" * 64}]
+    problems = CP.single_identity_problems(cands)
+    assert any("share one declaration_version_id" in p for p in problems)
+
+
+def test_a_second_source_sha_across_the_trace_tables_is_rejected():
+    cands = _candidates()
+    cands["axis_facts"] = [{**cands["axis_facts"][0], "source_git_sha": "deadbeefcafe"}]
+    problems = CP.single_identity_problems(cands)
+    assert any("share one source_git_sha" in p for p in problems)
+
+
+def test_a_non_constant_identity_within_a_file_is_rejected():
+    cands = _candidates()
+    row = cands["axis_facts"][0]
+    cands["axis_facts"] = [row, {**row, "declaration_version_id": "e" * 64}]
+    problems = CP.single_identity_problems(cands)
+    assert any("not constant within the file" in p for p in problems)
+
+
+# --- completeness --------------------------------------------------------------------------------
+
+
+def test_an_incomplete_cutover_set_is_rejected():
+    cands = _candidates()
+    del cands["axis_results"]
+    assert any("missing cutover candidate" in p for p in CP.completeness_problems(cands))
+    assert CP.completeness_problems(_candidates()) == []
+
+
+# --- semantic no-change --------------------------------------------------------------------------
+
+
+def test_identity_only_change_passes_even_across_types():
+    """Only declaration_version_id / source_git_sha differ, and the deployed side is loader-TYPED
+    (int result_score, not the CSV string) — canonicalization makes them compare equal."""
+    candidate = [{"declaration_version_id": "NEW", "source_git_sha": "newsha",
+                  "product_slug": "p", "axis": "openness", "result_score": "4"}]
+    deployed = [{"declaration_version_id": "OLD", "source_git_sha": "oldsha",
+                 "product_slug": "p", "axis": "openness", "result_score": 4, "_dlt_id": "x"}]
+    assert CP.semantic_no_change_problems("axis_results", candidate, deployed) == []
+
+
+def test_a_changed_content_value_is_rejected():
+    candidate = [{"declaration_version_id": "NEW", "source_git_sha": "s", "product_slug": "p", "result_score": "4"}]
+    deployed = [{"declaration_version_id": "OLD", "source_git_sha": "s", "product_slug": "p", "result_score": "5"}]
+    problems = CP.semantic_no_change_problems("axis_results", candidate, deployed)
+    assert any("NOT reproduced" in p for p in problems)
+    assert any("NOT present" in p for p in problems)
+
+
+def test_row_multiplicity_difference_is_rejected():
+    row = {"declaration_version_id": "NEW", "source_git_sha": "s", "product_slug": "p", "result_score": "4"}
+    old = {**row, "declaration_version_id": "OLD"}
+    problems = CP.semantic_no_change_problems("axis_results", [row, row], [old])
+    assert any("NOT present" in p for p in problems)  # the duplicate candidate row has no deployed match
+
+
+def test_an_all_null_candidate_column_dropped_by_the_loader_is_tolerated():
+    """`adoption_reconciliation.override_id` is empty in every row and the loader drops it; its absence
+    downstream is expected, not a content difference."""
+    candidate = [{"declaration_version_id": "NEW", "product_slug": "p", "status": "x",
+                  "override_id": "", "evaluated_at": "2026-08-27T01:00:00Z"}]
+    deployed = [{"declaration_version_id": "OLD", "product_slug": "p", "status": "x",
+                 "evaluated_at": "2026-08-27T09:00:00Z"}]  # no override_id, different evaluated_at
+    assert CP.semantic_no_change_problems("adoption_reconciliation", candidate, deployed) == []
+
+
+def test_a_candidate_column_with_data_missing_downstream_is_rejected():
+    candidate = [{"declaration_version_id": "NEW", "product_slug": "p", "status": "x",
+                  "override_id": "ovr-1", "evaluated_at": "t"}]
+    deployed = [{"declaration_version_id": "OLD", "product_slug": "p", "status": "x", "evaluated_at": "t2"}]
+    problems = CP.semantic_no_change_problems("adoption_reconciliation", candidate, deployed)
+    assert any("carries data but is absent" in p for p in problems)
+
+
+def test_a_deployed_only_content_column_is_rejected():
+    candidate = [{"declaration_version_id": "NEW", "source_git_sha": "s", "product_slug": "p"}]
+    deployed = [{"declaration_version_id": "OLD", "source_git_sha": "s", "product_slug": "p", "surprise": "z"}]
+    problems = CP.semantic_no_change_problems("axis_results", candidate, deployed)
+    assert any("does not declare" in p for p in problems)
+
+
+def test_empty_sides_are_reported_not_crashed():
+    assert CP.semantic_no_change_problems("axis_results", [], [{"a": 1}]) == ["axis_results: no candidate rows"]
+    assert CP.semantic_no_change_problems("axis_results", [{"a": 1}], []) == [
+        "axis_results: no deployed rows to compare against"]
+
+
+# --- the offline CLI -----------------------------------------------------------------------------
+
+
+def _write_candidate_csvs(directory, cands):
+    import csv
+
+    for table, rows in cands.items():
+        path = directory / f"{table}.csv"
+        with path.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(rows)
+
+
+def test_cli_runs_the_single_identity_check_offline(tmp_path, monkeypatch, capsys):
+    _write_candidate_csvs(tmp_path, _candidates())
+    monkeypatch.setattr(sys, "argv", ["cutover_preflight", "--dir", str(tmp_path)])
+    assert CP.main() == 0
+    out = capsys.readouterr().out
+    assert "single-identity: ok" in out
+    assert "semantic-no-change: skipped" in out
+
+
+def test_cli_fails_on_a_split_identity(tmp_path, monkeypatch):
+    cands = _candidates()
+    cands["axis_results"] = [{**cands["axis_results"][0], "declaration_version_id": "e" * 64}]
+    _write_candidate_csvs(tmp_path, cands)
+    monkeypatch.setattr(sys, "argv", ["cutover_preflight", "--dir", str(tmp_path)])
+    assert CP.main() == 2
+
+
+def test_cli_semantic_against_a_deployed_export(tmp_path, monkeypatch):
+    """A deployed CSV export that matches the candidate on content (differing only on identity /
+    evaluated_at) passes; a changed value fails."""
+    cands = _candidates()
+    cand_dir = tmp_path / "cand"
+    cand_dir.mkdir()
+    _write_candidate_csvs(cand_dir, cands)
+
+    # The deployed export: same content, re-keyed to the OLD identity + a stale evaluated_at.
+    deployed = {table: [dict(rows[0])] for table, rows in cands.items()}
+    for rows in deployed.values():
+        rows[0]["declaration_version_id"] = "o" * 64
+        if "source_git_sha" in rows[0]:
+            rows[0]["source_git_sha"] = "oldsha000000"
+        if "evaluated_at" in rows[0]:
+            rows[0]["evaluated_at"] = "2020-01-01T00:00:00Z"
+    export = tmp_path / "deployed"
+    export.mkdir()
+    _write_candidate_csvs(export, deployed)
+
+    monkeypatch.setattr(sys, "argv",
+                        ["cutover_preflight", "--dir", str(cand_dir), "--deployed-dir", str(export)])
+    assert CP.main() == 0
+
+    # Now tamper one deployed content value → the semantic check fails.
+    deployed["axis_results"][0]["result_score"] = "5"
+    _write_candidate_csvs(export, deployed)
+    assert CP.main() == 2


### PR DESCRIPTION
## What

Adds `build/cutover_preflight.py` — the cross-cutover pre-flight invariants (§8 / §0.2) for the `evaluator_version` cutover, as **pure functions plus an offline CLI, no platform mutation**. The last cutover prerequisite; the cutover itself stays **unauthorized**.

The cutover bumps `EVALUATOR_VERSION`, rebuilds every declaration-keyed candidate from one clean commit, and re-uploads them so all five live tables move to a single new `declaration_version_id` in one pass. That swap must change **identity only**. This module makes both invariants checkable:

- **`single_identity_problems`** — every candidate across both publishers shares **one** `declaration_version_id` (and one `source_git_sha` on the trace tables that carry it). Proves the single-commit build collapsed to one generation rather than smuggling two.
- **`semantic_no_change_problems`** — for each of the five live tables, project out the per-table non-content columns (`declaration_version_id`; `source_git_sha` where present; `adoption_reconciliation.evaluated_at`, a build timestamp) and require the new candidate rows to equal the currently-deployed rows as an **order-independent multiset**. Any difference outside the projected columns fails the cutover — it would mean the evaluator bump carried a content change, which D1's bump policy forbids without its own justified generation.

The comparison canonicalizes scalars so a candidate CSV string (`"4"`, `"True"`, `""`) and the loader's typed round-trip (`4`, `True`, `None`) compare equal, and tolerates the loader's all-null-column drop (`override_id` on reconciliation). The deployed rows come from an offline CSV export (`--deployed-dir`, the reviewed path) or a read-only `pyoso` read (`--live`) — neither writes anything.

```
uv run python -m build.cutover_preflight --dir build/evaluation                        # single identity, offline
uv run python -m build.cutover_preflight --dir build/evaluation --deployed-dir export/  # + semantic vs CSV export
uv run python -m build.cutover_preflight --dir build/evaluation --live                  # + semantic vs pyoso (read-only)
```

## Tests

`tests/test_cutover_preflight.py` (15): shared vs split identity; a second `source_git_sha`; non-constant identity within a file; completeness of the cutover set; identity-only change across types (typed deployed side); a changed content value; row-multiplicity difference; the tolerated all-null-column drop; a data-bearing candidate column missing downstream; a deployed-only content column; empty sides; and the offline CLI (identity pass/fail, semantic vs a deployed export). Ruff clean; `build.validate` prints `0 error(s)`.

## Scope

Pure code + tests, no platform mutation. Creating the two live-generation real Releases and executing the `evaluator_version` cutover remain **unauthorized**. Cutover plan §8/§0.2 updated to reference the module.

## Checklist

- [x] `uv run python -m build.validate` prints `0 error(s)`
- [ ] N/A: no new/changed scores (a pre-flight check module + tests + runbook)
- [x] I did not edit `build/notebook_data.json` or `notebooks/ai-stack-map.py`
- [ ] N/A: no product/roster changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5bY5TtNtdqoxaeJBdNmXv)_