### PR TITLE
Discovery sweep: 36 agent_tools_protocols candidates

### DIFF
--- a/sources/registry/agent_tools_protocols.yaml
+++ b/sources/registry/agent_tools_protocols.yaml
@@ -1,19 +1,14 @@
-# Swept 2026-08-30 from the warehouse discovery pool (currentai.scores.repos_summary, refreshed
+# Swept 2026-08-30 from the warehouse discovery pool (currentai.scores.repos_summary, snapshot
 # 2026-08-24), over the six subcategories that carry agent-facing tooling: AI Engineering / Give
 # agent tools, Give agent knowledge and Protocols, and Infrastructure / Protocols, Make world
 # agent-ready and Index & Search. Predeclared retrieval cutoff: the top 300 repositories by
 # all-time stars across those six, which bottoms out at 4,621 stars. Every row below was verified
-# against the GitHub API on 2026-08-30; the counts, the parked candidates and their reasons are in
-# the sweep summary on the discovery PR. Nothing here is scored.
+# against the GitHub API on 2026-08-30, and every declared package against its registry API on the
+# same date. Counts, parked candidates and their reasons are in the sweep summary on the PR.
+# Nothing here is scored, and a row here is a candidate, not a commitment to publish.
 category: agent_tools_protocols
 products:
   # Protocol and specification layer
-  - slug: mcp-go-sdk
-    display_name: MCP Go SDK
-    type: software
-    org: anthropic
-    github: modelcontextprotocol/go-sdk
-    homepage: https://modelcontextprotocol.io
   - slug: agents-md
     display_name: AGENTS.md
     type: software
@@ -26,6 +21,18 @@ products:
     org: agentskills
     github: agentskills/agentskills
     homepage: https://agentskills.io
+  - slug: design-md
+    display_name: DESIGN.md
+    type: software
+    org: google
+    github: google-labs-code/design.md
+    homepage: https://stitch.withgoogle.com/docs/design-md/specification
+  - slug: mcp-go
+    display_name: MCP Go
+    type: software
+    org: mark3labs
+    github: mark3labs/mcp-go
+    homepage: https://mcp-go.dev
 
   # Tool servers and tool-calling platforms
   - slug: aws-mcp-servers
@@ -52,6 +59,52 @@ products:
     org: klavis-ai
     github: Klavis-AI/klavis
     homepage: https://www.klavis.ai
+  - slug: open-connector
+    display_name: Open Connector
+    type: software
+    org: oomol
+    github: oomol-lab/open-connector
+    homepage: https://oomol.com
+  - slug: fastapi-mcp
+    display_name: FastAPI-MCP
+    type: software
+    org: tadata
+    github: tadata-org/fastapi_mcp
+    pypi: fastapi-mcp
+    homepage: https://fastapi-mcp.tadata.com/
+
+  # Target-specific MCP servers
+  - slug: desktop-commander-mcp
+    display_name: Desktop Commander MCP
+    type: software
+    org: desktop-commander
+    github: wonderwhy-er/DesktopCommanderMCP
+    npm: "@wonderwhy-er/desktop-commander"
+    homepage: https://desktopcommander.app/
+  - slug: atlassian-mcp
+    display_name: Atlassian MCP
+    type: software
+    org: sooperset
+    github: sooperset/mcp-atlassian
+    homepage: https://mcp-atlassian.soomiles.com
+  - slug: git-mcp
+    display_name: GitMCP
+    type: software
+    org: idosal
+    github: idosal/git-mcp
+    homepage: https://gitmcp.io
+  - slug: browser-tools-mcp
+    display_name: Browser Tools MCP
+    type: software
+    org: agentdesk
+    github: AgentDeskAI/browser-tools-mcp
+    npm: "@agentdeskai/browser-tools-mcp"
+    homepage: https://agentdesk.ai/
+  - slug: capsule-fs
+    display_name: Capsule FS
+    type: software
+    org: unicity
+    github: unicity-aos/capsule-fs
 
   # Retrieval and browsing services
   - slug: crawl4ai
@@ -80,12 +133,17 @@ products:
     org: lightpanda
     github: lightpanda-io/browser
     homepage: https://lightpanda.io
+  - slug: agent-reach
+    display_name: Agent-Reach
+    type: software
+    org: panniantong
+    github: Panniantong/Agent-Reach
 
   # Document ingestion for agent consumption
   - slug: mineru
     display_name: MinerU
     type: software
