### PR TITLE
Preflight: account for every CI step, not every step matching a regex

### DIFF
--- a/build/preflight.py
+++ b/build/preflight.py
@@ -1,93 +1,153 @@
-"""Run locally what CI's `validate` workflow runs, in its order, and fail the same way.
+"""Run locally what CI's `validate` workflow runs, and account for every step it does not.
 
-Why this exists. The promotion of five products into `agent_tools_protocols` passed a local
-loop of `validate` + `check_recipe` + `check_rubric` + `check_verification` + `pytest`, and then
-failed CI on `build.check_components` with ten errors: the `raw:` strings had been hand-written
-and did not recompose from the structured `components` mappings. `build.validate` does not check
-that, so no amount of running it would have caught the problem. The local loop was not
-representative of CI, and the only reason that was survivable is that the batch was five
-products. It will not be survivable at four hundred.
+Why this exists. The promotion of five products passed a local loop of `validate` +
+`check_recipe` + `check_rubric` + `check_verification` + `pytest`, then failed CI on
+`build.check_components` with ten errors: the `raw:` strings had been hand-written and did not
+recompose from their structured `components` mappings. `build.validate` does not check that, so
+no amount of running it would have caught the problem. That was survivable at five products. It
+is not survivable at four hundred.
 
-The step list is READ FROM `.github/workflows/validate.yml` at run time rather than restated
-here, so this cannot drift from CI by being forgotten. `tests/test_preflight.py` asserts the
-parse finds every step, which is what keeps the reading honest if the workflow's shape changes.
+WHY THIS IS NOT A REGEX. The first version of this module scraped the workflow for commands
+matching `uv run python -m build.*` or `uv run pytest`, and its test recomputed the expected list
+with the same regex. Any CI command the pattern did not recognize - the notebook AST parse run
+through `python -c`, `marimo check`, the `git checkout` that restores generated files, the whole
+`generated-files-guard` job - was invisible to the implementation AND to the test, which stayed
+green while covering less than it claimed. A test that confirms its own blind spot is worse than
+no test, because it is believed.
 
-`build.render` and `build.serialize` WRITE bot-owned generated files - `build/notebook_data.json`
-and `notebooks/ai-stack-map.py`. CI regenerates them in a throwaway checkout; locally they dirty
-your tree, and committing them fails the `generated-files-guard` job. Restore them after a run:
-`git checkout -- build/notebook_data.json notebooks/ai-stack-map.py`. They are left rather than
-auto-reverted because a run that silently reverted files would hide a real regeneration diff.
+So the unit here is the workflow's own STEP, read structurally from the YAML, and the invariant
+is total:
 
