### PR TITLE
Trim the Details payload to what the modal renders

### DIFF
--- a/build/details_payload.py
+++ b/build/details_payload.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 
+from build.vocabulary import axes
+
 #: What the modal's JavaScript actually reads off a product. It renders the three axes, the
 #: description and the identity line. It never reads `freshness`, `slug`, `org_slug`, `tier`,
 #: `maturity`, `mature` or `overall_score` - those belong to the table and the gap arithmetic.
@@ -54,7 +56,7 @@ def details_records(data: Mapping, order: Sequence[str]) -> dict[str, dict]:
         category = data["categories"][cid]
         for product in category["products"]:
             record = {k: product[k] for k in PRODUCT_KEYS if k in product}
-            for axis in ("openness", "adoption", "capability"):
+            for axis in axes():
                 if axis in record:
                     record[axis] = _trim_axis(record[axis])
             record["category_label"] = category["label"]

--- a/build/details_payload.py
+++ b/build/details_payload.py
@@ -1,0 +1,62 @@
+"""The per-product records the Details modal renders, and only those.
+
+Its own module because `build/render.py` is a marimo notebook: every function in it sits under
+an `@app.cell` decorator and is a cell, not an importable symbol. A helper defined there cannot
+be imported by a test, which is how the size test came to rebuild the payload with its own
+`{**product}` expansion instead of measuring the real one - so a trim in render.py changed
+nothing the test saw. That is the second self-confirming test in this repo in as many days, and
+the fix is the same one: one implementation, imported by both.
+
+WHY TRIMMING IS CORRECTNESS, NOT A SIZE TRICK. The payload is a single marimo cell output under
+a hard 8 MB cap. marimo does not raise when a cell exceeds it - it silently replaces the output,
+and the Details buttons are rendered by a DIFFERENT cell, so the notebook looks perfect while
+every button is wired to a handler that was never installed. That shipped on 2026-08-18.
+
+The payload grows linearly with the corpus. At 527 products the untrimmed record set measures
+close to the cap; a 135-product expansion put it at ~8.8 MB, over. Carrying a field the modal
+never reads was already a defect at 527 - the expansion is only what made it visible.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+#: What the modal's JavaScript actually reads off a product. It renders the three axes, the
+#: description and the identity line. It never reads `freshness`, `slug`, `org_slug`, `tier`,
+#: `maturity`, `mature` or `overall_score` - those belong to the table and the gap arithmetic.
+PRODUCT_KEYS = ("product", "org", "type", "description", "version_note", "lineage",
+                "openness", "adoption", "capability")
+
+#: Per axis. `bucket`, `governing_release` and `last_verified` are consumed elsewhere.
+AXIS_KEYS = ("score", "class", "level", "reach", "value", "basis", "basis_detail", "note",
+             "confidence", "components", "signal_type", "sources", "relative_to", "relation")
+
+#: Per source. The modal shows a link and what the document showed. `content_sha256` is the
+#: bulk of the excess - 64 hex characters per source, several sources per axis, three axes per
+#: product - and `accessed`, `http_status` and `establishes` are never rendered either.
+SOURCE_KEYS = ("url", "shows", "text")
+
+
+def _trim_axis(axis: object) -> object:
+    if not isinstance(axis, Mapping):
+        return axis
+    out = {k: v for k, v in axis.items() if k in AXIS_KEYS}
+    sources = out.get("sources")
+    if isinstance(sources, Sequence) and not isinstance(sources, (str, bytes)):
+        out["sources"] = [{k: v for k, v in s.items() if k in SOURCE_KEYS}
+                          for s in sources if isinstance(s, Mapping)]
+    return out
+
+
+def details_records(data: Mapping, order: Sequence[str]) -> dict[str, dict]:
+    """Payload keyed by product name, carrying only what the modal renders."""
+    payload: dict[str, dict] = {}
+    for cid in order:
+        category = data["categories"][cid]
+        for product in category["products"]:
+            record = {k: product[k] for k in PRODUCT_KEYS if k in product}
+            for axis in ("openness", "adoption", "capability"):
+                if axis in record:
+                    record[axis] = _trim_axis(record[axis])
+            record["category_label"] = category["label"]
+            payload[product["product"]] = record
+    return payload

--- a/build/render.py
+++ b/build/render.py
@@ -763,10 +763,10 @@ def details_payload(DATA, ORDER, mo):
     # Build a per-product payload keyed by product name, then install a delegated
     # click handler + modal via a hidden-iframe onload bootstrap (marimo strips
     # <script>, so we inject through the iframe into the parent document).
-    _payload = {}
-    for _cid in ORDER:
-        for _p in DATA["categories"][_cid]["products"]:
-            _payload[_p["product"]] = {**_p, "category_label": DATA["categories"][_cid]["label"]}
+    # Only what the modal reads, built by build/details_payload.py so the size test can
+    # import and measure the real payload rather than a second copy of this expansion.
+    from build.details_payload import details_records
+    _payload = details_records(DATA, ORDER)
     # Base64, not raw JSON. This payload is interpolated into an HTML *attribute*, so it
     # gets escaped (" -> &quot;), and a single astral character anywhere in it (a Hugging
     # Face emoji, in practice) widens the whole Python string to 4 bytes per character.

--- a/tests/test_details_payload_size.py
+++ b/tests/test_details_payload_size.py
@@ -41,18 +41,19 @@ PAYLOAD = Path(__file__).resolve().parents[1] / "build" / "notebook_data.json"
 
 
 def _details_attribute() -> str:
-    """Rebuild exactly what build/render.py puts in the iframe's onload attribute."""
+    """Exactly what build/render.py puts in the iframe's onload attribute.
+
+    Built by importing the real payload builder. This function used to rebuild the payload
+    with its own `{**product}` expansion, which meant it measured a payload the notebook
+    never shipped: a trim in render.py changed nothing here, and this test would have gone
+    on passing or failing for reasons unrelated to what marimo actually receives.
+    """
+    from build.details_payload import details_records
+
     data = json.loads(PAYLOAD.read_text(encoding="utf-8"))
     order = data["order"] if isinstance(data.get("order"), list) else list(data["categories"])