-    org: opendatalab
+    org: shanghai-ai-laboratory
     github: opendatalab/MinerU
     pypi: mineru
     homepage: https://opendatalab.github.io/MinerU/
@@ -110,3 +168,15 @@ products:
     github: opendataloader-project/opendataloader-pdf
     pypi: opendataloader-pdf
     homepage: https://opendataloader.org
+  - slug: omniparse
+    display_name: OmniParse
+    type: software
+    org: cognitivelab
+    github: adithya-s-k/omniparse
+    homepage: https://omniparse.cognitivelab.in/
+  - slug: xberg
+    display_name: Xberg
+    type: software
+    org: xberg
+    github: xberg-io/xberg
+    homepage: https://docs.xberg.io

--- a/sources/registry/agent_tools_protocols.yaml
+++ b/sources/registry/agent_tools_protocols.yaml
@@ -1,0 +1,112 @@
+# Swept 2026-08-30 from the warehouse discovery pool (currentai.scores.repos_summary, refreshed
+# 2026-08-24), over the six subcategories that carry agent-facing tooling: AI Engineering / Give
+# agent tools, Give agent knowledge and Protocols, and Infrastructure / Protocols, Make world
+# agent-ready and Index & Search. Predeclared retrieval cutoff: the top 300 repositories by
+# all-time stars across those six, which bottoms out at 4,621 stars. Every row below was verified
+# against the GitHub API on 2026-08-30; the counts, the parked candidates and their reasons are in
+# the sweep summary on the discovery PR. Nothing here is scored.
+category: agent_tools_protocols
+products:
+  # Protocol and specification layer
+  - slug: mcp-go-sdk
+    display_name: MCP Go SDK
+    type: software
+    org: anthropic
+    github: modelcontextprotocol/go-sdk
+    homepage: https://modelcontextprotocol.io
+  - slug: agents-md
+    display_name: AGENTS.md
+    type: software
+    org: agentsmd
+    github: agentsmd/agents.md
+    homepage: https://agents.md
+  - slug: agent-skills
+    display_name: Agent Skills
+    type: software
+    org: agentskills
+    github: agentskills/agentskills
+    homepage: https://agentskills.io
+
+  # Tool servers and tool-calling platforms
+  - slug: aws-mcp-servers
+    display_name: AWS MCP Servers
+    type: software
+    org: amazon-web-services
+    github: awslabs/mcp
+    homepage: https://awslabs.github.io/mcp/
+  - slug: mcp-toolbox-for-databases
+    display_name: MCP Toolbox for Databases
+    type: software
+    org: google-cloud
+    github: googleapis/mcp-toolbox
+    homepage: https://mcp-toolbox.dev
+  - slug: aci-dev
+    display_name: ACI.dev
+    type: software
+    org: aipotheosis-labs
+    github: aipotheosis-labs/aci
+    homepage: https://www.aci.dev
+  - slug: klavis
+    display_name: Klavis
+    type: software
+    org: klavis-ai
+    github: Klavis-AI/klavis
+    homepage: https://www.klavis.ai
+
+  # Retrieval and browsing services
+  - slug: crawl4ai
+    display_name: Crawl4AI
+    type: software
+    org: unclecode
+    github: unclecode/crawl4ai
+    pypi: crawl4ai
+    homepage: https://crawl4ai.com
+  - slug: context7
+    display_name: Context7
+    type: software
+    org: upstash
+    github: upstash/context7
+    npm: "@upstash/context7-mcp"
+    homepage: https://context7.com
+  - slug: steel-browser
+    display_name: Steel Browser
+    type: software
+    org: steel
+    github: steel-dev/steel-browser
+    homepage: https://steel.dev
+  - slug: lightpanda
+    display_name: Lightpanda
+    type: software
+    org: lightpanda
+    github: lightpanda-io/browser
+    homepage: https://lightpanda.io
+
+  # Document ingestion for agent consumption
+  - slug: mineru
+    display_name: MinerU
+    type: software
+    org: opendatalab
+    github: opendatalab/MinerU
+    pypi: mineru
+    homepage: https://opendatalab.github.io/MinerU/
+  - slug: marker
+    display_name: Marker
+    type: software
+    org: datalab
+    github: datalab-to/marker
+    pypi: marker-pdf
+    homepage: https://www.datalab.to
+  - slug: liteparse
+    display_name: LiteParse
+    type: software
+    org: llamaindex
+    github: run-llama/liteparse
+    pypi: liteparse
+    homepage: https://developers.llamaindex.ai/liteparse/
+  - slug: opendataloader-pdf
+    display_name: OpenDataLoader PDF
+    type: software
+    org: opendataloader
+    github: opendataloader-project/opendataloader-pdf
+    pypi: opendataloader-pdf
+    homepage: https://opendataloader.org