-Not a substitute for CI. `check_parity` and `check_artifacts --live` need credentials and the
-warehouse and run in their own workflows; a green preflight means the offline gates hold, not
-that the branch is mergeable.
+    every `run:` step in validate.yml is either executed locally or listed in PLAN with a reason
+
+`tests/test_preflight.py` asserts that set equality against the parsed workflow, not against a
+second copy of this file's idea of a step. A step added to CI fails the test until somebody
+classifies it, which is the only version of "cannot drift" that is true.
+
+Generated files. `serialize` and `render` write `build/notebook_data.json` and
+`notebooks/ai-stack-map.py`, which are bot-owned. This module hashes them before the run, reports
+any change as a finding, and restores them afterwards, so a regeneration diff cannot hide and the
+tree is not left dirty either.
 """
 from __future__ import annotations
 
 import argparse
-import re
-import shlex
+import hashlib
 import subprocess
 import sys
 import time
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "validate.yml"
 
-# Captured to end of line, NOT to the first quote. Stopping at the quote silently truncated
-# `--max-age-days "${{ inputs.n }}"` to `--max-age-days`, which passed the `${{` filter below
-# and would have run the gate with a missing argument.
-_STEP = re.compile(r"uv run (python -m build\.[a-z_]+[^\n]*|pytest[^\n]*)")
+GENERATED = ("build/notebook_data.json", "notebooks/ai-stack-map.py")
+
+RUN, SKIP, CI_ONLY = "LOCAL_RUN", "LOCAL_SKIP", "CI_ONLY"
+
+#: Every `run:` step in validate.yml, by its workflow `name`. The value is the mode and, for
+#: anything not run locally, the reason. Adding a step to CI without adding it here fails
+#: tests/test_preflight.py.
+PLAN: dict[str, tuple[str, str]] = {
+    "Install dependencies": (SKIP, "the local environment is already synced; `uv run` resolves it per call"),
+    "Validate sources (schema + cross-file invariants)": (RUN, ""),
+    "Run tests": (RUN, ""),
+    "Verification gates (invariant, digests, producible-pairs)": (RUN, ""),
+    "Capability gate (recorded comparisons hold)": (RUN, ""),
+    "Recipe gate (structure, deferral completeness, discarded evidence)": (RUN, ""),
+    "Components gate (a structured mapping matches its raw string)": (RUN, ""),
+    "Rubric gate (recorded scores reproduce)": (RUN, ""),
+    "Adoption gate (every band exists on its instrument's scale)": (RUN, ""),
+    "Instrument gate (every signal_type claim has what it needs to be falsifiable)": (RUN, ""),
+    "Routing table structure": (RUN, ""),
+    "Freshness report (informational, does not gate)": (RUN, ""),
+    "Serialize dry-run": (RUN, ""),
+    "Retirement gate (a removed slug carries a redirect alias)": (RUN, ""),
+    "Gate the serialized payload": (RUN, ""),
+    "Render notebook and check it parses": (RUN, ""),
+    "Fail if PR hand-edits bot-owned generated files": (
+        CI_ONLY,
+        "compares the PR against its merge base, which needs the PR context. Locally the same "
+        "class of problem is caught by this module's own generated-file check below.",
+    ),
+}
 
 
-def steps(workflow: Path = WORKFLOW) -> list[str]:
-    """The `uv run` commands CI executes, in workflow order, de-duplicated."""
-    found, seen = [], set()
-    for match in _STEP.finditer(workflow.read_text()):
-        command = match.group(1).strip().rstrip("\"'")
-        if "${{" in command:  # a workflow-input default; not reproducible locally
-            continue
-        if command not in seen:
-            seen.add(command)
-            found.append(command)
+def ci_steps(workflow: Path = WORKFLOW) -> list[tuple[str, str, str]]:
+    """(job, step name, run block) for every `run:` step in the workflow, in file order."""
+    document = yaml.safe_load(workflow.read_text()) or {}
+    found = []
+    for job_name, job in (document.get("jobs") or {}).items():
+        for step in (job.get("steps") or []):
+            if "run" in step:
+                found.append((job_name, step.get("name") or "", step["run"]))
     return found
+
+
+def unaccounted(workflow: Path = WORKFLOW) -> list[str]:
+    """Step names CI runs that PLAN does not classify. The invariant this module exists for."""
+    return [name for _, name, _ in ci_steps(workflow) if name not in PLAN]
+
+
+def _digests() -> dict[str, str | None]:
+    out: dict[str, str | None] = {}
+    for rel in GENERATED:
+        path = ROOT / rel
+        out[rel] = hashlib.sha256(path.read_bytes()).hexdigest() if path.exists() else None
+    return out
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--skip-tests", action="store_true",
                         help="skip the pytest step, which dominates the wall clock")
-    parser.add_argument("--list", action="store_true", help="print the steps and exit")
+    parser.add_argument("--list", action="store_true", help="print the plan and exit")
     args = parser.parse_args()
 
-    plan = steps()
-    if args.skip_tests:
-        plan = [c for c in plan if not c.startswith("pytest")]
+    missing = unaccounted()
+    if missing:
+        print("validate.yml has steps this module does not classify; add them to PLAN:")
+        for name in missing:
+            print(f"  ! {name!r}")
+        return 1
+
+    plan = [(job, name, run) for job, name, run in ci_steps()
+            if PLAN[name][0] == RUN and not (args.skip_tests and "pytest" in run)]
     if args.list:
-        print("\n".join(plan))
+        for job, name, _ in ci_steps():
+            mode, reason = PLAN[name]
+            print(f"  {mode:10} [{job}] {name}" + (f"\n             -> {reason}" if reason else ""))
         return 0
 
-    failures: list[tuple[str, int]] = []
-    for command in plan:
+    before = _digests()
+    failures: list[str] = []
+    for _, name, run in plan:
         started = time.monotonic()
-        result = subprocess.run(["uv", "run", *shlex.split(command)], cwd=ROOT,
-                                capture_output=True, text=True)
-        elapsed = time.monotonic() - started
+        result = subprocess.run(["bash", "-e", "-c", run], cwd=ROOT, capture_output=True, text=True)
         status = "ok  " if result.returncode == 0 else "FAIL"
-        print(f"  {status} {command:52} {elapsed:6.1f}s")
+        print(f"  {status} {name[:58]:58} {time.monotonic() - started:6.1f}s")
         if result.returncode != 0:
-            failures.append((command, result.returncode))
-            tail = (result.stdout + result.stderr).strip().splitlines()[-12:]
-            for line in tail:
+            failures.append(name)
+            for line in (result.stdout + result.stderr).strip().splitlines()[-12:]:
                 print(f"       | {line}")
 
+    regenerated = [rel for rel, digest in _digests().items() if digest != before[rel]]
+    if regenerated:
+        print("\ngenerated files changed under this run, and were restored:")
+        for rel in regenerated:
+            print(f"  ~ {rel}")
+        print("  commit them from a bot run, never by hand - CI's generated-files-guard rejects that.")
+        subprocess.run(["git", "checkout", "--", *regenerated], cwd=ROOT, check=False)
+
+    skipped = [(n, r) for n, (m, r) in PLAN.items() if m != RUN]
     print()
     if failures:
-        print(f"{len(failures)} of {len(plan)} step(s) failed: {', '.join(c for c, _ in failures)}")
+        print(f"{len(failures)} of {len(plan)} step(s) failed: {', '.join(failures)}")
         return 1
-    print(f"all {len(plan)} offline CI steps pass. check_parity and check_artifacts --live "
-          f"need the warehouse and run separately.")
+    print(f"all {len(plan)} locally-runnable CI steps pass; {len(skipped)} accounted for and not run.")
+    print("check_parity and check_artifacts --live need the warehouse and run in their own workflows.")
     return 0
 
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,50 +1,84 @@
-"""The preflight step list must stay the CI step list.
+"""Preflight must account for every CI step, and the accounting must not be self-confirming.
 
-The failure this guards against is the one that produced the module: a local gate loop that
-looked thorough and was missing the one check that mattered. If preflight can silently cover
-fewer steps than CI, it recreates that gap while looking like a fix for it.
+The first version of this file recomputed its expectation with the same regex production used,
+so a CI command the pattern did not recognize was omitted from both and the test stayed green
+while covering less than it claimed. These tests parse the workflow structurally instead, and
+compare against the hand-written PLAN, which is the only thing that can actually disagree.
 """
