### PR TITLE
Declare the payload's contract as a number consumers can gate on

### DIFF
--- a/build/serialize.py
+++ b/build/serialize.py
@@ -456,6 +456,16 @@ def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None =
         released = release_date(version)
     if contract is None:
         contract = PAYLOAD_CONTRACT
+    # A caller cannot assert a shape claim the code does not hold. Below 1 every consumer
+    # rejects the payload outright; above PAYLOAD_CONTRACT it claims a shape this build does
+    # not produce, which would make every consumer refuse a payload that is in fact fine.
+    if not isinstance(contract, int) or isinstance(contract, bool) or contract < 1:
+        raise ValueError(f"contract must be an integer >= 1, got {contract!r}")
+    if contract > PAYLOAD_CONTRACT:
+        raise ValueError(
+            f"contract {contract} claims a shape this build does not produce "
+            f"(PAYLOAD_CONTRACT is {PAYLOAD_CONTRACT}); bump the constant instead"
+        )
     orgs, cats, prods, scores = (sources["organizations"], sources["categories"],
                                  sources["products"], sources["scores"])
     taxonomy = sources["taxonomy"]

--- a/build/serialize.py
+++ b/build/serialize.py
@@ -2,7 +2,7 @@
 
 Reproduces the exact structure the live notebook consumes:
   { descriptions, layer_order[], categories: {cid: {label, arc, layer, products[]}},
-    order[], n_total, generated, version, released, long_tail }
+    order[], n_total, generated, version, released, contract, long_tail }
 """
 from datetime import date
 from pathlib import Path
@@ -253,8 +253,9 @@ def _row(slug: str, prod: dict, org_slug: str, org_name: str, score: dict,
     # consumers get a stable 3-way verdict that survives changes to the openness.class
     # vocabulary. Same collapse the category gap logic uses (_gap_bucket).
     # The payload's `components` stays a flat string whatever shape the record carries, and
-    # `raw` never ships. The front end's contract with this payload is undocumented and
-    # untested, and build/render.py plus the rendered notebook both do `row('Components',
+    # `raw` never ships. The front end's contract with this payload is declared as
+    # PAYLOAD_CONTRACT below but is not enforced field by field, and build/render.py plus the
+    # rendered notebook both do `row('Components',
     # o.components)` on it — so a mapping here would render as [object Object] in the product
     # detail panel and force a regeneration of a bot-owned file. Keeping the key a string
     # means the structured-dimensions migration is invisible downstream, which is also what
@@ -397,6 +398,24 @@ def _aliases(prods: dict, orgs: dict, published: set[str], org_slugs: set[str]) 
     }
 
 
+# The shape of this payload, as a number a consumer can compare against.
+#
+# Bump it when a consumer reading the PREVIOUS contract would MISREAD this payload — a renamed
+# or removed key, a field changing type or meaning. Do not bump for additions: a new key a reader
+# does not know about is ignored, which is why adding is safe and renaming is not.
+#
+# It exists because the alternative is doing the check by hand. Renaming the `depth` gap to
+# `resiliency` in 2026-08 needed a transitional alias in the front end, three pull requests across
+# two repositories, and a merge order written on the ticket so nobody landed them the wrong way
+# round. A consumer that declares the contract it understands turns all of that into one
+# comparison: if the payload's contract is higher than what the consumer supports, the consumer
+# ships support first. Nothing else enforces that ordering.
+#
+# History:
+#   1 - the shape as of 2026-08. Gap keys void/capability/adoption/resiliency/openness/disclosure.
+PAYLOAD_CONTRACT = 1
+
+
 def repo_version(root: Path | None = None) -> str:
     """The release version this payload was built from, read from ``pyproject.toml``.
 
@@ -428,13 +447,15 @@ def release_date(version: str, root: Path | None = None) -> str:
 
 def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None = None,
                   freshness: dict | None = None, version: str | None = None,