--- a/sources/registry/agent_tools_protocols.yaml
+++ b/sources/registry/agent_tools_protocols.yaml
@@ -106,6 +106,64 @@ products:
     org: unicity
     github: unicity-aos/capsule-fs
 
+  - slug: code-review-graph
+    display_name: Code Review Graph
+    type: software
+    org: tirth8205
+    github: tirth8205/code-review-graph
+    homepage: https://code-review-graph.com
+  - slug: claude-context
+    display_name: Claude Context
+    type: software
+    org: zilliz
+    github: zilliztech/claude-context
+  - slug: repowise
+    display_name: RepoWise
+    type: software
+    org: repowise
+    github: repowise-dev/repowise
+    homepage: https://repowise.dev
+  - slug: unity-mcp
+    display_name: Unity MCP
+    type: software
+    org: coplay
+    github: CoplayDev/unity-mcp
+    homepage: https://coplaydev.github.io/unity-mcp/
+  - slug: godot-mcp
+    display_name: Godot MCP
+    type: software
+    org: coding-solo
+    github: Coding-Solo/godot-mcp
+  - slug: ida-pro-mcp
+    display_name: IDA Pro MCP
+    type: software
+    org: mrexodia
+    github: mrexodia/ida-pro-mcp
+    homepage: https://plugins.hex-rays.com/mrexodia/ida-pro-mcp
+  - slug: talk-to-figma-mcp
+    display_name: Cursor Talk To Figma MCP
+    type: software
+    org: grab
+    github: grab/cursor-talk-to-figma-mcp
+  - slug: excalidraw-mcp
+    display_name: Excalidraw MCP
+    type: software
+    org: excalidraw
+    github: excalidraw/excalidraw-mcp
+    homepage: https://mcp.excalidraw.com
+  - slug: zotero-mcp
+    display_name: Zotero MCP
+    type: software
+    org: 54yyyu
+    github: 54yyyu/zotero-mcp
+    homepage: https://stevenyuyy.com/zotero-mcp/
+  - slug: xiaohongshu-mcp
+    display_name: Xiaohongshu MCP
+    type: software
+    org: xpzouying
+    github: xpzouying/xiaohongshu-mcp
+    homepage: https://www.haha.ai/xiaohongshu-mcp
+
   # Retrieval and browsing services
   - slug: crawl4ai
     display_name: Crawl4AI


### PR DESCRIPTION
Discovery sweep for `agent_tools_protocols`, following `docs/workflows/discover-candidates.md`. Candidate rows only — no products, no scores, no roster changes.

*Revised twice after review. First pass removed an acceptance cap on the named candidates (15 → 26) and settled the organization identities. This pass removes the last of that cap, which had survived inside a cluster reason (26 → 36).*

## Window and sources swept

- **Source:** the warehouse discovery pool, `currentai.scores.repos_summary`, snapshot 2026-08-24.
- **Scope:** the six pool subcategories carrying agent-facing tooling — AI Engineering / *Give agent tools*, *Give agent knowledge*, *Protocols*; Infrastructure / *Protocols*, *Make world agent-ready*, *Index & Search*. Those six hold 1,905 repositories.
- **Predeclared retrieval cutoff:** the top 300 by all-time stars across the six, bottoming out at 4,621 stars. Coverage limitation: 1,605 pool repositories below that line were not retrieved. The cutoff bounds retrieval only. Everything retrieved was triaged on its merits, and nothing surfaced was rejected for its rank.
- **Predeclared maintenance rule**, stated before it was applied and applied uniformly: park on maintenance only if the repository is archived, or has had no push in over twelve months as of 2026-08-30. Six candidates meet it. No other quality, popularity, novelty or capacity threshold was applied.
- **Discovery boundary:** agent-facing protocols, tool servers, retrieval and browsing services, and document-ingestion tools. Excluded: general agent frameworks, vector databases, and generic browser automation unless the product is packaged specifically as an agent tool or protocol.