-import re
 from pathlib import Path
 
-from build.preflight import WORKFLOW, steps
+import pytest
+import yaml
+
+from build.preflight import CI_ONLY, GENERATED, PLAN, RUN, SKIP, WORKFLOW, ci_steps, unaccounted
 
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_every_ci_step_is_in_the_plan():
-    """Parsed against the workflow itself, so adding a CI gate adds it here for free."""
-    raw = re.findall(r"uv run (python -m build\.[a-z_]+[^\n]*|pytest[^\n]*)",
-                     WORKFLOW.read_text())
-    expected = [c.strip().rstrip("\"'") for c in raw if "${{" not in c]
-    assert steps() == list(dict.fromkeys(expected))
+def test_every_ci_run_step_is_accounted_for():
+    """The invariant. A step added to validate.yml fails here until somebody classifies it."""
+    assert unaccounted() == [], (
+        "these validate.yml steps are neither run locally nor listed in preflight.PLAN with a "
+        "reason; classify them"
+    )
 
 
-def test_the_plan_is_not_empty_and_names_the_gate_that_caused_this():
-    """`check_components` is the gate the promotion batch failed CI on. A parse that silently
-    matched nothing would return an empty list and report success, so both are asserted."""
-    plan = steps()
-    assert len(plan) >= 10
-    assert "python -m build.check_components" in plan
-    assert "python -m build.validate" in plan
-    assert "pytest -q" in plan
+def test_plan_lists_nothing_ci_does_not_run():
+    """The other direction: a PLAN entry for a step that no longer exists is stale."""
+    names = {name for _, name, _ in ci_steps()}
+    assert set(PLAN) - names == set()
 
 
-def test_workflow_inputs_are_excluded():
-    """Steps carrying a `${{ inputs.x }}` default cannot be reproduced locally and are dropped
-    rather than run with a literal `${{ ... }}` argument."""
-    assert not any("${{" in command for command in steps())
+def test_the_steps_are_read_from_the_workflow_not_restated():
+    """Parsed structurally, so multi-line shell and non-`uv run` commands are seen too - the
+    class the regex version silently dropped."""
+    document = yaml.safe_load(WORKFLOW.read_text())
+    expected = sum(1 for job in document["jobs"].values()
+                   for step in job.get("steps", []) if "run" in step)
+    assert len(ci_steps()) == expected
+    assert expected >= 15
 
 
-def test_parses_a_minimal_workflow(tmp_path):
+def test_a_non_uv_command_is_still_a_step(tmp_path):
+    """`marimo check` and a `python -c` AST parse are steps the old regex could not see. They
+    reach ci_steps() now, which is what makes the accounting total rather than pattern-shaped."""
     workflow = tmp_path / "validate.yml"
     workflow.write_text(
         "jobs:\n  validate:\n    steps:\n"
-        "      - run: uv run python -m build.validate\n"
-        "      - run: uv run pytest -q\n"
-        "      - run: uv run python -m build.check_components\n"
-        "      - run: uv run python -m build.check_freshness --max-age-days \"${{ inputs.n }}\"\n"
+        "      - name: Gate\n        run: uv run python -m build.validate\n"
+        "      - name: Notebook\n        run: |\n"
+        "          uv run marimo check notebooks/ai-stack-map.py\n"
+        "          uv run python -c 'import ast; ast.parse(open(\"x.py\").read())'\n"
+        "      - name: Restore\n        run: git checkout -- build/notebook_data.json\n"
     )
