### PR TITLE
Dispatch with GH_FETCH_TOKEN instead of a second secret

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -87,15 +87,21 @@ jobs:
       #
       # The cron stays as a backstop. This makes the normal case immediate rather than eventual.
       #
+      # Reuses GH_FETCH_TOKEN rather than minting a second secret. It is already a classic PAT
+      # with the repo scope (refresh-data.yml asserts exactly that before it runs), and that scope
+      # is what POSTing a dispatch to aipotluck.org requires. A dedicated token would buy
+      # independent expiry; it would also be a second thing to rotate and forget.
+      #
       # Skips cleanly when the token is absent, because a missing secret should degrade to the
-      # old behaviour rather than fail a publish that already succeeded.
+      # old behaviour rather than fail a publish that already succeeded. A token that is present
+      # but rejected is a different case and fails loudly, via curl --fail-with-body.
       - name: Notify aipotluck.org that new data is published
         if: steps.commit.outputs.published == 'true'
         env:
-          DISPATCH_TOKEN: ${{ secrets.AIPOTLUCK_DISPATCH_TOKEN }}
+          DISPATCH_TOKEN: ${{ secrets.GH_FETCH_TOKEN }}
         run: |
           if [ -z "$DISPATCH_TOKEN" ]; then
-            echo "::notice::AIPOTLUCK_DISPATCH_TOKEN not set — skipping publish notification." \
+            echo "::notice::GH_FETCH_TOKEN not set — skipping publish notification." \
                  "aipotluck.org will pick this up on its daily cron instead."
             exit 0
           fi


### PR DESCRIPTION
Follow-up to #396, and the last thing standing between CUR-570 and working.

## Why

#396 asked for a new secret, `AIPOTLUCK_DISPATCH_TOKEN`. That cannot be created: currentai-org has not opted into fine-grained PATs, so the org is not offered as a resource owner. `refresh-data.yml` already records this — it errors with "GH_FETCH_TOKEN advertises no OAuth scopes, so it is a fine-grained PAT / This workflow requires a CLASSIC PAT", and names 2026-08-19 as the day that was learned.

The alternative was a second classic PAT with `repo` scope. `GH_FETCH_TOKEN` is already exactly that — `refresh-data.yml` asserts its scope before it runs — and `repo` is the scope POSTing a dispatch to aipotluck.org needs. A dedicated token would buy independent expiry; it would also be a second thing to rotate and forget.

## The expiry question

Sharing a token means one expiry takes out both the weekly refresh and the publish trigger. That is acceptable here because neither failure is silent:

- `refresh-data.yml` probes the token's scopes in a preflight step and fails loudly.
- This step uses `curl --fail-with-body`, so a present-but-rejected token returns 401/403 and fails the step.

The only silent path is an *absent* secret, which now cannot happen without also breaking the refresh in a way that announces itself.

## Test plan

- `regenerate.yml` parses; 12 steps, notify last, still gated on `steps.commit.outputs.published == 'true'`
- No change to what is committed, when, or to the dispatch payload — only which secret supplies the token