## What makes a target-specific MCP server a product

Stated as a rule because fifteen of the thirty-six accepted rows turn on it, and because the previous revision applied it inconsistently.

A target-specific MCP server is a candidate product when it is **independently published and maintained** — its own repository, its own release cadence, an owner distinct from the product it targets. It is *not* a candidate when it is a surface of a product already on the map, which is why `firecrawl/firecrawl-mcp-server` and `exa-labs/exa-mcp-server` are deduplicated as SKUs rather than triaged.

Narrowness of target is not a disqualifier. The category already publishes six servers of exactly this shape — `github-mcp`, `slack-mcp`, `notion-mcp`, `postgres-mcp`, `filesystem-mcp`, `playwright-mcp` — so a rule that excluded a Unity or Zotero server would also exclude six published products. None of the targets here (Unity, Godot, Ghidra, IDA Pro, Figma, Excalidraw, Zotero, WhatsApp, Xiaohongshu) is itself a product on the map, so none of these rows is a SKU of anything.

## Counts

```
raw_signals       300  =  duplicate_signals  34  +  unique_candidates 266
unique_candidates 266  =  accepted           36  +  parked           230
```

Both balance. The 230 parked are 17 named individually and 213 grouped into named clusters, every member listed.

## Accepted (36)

The registry is the tail tier and may hold more than the category eventually publishes; nothing here is a commitment to promote.

**Protocol and specification layer (4)** — `agents-md` (`agentsmd/agents.md`), `agent-skills` (`agentskills/agentskills`), `design-md` (`google-labs-code/design.md`), `mcp-go` (`mark3labs/mcp-go`)

**Tool servers and tool-calling platforms (6)** — `aws-mcp-servers` (`awslabs/mcp`), `mcp-toolbox-for-databases` (`googleapis/mcp-toolbox`), `aci-dev` (`aipotheosis-labs/aci`), `klavis` (`Klavis-AI/klavis`), `open-connector` (`oomol-lab/open-connector`), `fastapi-mcp` (`tadata-org/fastapi_mcp`)

**Target-specific MCP servers (15)** — `desktop-commander-mcp` (`wonderwhy-er/DesktopCommanderMCP`), `atlassian-mcp` (`sooperset/mcp-atlassian`), `git-mcp` (`idosal/git-mcp`), `browser-tools-mcp` (`AgentDeskAI/browser-tools-mcp`), `capsule-fs` (`unicity-aos/capsule-fs`), `code-review-graph` (`tirth8205/code-review-graph`), `claude-context` (`zilliztech/claude-context`), `repowise` (`repowise-dev/repowise`), `unity-mcp` (`CoplayDev/unity-mcp`), `godot-mcp` (`Coding-Solo/godot-mcp`), `ida-pro-mcp` (`mrexodia/ida-pro-mcp`), `talk-to-figma-mcp` (`grab/cursor-talk-to-figma-mcp`), `excalidraw-mcp` (`excalidraw/excalidraw-mcp`), `zotero-mcp` (`54yyyu/zotero-mcp`), `xiaohongshu-mcp` (`xpzouying/xiaohongshu-mcp`)

**Retrieval and browsing services (5)** — `crawl4ai` (`unclecode/crawl4ai`), `context7` (`upstash/context7`), `steel-browser` (`steel-dev/steel-browser`), `lightpanda` (`lightpanda-io/browser`), `agent-reach` (`Panniantong/Agent-Reach`)

**Document ingestion for agent consumption (6)** — `mineru` (`opendatalab/MinerU`), `marker` (`datalab-to/marker`), `liteparse` (`run-llama/liteparse`), `opendataloader-pdf` (`opendataloader-project/opendataloader-pdf`), `omniparse` (`adithya-s-k/omniparse`), `xberg` (`xberg-io/xberg`)

Every accepted row was fetched from the GitHub API on 2026-08-30 for existence, canonical `owner/repo`, licence, archived state and last push. Source URL for each is `https://github.com/<repository>`. Each declared `pypi` / `npm` package was fetched from its registry API on 2026-08-30 and confirmed to point back at the declared repository. `omniparse` declares no `pypi` deliberately: the package of that name on PyPI belongs to `The-Swarm-Corporation/OmniParse`, a different project.