-    assert steps(workflow) == [
-        "python -m build.validate", "pytest -q", "python -m build.check_components",
-    ]
+    steps = ci_steps(workflow)
+    assert [name for _, name, _ in steps] == ["Gate", "Notebook", "Restore"]
+    assert "marimo check" in steps[1][2]
+    # None of these names is in PLAN, so all three are unaccounted - including the two the
+    # regex version could not even see.
+    assert unaccounted(workflow) == ["Gate", "Notebook", "Restore"]
+
+
+def test_every_plan_mode_is_known_and_reasons_accompany_the_skips():
+    for name, (mode, reason) in PLAN.items():
+        assert mode in {RUN, SKIP, CI_ONLY}, name
+        if mode != RUN:
+            assert len(reason) > 20, f"{name} is not run locally and needs a reason"
+
+
+def test_the_generated_files_are_the_bot_owned_pair():
+    """Named so the restore step cannot silently stop covering one of them."""
+    assert set(GENERATED) == {"build/notebook_data.json", "notebooks/ai-stack-map.py"}
+    for rel in GENERATED:
+        assert (ROOT / rel).exists()
+
+
+@pytest.mark.parametrize("gate", [
+    "Components gate (a structured mapping matches its raw string)",
+    "Validate sources (schema + cross-file invariants)",
+    "Run tests",
+])
+def test_the_gates_that_caught_real_failures_run_locally(gate):
+    """check_components is the gate the promotion batch failed CI on; it must never become a
+    CI_ONLY entry, which would reintroduce exactly the blind spot this module was written for."""
+    assert PLAN[gate][0] == RUN


### PR DESCRIPTION
The preflight added alongside the declaration work claimed it could not drift from CI. It could.

## The flaw

It scraped `validate.yml` for commands matching `uv run python -m build.*` or `uv run pytest`, and `tests/test_preflight.py` recomputed its expectation **with the same regex**. Anything the pattern did not recognize was invisible to the implementation and to the test at once:

- the generated-notebook AST parse, run through `python -c`
- `marimo check notebooks/ai-stack-map.py`
- the `git checkout` step that restores generated files
- the entire `generated-files-guard` job

A test that recomputes the production expectation with the production pattern confirms its own blind spot, and is worse than no test because it is believed.

## The fix

The unit is now the workflow's own **step**, read structurally from the YAML. The invariant is total:

> every `run:` step in validate.yml is either executed locally or listed in `PLAN` with a reason

`PLAN` is hand-written and keyed on the step name, so a step added to CI fails the test until somebody classifies it as `LOCAL_RUN`, `LOCAL_SKIP` or `CI_ONLY`. The tests assert set equality in **both** directions against the parsed workflow — an unclassified step fails, and so does a `PLAN` entry for a step CI no longer runs.

Two of the new tests exist specifically to pin the old failure: one feeds a synthetic workflow containing `marimo check`, a `python -c` AST parse and a bare `git checkout`, and asserts all three now reach `ci_steps()`; another asserts `check_components` — the gate the promotion batch actually failed CI on — is `LOCAL_RUN` and can never be quietly reclassified.

## Generated files

`serialize` and `render` write `build/notebook_data.json` and `notebooks/ai-stack-map.py`. The previous version told you to restore them by hand after every run, which is poor ergonomics for a command meant to precede hundreds of product changes. It now hashes them before, reports any change as a finding, and restores them — so the diff cannot hide **and** the run is side-effect-free.

## Result

`all 14 locally-runnable CI steps pass; 2 accounted for and not run.` About 80 seconds without pytest. `check_parity` and `check_artifacts --live` need the warehouse and stay in their own workflows.