-                  released: str | None = None) -> dict:
+                  released: str | None = None, contract: int | None = None) -> dict:
     if generated is None:
         generated = date.today().isoformat()
     if version is None:
         version = repo_version()
     if released is None:
         released = release_date(version)
+    if contract is None:
+        contract = PAYLOAD_CONTRACT
     orgs, cats, prods, scores = (sources["organizations"], sources["categories"],
                                  sources["products"], sources["scores"])
     taxonomy = sources["taxonomy"]
@@ -510,7 +531,7 @@ def build_payload(sources: dict, frozen_long_tail: dict, generated: str | None =
             "organizations": organizations,
             "aliases": _aliases(prods, orgs, published_slugs, set(organizations)),
             "n_total": n, "generated": generated,
-            "version": version, "released": released,
+            "version": version, "released": released, "contract": contract,
             # Published products only: see _filter_long_tail. A preliminary category's
             # products are not shown above, so their tail rows stay visible below.
             "long_tail": _filter_long_tail(
@@ -528,13 +549,15 @@ if __name__ == "__main__":
                         help="value for the payload 'version' field (default: pyproject.toml)")
     parser.add_argument("--released", default=None,
                         help="value for the payload 'released' field (default: CHANGELOG.md)")
+    parser.add_argument("--contract", default=None, type=int,
+                        help="value for the payload 'contract' field (default: PAYLOAD_CONTRACT)")
     args = parser.parse_args()
     sources = load_sources(ROOT)
     frozen = json.load(open(ROOT / "sources" / "snapshots" / "long_tail.json"))
     payload = build_payload(sources, frozen, generated=args.date,
                             freshness=resolve_freshness(ROOT), version=args.version,
-                            released=args.released)
+                            released=args.released, contract=args.contract)
     (ROOT / "build" / "notebook_data.json").write_text(json.dumps(payload, indent=2, ensure_ascii=False))
     print(f"wrote build/notebook_data.json "
-          f"({payload['n_total']} products, v{payload['version']} "
+          f"({payload['n_total']} products, v{payload['version']} contract {payload['contract']} "
           f"released {payload['released']}, built {payload['generated']})")

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,6 +1,6 @@
 import pytest
 