## Organization identities

**`mineru` → `shanghai-ai-laboratory`, resolved.** The `opendatalab` GitHub org publishes its contact address as `OpenDataLab@pjlab.org.cn`, the Shanghai AI Laboratory domain, so OpenDataLab is a project identity under that lab rather than a separate organization. The row uses the supported slug, which already holds `internlm` and `lmdeploy`.

**`mcp-go-sdk` → parked, unresolved.** Its organization cannot be settled without also deciding where the three existing MCP SDK records belong, which is a governance question this PR should not answer. Reason recorded with the other parked candidates below.

Six rows reuse existing slugs — `amazon-web-services`, `google`, `google-cloud`, `llamaindex`, `shanghai-ai-laboratory`, `zilliz`. Thirty introduce a slug the corpus does not have. Each is the publishing entity's own name, or its GitHub owner where no company exists; org records are created at promotion, not here.

## Licence findings that promotion must not skip

- **`opendatalab/MinerU` is not ordinary Apache-2.0.** Its `LICENSE.md` is Apache-2.0 plus additional terms: a separate commercial licence above 100M MAU or USD 20M monthly revenue, a prominent-attribution obligation for online services, and automatic termination for breach. Use-bounded and source-available under this corpus's rules, not an OSI grant. The GitHub `NOASSERTION` is substantive, not a parsing failure.
- **`excalidraw/excalidraw-mcp` ships no LICENSE file at all.** The row records identity only, but promotion cannot treat absence as permissive — the corpus's own precedent is to read an unlicensed public repository as all-rights-reserved.
- **`mark3labs/mcp-go` is cleanly MIT.** The other `NOASSERTION` case is the parked `modelcontextprotocol/go-sdk`, whose LICENSE describes an MIT-to-Apache-2.0 transition with documentation under CC-BY-4.0 — the same three-way split already recorded on `model-context-protocol`, to be recorded as components rather than flattened.

## Follow-ups, deliberately not in this PR

- **Open the agent-memory / context-store category proposal.** The cluster is coherent and 22 products deep, and it is a real taxonomy gap.
- **Hold the skills/plugin-content proposal** pending an ontology decision — many of those entries are content packs rather than products.
- **`docs/workflows/discover-candidates.md` names `currentai.entities.repos`** as the discovery pool. This sweep used `currentai.scores.repos_summary`, which carries the same repositories plus the star counts a retrieval cutoff needs. If that is now canonical the workflow doc should say so, separately from this PR.

## Parked, named individually (17)

Each carries a durable boundary, identity, maintenance or duplication reason. None is parked to cap the size of the accepted set.

