### PR TITLE
Tell aipotluck.org when new data is published

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -62,10 +62,12 @@ jobs:
         run: |
           uv run marimo check notebooks/ai-stack-map.py
       - name: Commit regenerated artifacts
+        id: commit
         run: |
           ARTIFACTS="build/notebook_data.json notebooks/ai-stack-map.py README.md"
           if git diff --quiet $ARTIFACTS; then
             echo "No changes to generated artifacts."
+            echo "published=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git config user.name "github-actions[bot]"
@@ -73,3 +75,37 @@ jobs:
           git add $ARTIFACTS
           git commit -m "chore(build): regenerate notebook data, notebooks, README badges [bot]"
           git push
+          echo "published=true" >> "$GITHUB_OUTPUT"
+
+      # Tell the consumer, instead of making it guess.
+      #
+      # aipotluck.org pulls this payload on a daily cron, and that cron has never once fired on
+      # time: across 26 scheduled runs the delay ranged from 45 minutes to ten hours, because
+      # GitHub queues scheduled workflows under load. The consequence is not just lateness — on
+      # 2026-08-27 a rename merged here at 21:43 and the sync's slot had passed, so the change
+      # waited a further day. Polling cannot fix that; only the publisher knows when it published.
+      #
+      # The cron stays as a backstop. This makes the normal case immediate rather than eventual.
+      #
+      # Skips cleanly when the token is absent, because a missing secret should degrade to the
+      # old behaviour rather than fail a publish that already succeeded.
+      - name: Notify aipotluck.org that new data is published
+        if: steps.commit.outputs.published == 'true'
+        env:
+          DISPATCH_TOKEN: ${{ secrets.AIPOTLUCK_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$DISPATCH_TOKEN" ]; then
+            echo "::notice::AIPOTLUCK_DISPATCH_TOKEN not set — skipping publish notification." \
+                 "aipotluck.org will pick this up on its daily cron instead."
+            exit 0
+          fi
+          GENERATED=$(python3 -c "import json;print(json.load(open('build/notebook_data.json'))['generated'])")
+          CONTRACT=$(python3 -c "import json;print(json.load(open('build/notebook_data.json')).get('contract',1))")
+          echo "Notifying aipotluck.org: generated=$GENERATED contract=$CONTRACT sha=$GITHUB_SHA"
+          curl --fail-with-body --silent --show-error \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $DISPATCH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/currentai-org/aipotluck.org/dispatches \
+            -d "{\"event_type\":\"gap-map-data-published\",\"client_payload\":{\"generated\":\"$GENERATED\",\"contract\":$CONTRACT,\"source_sha\":\"$GITHUB_SHA\"}}"


### PR DESCRIPTION
Producer half of the last piece of CUR-570. Consumer half is [aipotluck.org#372](https://github.com/currentai-org/aipotluck.org/pull/372).

## Why

aipotluck.org pulls this payload on a daily cron, and **that cron has never once fired on time.** Across 26 scheduled runs, measured against its 12:17 UTC slot:

| Delay | Days |
|---|---|
| +45 to +69 min | 17 |
| +85 to +95 min | 6 |
| +104 to +184 min | 3 |
| +608 min | 27 Aug |

That is normal GitHub behaviour — scheduled workflows queue under load — and it is not fixable from the consumer side. On 2026-08-27 a rename merged here at 21:43, after the consumer's slot had passed, so the change waited a further day.

Polling cannot solve this. Only the publisher knows when it published.

## What this does

Sends a `repository_dispatch` to `currentai-org/aipotluck.org` after the payload commit lands, carrying `generated`, `contract` and the source SHA. The consumer keeps its cron as a backstop, so a missed dispatch degrades to *late* rather than to *never*.

## Two details worth reviewing

**The commit step now reports whether it published.** It `exit 0`s when there is nothing to commit, so a step placed after it would fire on every run and announce a publish that never happened. It writes `published=true|false` to `$GITHUB_OUTPUT` and the notify step gates on it.

**A missing secret skips, it does not fail.** If `AIPOTLUCK_DISPATCH_TOKEN` is unset the step emits a `::notice::` naming the fallback and exits 0. A publish that has already succeeded and pushed should not be marked failed because a notification could not be sent.

## Needs one thing from a maintainer

**`AIPOTLUCK_DISPATCH_TOKEN`** — a secret on this repo, holding a token with permission to POST dispatches to `currentai-org/aipotluck.org`. Until it exists the step no-ops with a notice and the daily cron behaves exactly as it does today, so this is safe to merge before the secret is set.

## Test plan

- `uv run python -m build.validate` — `0 error(s)`
- `regenerate.yml` parses; 12 steps, the notify step last and gated on the commit step's output
- No change to what is committed or when — only an added notification after the existing push