-from build.serialize import (build_payload, release_date, repo_version,
+from build.serialize import (PAYLOAD_CONTRACT, build_payload, release_date, repo_version,
                              _stage_and_gaps)
 
 
@@ -592,3 +592,31 @@ def test_descriptions_match_the_reference_doc():
     for num, text in _STAGE_DESC.items():
         labelled = f"- **Stage {num}: {_STAGE_NAMES[num]}.** {text}"
         assert labelled in method, f"methodology.md is out of sync for stage {num}"
+
+
+# --- Payload contract ------------------------------------------------------
+# The number a consumer compares against to decide whether it can read this payload at all.
+
+def test_payload_carries_the_contract():
+    payload = build_payload(_sources(), frozen_long_tail={}, generated="2026-06-10")
+    assert payload["contract"] == PAYLOAD_CONTRACT
+
+
+def test_payload_contract_can_be_set_explicitly():
+    payload = build_payload(_sources(), frozen_long_tail={}, generated="2026-06-10", contract=7)
+    assert payload["contract"] == 7
+
+
+def test_contract_is_an_integer_so_consumers_can_compare_it():
+    """A consumer gates on `payload.contract > supported`, which needs an ordered type."""
+    assert isinstance(PAYLOAD_CONTRACT, int) and PAYLOAD_CONTRACT >= 1
+
+
+def test_the_gap_vocabulary_is_what_contract_1_promises():
+    """Contract 1 names these six gap keys. Renaming one without bumping the contract is the
+    exact failure this number exists to prevent, so pin the pair together."""
+    payload = build_payload(_sources(), frozen_long_tail={}, generated="2026-06-10")
+    assert payload["contract"] == 1
+    assert set(payload["descriptions"]["gaps"]) == {
+        "void", "capability", "adoption", "resiliency", "openness", "disclosure"
+    }

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,7 +1,7 @@
 import pytest
 
-from build.serialize import (PAYLOAD_CONTRACT, build_payload, release_date, repo_version,
-                             _stage_and_gaps)
+from build.serialize import (PAYLOAD_CONTRACT, _GAP_DESC, build_payload, release_date,
+                             repo_version, _stage_and_gaps)
 
 
 def _p(cls, adoption, capability):
@@ -603,8 +603,23 @@ def test_payload_carries_the_contract():
 
 
 def test_payload_contract_can_be_set_explicitly():
-    payload = build_payload(_sources(), frozen_long_tail={}, generated="2026-06-10", contract=7)
-    assert payload["contract"] == 7
+    """Only downward, to the current contract or below — see the guard tests beneath."""
+    payload = build_payload(_sources(), frozen_long_tail={}, generated="2026-06-10",
+                            contract=PAYLOAD_CONTRACT)
+    assert payload["contract"] == PAYLOAD_CONTRACT
+
+
+def test_contract_override_rejects_a_shape_this_build_does_not_produce():
+    """--contract 99 would make every consumer refuse a payload that is in fact fine."""
+    with pytest.raises(ValueError, match="does not produce"):
+        build_payload(_sources(), frozen_long_tail={}, generated="2026-06-10",
+                      contract=PAYLOAD_CONTRACT + 1)
+
+
+def test_contract_override_rejects_a_value_no_consumer_accepts():
+    for bad in (0, -1, "1", 1.5, True):
+        with pytest.raises(ValueError, match="integer >= 1"):
+            build_payload(_sources(), frozen_long_tail={}, generated="2026-06-10", contract=bad)
 
 
 def test_contract_is_an_integer_so_consumers_can_compare_it():
@@ -620,3 +635,49 @@ def test_the_gap_vocabulary_is_what_contract_1_promises():
     assert set(payload["descriptions"]["gaps"]) == {
         "void", "capability", "adoption", "resiliency", "openness", "disclosure"
     }
+
+
+# The test above pins the DESCRIPTION dict. The values a consumer actually branches on are
+# emitted separately by _stage_and_gaps as bare string literals, and nothing tied the two
+# together: renaming `gaps = ["resiliency"]` there while leaving _GAP_DESC alone passed every
+# contract test and shipped a payload whose categories carry a gap the descriptions do not
+# define. A front end doing GAP_META[gap].label on it dereferences undefined. These two close
+# that, and they are the assertion the contract number actually rests on.
+
+def _every_gap_branch():
+    """Rows chosen to reach each branch in _stage_and_gaps, so the union covers the vocabulary."""
+    w = {"adopt": 0.5, "cap": 0.5}
+    return [
+        _stage_and_gaps([_p("closed", 1, 1)], w),                              # void
+        _stage_and_gaps([_p("open_source", 5, 5)], w),                         # resiliency
+        _stage_and_gaps([_p("open_source", 5, 5) for _ in range(4)], w),       # none (Stage 5)
+        _stage_and_gaps([_p("open_source", 5, 2)], w),                         # capability
+        _stage_and_gaps([_p("open_source", 2, 5)], w),                         # adoption
+        _stage_and_gaps([_p("open_weights", 5, 5)], w),                        # openness
+        _stage_and_gaps([_p("open_source", 5, 5)], w, disclosure=True),        # disclosure
+    ]
+
+
+def test_every_emitted_gap_has_a_description():
+    """A gap the payload emits but does not describe is unreadable to a consumer."""
+    emitted = {g for sg in _every_gap_branch() for g in sg["gaps"]}
+    undescribed = emitted - set(_GAP_DESC)
+    assert not undescribed, f"gaps emitted with no entry in _GAP_DESC: {sorted(undescribed)}"
+
+
+def test_the_branches_cover_the_whole_declared_vocabulary():
+    """And the reverse: a described gap nothing can emit is dead vocabulary in the contract."""
+    emitted = {g for sg in _every_gap_branch() for g in sg["gaps"]}
+    assert emitted == set(_GAP_DESC), (
+        f"declared but never emitted: {sorted(set(_GAP_DESC) - emitted)}; "
+        f"emitted but never declared: {sorted(emitted - set(_GAP_DESC))}"
+    )
+
+
+def test_a_built_payload_never_carries_an_undescribed_gap():
+    """The same invariant at the payload level, over the real category roster."""
+    payload = build_payload(_sources(), frozen_long_tail={}, generated="2026-06-10")
+    described = set(payload["descriptions"]["gaps"])
+    for cid in payload["order"]:
+        for gap in payload["categories"][cid]["gaps"]:
+            assert gap in described, f"category {cid} carries undescribed gap {gap!r}"


### PR DESCRIPTION
Part of CUR-570. The producer half of making the payload's contract explicit; the consumer half is a companion PR on `aipotluck.org`.

## Why

The payload's shape is a contract with whatever reads it, and until now that contract was implicit. Renaming the `depth` gap to `resiliency` in August needed a transitional alias in the front end, three pull requests across two repositories, and a merge order written on a Linear ticket so nobody landed them the wrong way round. Every part of that was a person enforcing an ordering no machine knew about.

`serialize.py` already had the note admitting it: *"The front end's contract with this payload is undocumented and untested."*

## What this adds

`PAYLOAD_CONTRACT`, stamped into every payload as `contract`, next to `version`, `released` and `generated`.

A consumer declares the contract it understands. If the payload's number is higher, the consumer ships support first, then raises its own. Same ordering as August, enforced by one comparison instead of by vigilance.

**Bump it when a reader of the previous contract would MISREAD this payload** — a renamed or removed key, a field changing type or meaning. **Not for additions:** an unknown key is ignored, which is exactly why adding is safe and renaming is not. The constant carries a history list so a future reader can see what each number meant.

## The guards that keep the number honest

A version number nobody maintains is worse than none.

My first version of this guard pinned `_GAP_DESC`'s keys — and review caught that it watched the wrong dict. The values a consumer branches on are emitted separately by `_stage_and_gaps` as bare string literals, with nothing tying the two together. Renaming `gaps = ["resiliency"]` to `["redundancy"]` while leaving `_GAP_DESC` untouched **passed every contract test**, and would have shipped a payload carrying a gap its own descriptions do not define. A front end doing `GAP_META[gap].label` on that dereferences `undefined`.

Three assertions now close it, in both directions:

- every gap any branch emits has an entry in `_GAP_DESC`, so an emitted gap is always readable;
- every declared gap is reachable by some branch, so the contract cannot accrete vocabulary nothing produces;
- the same invariant at payload level, over the real category roster.

The same tamper now fails **four** tests.

## The `--contract` override is bounded

Also from review: the flag was unbounded. Below 1, every consumer rejects the payload; above `PAYLOAD_CONTRACT`, it asserts a shape this build does not produce, making every consumer refuse a payload that is in fact fine. It is now floored at 1 and capped at the constant.

## Test plan

- `uv run pytest -q` — 1165 passed
- `uv run python -m build.validate` — `0 error(s)`
- `uv run python -m build.serialize` prints `522 products, v0.2.0 contract 1 released 2026-08-16, built 2026-08-28`, and the payload carries `"contract": 1`
- Reverted the regenerated `notebook_data.json` so the bot handles it on merge

## Checklist

- [x] `uv run python -m build.validate` prints `0 error(s)`
- [x] New/changed scores cite sources (`url`, `shows`, `accessed`) — n/a, no score changes
- [x] I did not edit `build/notebook_data.json` or `notebooks/ai-stack-map.py`
- [x] Product appears in exactly one category roster and one org roster — n/a, no product changes