- **modelcontextprotocol/go-sdk** (5,005 stars) — https://github.com/modelcontextprotocol/go-sdk — *identity*: the repository sits under the `modelcontextprotocol` org, and this corpus's own score record for `model-context-protocol` puts governance with the Linux Foundation's AAIF. The three existing MCP SDK products (`mcp-python-sdk`, `mcp-typescript-sdk`, `mcp-inspector`) are filed under `anthropic`, precedent that predates the donation. Filing this row under `anthropic` extends stale precedent; filing it under a new slug splits the SDK family across two orgs. Parked for a resolution that covers all four records at once, not just this one
- **transitive-bullshit/agentic** (18,115 stars) — https://github.com/transitive-bullshit/agentic — *maintenance*: archived, last push 2026-02-11
- **airweave-ai/airweave** (6,561 stars) — https://github.com/airweave-ai/airweave — *maintenance*: archived, last push 2026-06-05
- **quivrhq/megaparse** (7,413 stars) — https://github.com/quivrhq/megaparse — *maintenance*: last push 2025-02-21, eighteen months before the sweep
- **browsermcp/mcp** (7,006 stars) — https://github.com/browsermcp/mcp — *maintenance*: last push 2025-04-24, sixteen months before the sweep
- **openclaw/mcporter** (4,947 stars) — https://github.com/openclaw/mcporter — *boundary*: calls MCP servers from TypeScript; a client-side convenience layer that sits in orchestration_agents, not in the tool and protocol layer
- **mcp-ui-org/mcp-ui** (5,098 stars) — https://github.com/mcp-ui-org/mcp-ui — *boundary*: UI over MCP, sitting between agent_tools_protocols and ui_api. The workflow says escalate a two-category boundary rather than assign it
- **getbindu/bindu** (8,664 stars) — https://github.com/getbindu/bindu — *boundary*: identity, communication and payments for agents. The payments dimension has no peer anywhere in the taxonomy, so the product cannot be placed without stretching a category
- **sciphi-ai/r2r** (7,972 stars) — https://github.com/sciphi-ai/r2r — *boundary*: between a retrieval service and a RAG framework; RAG frameworks are outside the sweep boundary
- **zipstack/unstract** (7,155 stars) — https://github.com/zipstack/unstract — *boundary*: packaged as an API deployment and ETL pipeline rather than as a tool an agent calls
- **withcoral/coral** (4,981 stars) — https://github.com/withcoral/coral — *boundary*: one SQL interface over APIs, files and live sources; sits on the storage boundary
- **vectifyai/pageindex** (35,290 stars) — https://github.com/vectifyai/pageindex — *boundary*: a document index; sits on the storage boundary, where the vector databases went on 2026-08-18
- **startrail-org/pixelrag** (9,655 stars) — https://github.com/startrail-org/pixelrag — *boundary*: pixel-native search index; same storage boundary as PageIndex
- **lauriewired/ghidramcp** (9,841 stars) — https://github.com/lauriewired/ghidramcp — *maintenance*: last push 2025-06-23, fourteen months before the sweep
- **lharries/whatsapp-mcp** (6,185 stars) — https://github.com/lharries/whatsapp-mcp — *maintenance*: last push 2025-07-13, thirteen months before the sweep
- **lastmile-ai/mcp-agent** (8,514 stars) — https://github.com/lastmile-ai/mcp-agent — *boundary*: builds agents on MCP with workflow patterns. That is an agent framework, which the sweep boundary excludes and orchestration_agents already covers; it is not a tool server
- **opendatalab/pdf-extract-kit** (9,985 stars) — https://github.com/opendatalab/pdf-extract-kit — *identity*: same org as the accepted `mineru` and functionally upstream of it. Whether these are one product or two is an entity-resolution call, and the workflow says park an unresolved identity rather than guess

## Parked, by cluster (213)

Every grouped `owner/repo` denotes `https://github.com/<owner>/<repo>`. These come from the 2026-08-24 pool snapshot and were triaged on 2026-08-30 against the description and identity the snapshot carries. **They were not individually re-fetched from the GitHub API on 2026-08-30** — only the accepted rows and the fourteen individually-named parked candidates above were. A grouped repository's live state is therefore unverified, and a later sweep should re-check rather than inherit these calls.

### Agent skill and plugin content packs (68)

content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls. No category in the taxonomy holds authored agent content.

`graphify-labs/graphify`, `kepano/obsidian-skills`, `k-dense-ai/scientific-agent-skills`, `volcengine/openviking`, `mukul975/anthropic-cybersecurity-skills`, `googleworkspace/cli`, `vercel-labs/skills`, `zhaoxuya520/reverse-skill`, `ahujasid/blender-mcp`, `phuryn/pm-skills`, `openai/skills`, `op7418/guizang-ppt-skill`, `virgiliojr94/book-to-skill`, `tencentcloud/tencentdb-agent-memory`, `anthropics/knowledge-work-plugins`, `alchaincyf/huashu-design`, `google/skills`, `larksuite/cli`, `hardikpandya/stop-slop`, `wanshuiyin/auto-claude-code-research-in-sleep`, `yusufkaraaslan/skill_seekers`, `agricidaniel/claude-seo`, `greensock/gsap-skills`, `lsdefine/genericagent`, `earthtojake/text-to-cad`, `jeffallan/claude-skills`, `memtensor/memos`, `yizhiyanhua-ai/fireworks-tech-graph`, `numman-ali/openskills`, `dontbesilent2025/dbskill`, `nicobailon/visual-explainer`, `openclaw/clawhub`, `anthropics/claude-for-legal`, `eze-is/web-access`, `kangarooking/cangjie-skill`, `agricidaniel/claude-ads`, `google-labs-code/stitch-skills`, `agents365-ai/drawio-skill`, `pleaseprompto/notebooklm-skill`, `rapidai/rapidocr`, `hkuds/openspace`, `simoneavogadro/android-reverse-engineering-skill`, `midudev/autoskills`, `parthjadhav/app-store-screenshots`, `sawyerhood/dev-browser`, `op7418/guizang-social-card-skill`, `xbuilderlab/cheat-on-content`, `promptslab/awesome-prompt-engineering`, `czlonkowski/n8n-skills`, `vincentwei1021/video-shotcraft`, `chuspeeism/dashi-ppt-skill`, `worldwonderer/oh-story-claudecode`, `jacob-bd/gemini-notebook-mcp-cli`, `anysearch-ai/anysearch-skill`, `antfu/skills`, `joeseesun/qiaomu-anything-to-notebooklm`, `google/agents-cli`, `browser-act/skills`, `diffusionstudio/lottie`, `jgraph/drawio-mcp`, `dotnet/skills`, `openai/plugins`, `ningzimu/codex-ppt-skill`, `openclaw/peekaboo`, `opensensenova/sensenova-skills`, `martian-engineering/lossless-claw`, `iflytek/skillhub`, `eastlondoner/vibe-tools`