-    payload = {}
-    for cid in order:
-        for product in data["categories"][cid]["products"]:
-            payload[product["product"]] = {
-                **product,
-                "category_label": data["categories"][cid]["label"],
-            }
     encoded = base64.b64encode(
-        json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        json.dumps(details_records(data, order), ensure_ascii=False).encode("utf-8")
     ).decode("ascii")
     # The attribute escaping render.py applies. A no-op on base64, deliberately.
     return encoded.replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;")
@@ -87,3 +88,49 @@ def test_the_payload_is_ascii_so_one_emoji_cannot_widen_it():
         "the payload is stored at more than 1 byte per character, which means a "
         "wide character crept in and doubled what marimo measures."
     )
+
+
+def test_the_payload_carries_only_what_the_modal_renders():
+    """The trim, asserted by key rather than by size.
+
+    A size assertion alone cannot tell a payload that is small because it is correct from one
+    that is small because the corpus shrank. These name the fields the modal never reads, so
+    re-adding one fails here rather than silently eating the headroom the cap leaves.
+    """
+    from build.details_payload import details_records
+
+    data = json.loads(PAYLOAD.read_text(encoding="utf-8"))
+    order = data["order"] if isinstance(data.get("order"), list) else list(data["categories"])
+    records = details_records(data, order)
+    assert records
+
+    for record in records.values():
+        assert not {"freshness", "slug", "org_slug", "tier", "maturity", "mature",
+                    "overall_score"} & set(record)
+        for axis in ("openness", "adoption", "capability"):
+            block = record.get(axis)
+            if not isinstance(block, dict):
+                continue
+            assert not {"bucket", "governing_release", "last_verified"} & set(block)
+            for source in block.get("sources") or []:
+                assert not {"content_sha256", "accessed", "http_status",
+                            "establishes"} & set(source)
+
+
+def test_the_trim_leaves_the_fields_the_modal_does_render():
+    """The other direction: a trim that dropped `note` or `sources` would shrink the payload
+    and gut the modal, and the size test would applaud."""
+    from build.details_payload import details_records
+
+    data = json.loads(PAYLOAD.read_text(encoding="utf-8"))
+    order = data["order"] if isinstance(data.get("order"), list) else list(data["categories"])
+    records = details_records(data, order)
+
+    with_sources = 0
+    for record in records.values():
+        assert record.get("description")
+        assert "category_label" in record
+        openness = record.get("openness") or {}
+        assert "score" in openness and "note" in openness
+        with_sources += bool(openness.get("sources"))
+    assert with_sources > len(records) * 0.9


### PR DESCRIPTION
A prerequisite for any corpus expansion, found by one.

## The wall

The Details payload is a single marimo cell output under a hard 8,000,000-byte cap. marimo does not raise when a cell exceeds it — it silently replaces the output, and the Details *buttons* are rendered by a **different** cell. So the notebook looks perfect and every button is wired to a handler that was never installed. That shipped once already, on 2026-08-18, and `tests/test_details_payload_size.py` exists because of it.

The payload grows linearly with the corpus:

| corpus | untrimmed | trimmed |
|---|---|---|
| 527 products (today) | 7,180,178 | **5,641,610** |
| 662 products (a 135-product expansion) | 8,827,258 — **over cap** | ~6.9 MB |

Carrying a field the modal never reads was already a defect at 527 products. The expansion is only what made it visible.

## The trim

Keyed on what the modal's JavaScript actually reads. It renders the three axes, the description and the identity line, and cites each source by `url` and `shows`. It never reads a product's `freshness`, `slug`, `org_slug`, `tier`, `maturity`, `mature` or `overall_score` — those belong to the table and the gap arithmetic — nor an axis's `bucket`, `governing_release` or `last_verified`, nor a source's `accessed`, `http_status`, `establishes` or `content_sha256`. The digests are the bulk of the excess: 64 hex characters per source, several sources per axis, three axes per product.

## The second self-confirming test

`_details_attribute()` in the size test **rebuilt the payload with its own `{**product}` expansion**, so it measured a payload the notebook never shipped — a trim in `render.py` would have changed nothing it saw.

The builder therefore moves to `build/details_payload.py`. It cannot live in `render.py`: that file is a marimo notebook, where every function sits under an `@app.cell` decorator and is a cell rather than an importable symbol. The test now imports the real builder.

Two new tests assert the trim **by key, in both directions** — that the unrendered fields are absent, and that `description`, `note` and `sources` survive. A size assertion alone cannot tell a payload that is small because it is correct from one that is small because it was gutted.

## Headroom, and what it does not buy

Trimming buys roughly 135 more products, not five thousand. The linear growth is unchanged; only the constant moved. Getting to the 5,000-product target needs the payload split across cells or fetched on demand, and this PR does not do that.

## Gates

All 14 offline CI steps pass.