### Agent memory and context stores (22)

agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols into storage; it wants a category-proposal issue of its own.

`egonex-ai/understand-anything`, `colbymchenry/codegraph`, `mem0ai/mem0`, `mempalace/mempalace`, `abhigyanpatwari/gitnexus`, `deusdata/codebase-memory-mcp`, `getzep/graphiti`, `supermemoryai/supermemory`, `rohitg00/agentmemory`, `vectorize-io/hindsight`, `mksglu/context-mode`, `memvid/memvid`, `nevamind-ai/memu`, `evermind-ai/everos`, `holaboss-ai/holaos`, `unicity-aos/capsule-memory`, `gsd-build/gsd-2`, `plastic-labs/honcho`, `gentleman-programming/engram`, `campfirein/byterover-cli`, `getzep/zep`, `vitali87/code-graph-rag`

### Agent frameworks, harnesses and runtimes (28)

general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents.

`d4vinci/scrapling`, `mindsdb/mindshub`, `yeachan-heo/oh-my-codex`, `herdrdev/herdr`, `labring/fastgpt`, `zai-org/open-autoglm`, `micro/go-micro`, `hkuds/rag-anything`, `primeintellect-ai/prime-agent`, `browser-use/browser-harness`, `hkuds/openharness`, `llmware-ai/llmware`, `yc-software/qm`, `neuml/txtai`, `0x4m4/hexstrike-ai`, `mcp-use/mcp-use`, `ntegrals/openbrowser`, `omnigent-ai/omnigent`, `openspg/kag`, `withastro/flue`, `mattpocock/sandcastle`, `microsoft/webwright`, `vercel-labs/open-agents`, `openbmb/ultrarag`, `elder-plinius/t3mp3st`, `agentscope-ai/agentteams`, `unicity-sphere/sphere-sdk`, `vercel/eve`

### GUI, mobile and desktop automation agents (16)

device and GUI automation agents rather than agent-facing tool services.

`stablyai/orca`, `alibaba/page-agent`, `microsoft/omniparser`, `hypfer/valetudo`, `x-plug/mobileagent`, `droidrun/mobilerun`, `firerpa/lamda`, `cursortouch/windows-mcp`, `clemenselflein/openmower`, `kijai/comfyui-wanvideowrapper`, `getsentry/xcodebuildmcp`, `cubiq/comfyui_ipadapter_plus`, `mobile-next/mobile-mcp`, `tradesdontlie/tradingview-mcp`, `executeautomation/mcp-playwright`, `ngxson/smolvlm-realtime-webcam`

### Generic browser automation and scraping libraries (14)

generic browser automation and scraping, excluded by the sweep boundary unless the product is packaged specifically as an agent tool, which is why Steel Browser and Lightpanda were accepted and these were not.

`naibowang/easyspider`, `vercel-labs/agent-browser`, `jackwener/opencli`, `apify/crawlee`, `builderio/gpt-crawler`, `h4ckf0r0day/obscura`, `getmaxun/maxun`, `apify/crawlee-python`, `jo-inc/camofox-browser`, `jdepoix/youtube-transcript-api`, `mishushakov/llm-scraper`, `adbar/trafilatura`, `epiral/bb-browser`, `knockoutez/wigolo`

### RAG frameworks and vector or hybrid search engines (9)

RAG frameworks and search or vector engines. Vector databases belong to storage, where Qdrant, Milvus and Pinecone were moved on 2026-08-18.

`headroomlabs-ai/headroom`, `pathwaycom/llm-app`, `quivrhq/quivr`, `startrail-org/leann`, `zilliztech/gptcache`, `timescale/pgai`, `neo4j-labs/llm-graph-builder`, `marqo-ai/marqo`, `feyninc/chonkie`

### OCR and document-image model toolkits (6)

OCR and document-image model toolkits. The corpus already places `olmocr`, a toolkit of exactly this shape, in dataset_processing_tools, so these follow that precedent.

`paddlepaddle/paddleocr`, `naptha/tesseract.js`, `deepseek-ai/deepseek-ocr`, `bytedance/dolphin`, `layout-parser/layout-parser`, `grobidorg/grobid`

### Coding-agent tooling and developer utilities (25)

tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol layer.

`ultraworkers/claw-code`, `garrytan/gstack`, `rtk-ai/rtk`, `hkuds/cli-anything`, `heygen-com/hyperframes`, `jcodesmore/ai-website-cloner-template`, `iofficeai/officecli`, `wavetermdev/waveterm`, `guillaumemeyer/watermarks-remover`, `bradautomates/claude-video`, `langchain-ai/openwiki`, `coderamp-labs/gitingest`, `chenhg5/cc-connect`, `zhishile/codex-auth-helper`, `mufeedvh/code2prompt`, `aidenybai/react-grab`, `opensquilla/opensquilla`, `steipete/agent-scripts`, `minishlab/semble`, `galaxy-dawn/claude-scholar`, `linuxhsj/openclaw-zero-token`, `maziyarpanahi/openmed`, `entireio/cli`, `neilsonnn/image-blaster`, `saladday/cc-switch-cli`

### Domain applications and other out-of-scope repositories (25)

domain applications, demos, whitepapers and other repositories outside the stack-map thesis for this category.

`openbb-finance/openbb`, `anthropics/financial-services`, `chenfei-wu/taskmatrix`, `garrytan/gbrain`, `microsoft/jarvis`, `livekit/livekit`, `unicitynetwork/whitepaper`, `arc53/docsgpt`, `nangohq/nango`, `cocoindex-io/cocoindex`, `tracer-cloud/opensre`, `semantica-agi/semantica`, `dmtrkovalenko/fff`, `evolution-foundation/evolution-api`, `simonlin1212/a-stock-data`, `cloudflare/computer`, `microsoft/llmlingua`, `run-llama/rags`, `volcengine/minecontext`, `metalbear-co/mirrord`, `katanaml/sparrow`, `marker-inc-korea/autorag`, `pennyroyaltea/gibberlink`, `integuru-ai/integuru`, `open-mmlab/mmocr`


## Deduplicated before triage (34)

Repository already declared by a head product (30): `activeloopai/deeplake`, `allenai/olmocr`, `chroma-core/chroma`, `composiohq/composio`, `deepset-ai/haystack`, `docling-project/docling`, `facebookresearch/faiss`, `firecrawl/firecrawl`, `github/github-mcp-server`, `hkuds/lightrag`, `infiniflow/ragflow`, `jina-ai/reader`, `lancedb/lancedb`, `meilisearch/meilisearch`, `microsoft/graphrag`, `microsoft/markitdown`, `microsoft/playwright-mcp`, `milvus-io/milvus`, `modelcontextprotocol/inspector`, `modelcontextprotocol/python-sdk`, `modelcontextprotocol/servers`, `modelcontextprotocol/typescript-sdk`, `nmslib/hnswlib`, `nousresearch/hermes-agent`, `pathwaycom/pathway`, `prefecthq/fastmcp`, `qdrant/qdrant`, `run-llama/llama_index`, `spotify/annoy`, `vespa-engine/vespa`

Resolved to a head product by hand, because the product declares no github artifact for repo-level dedup to match (4):

- **modelcontextprotocol/modelcontextprotocol** — spec repository of head product `model-context-protocol`, which declares no github artifact, so repo-level dedup misses it
- **a2aproject/a2a** — repository of head product `agent2agent-protocol`, which declares no github artifact. Canonical casing is `a2aproject/A2A`
- **firecrawl/firecrawl-mcp-server** — MCP surface of head product `firecrawl`; a SKU, not a product
- **exa-labs/exa-mcp-server** — MCP surface of head product `exa-search-api`; a SKU, not a product