### PR TITLE
Resolution ledger: make prior human decisions readable by the next bulk run

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -34,6 +34,7 @@ on:
       - "build/serialize_scores.py"
       - "build/taxonomy.py"
       - "build/validate.py"
+      - "build/resolution.py"
       - "build/vocabulary.py"
       - "build/publish_registry.py"
       - ".github/workflows/registry.yml"
@@ -58,6 +59,7 @@ on:
       - "build/serialize_scores.py"
       - "build/taxonomy.py"
       - "build/validate.py"
+      - "build/resolution.py"
       - "build/vocabulary.py"
       - "build/publish_registry.py"
   workflow_dispatch:

--- a/build/declaration_version.py
+++ b/build/declaration_version.py
@@ -172,6 +172,14 @@ POLICY_INPUTS: dict[str, dict[str, object]] = {
 
 # Non-declaration inputs — authored nowhere as a scoring declaration.
 NON_DECLARATION_INPUTS: dict[str, str] = {
+    "resolution_ledger.yaml": (
+        "governance over what MAY become a product, not a declaration of what is one. An entry "
+        "records that a candidate repository was already resolved - to an existing product, to a "
+        "SKU, or out of scope - and changes no product's identity, artifacts or score. Binding it "
+        "into the declaration digest would re-key every declaration_version_id corpus-wide "
+        "whenever somebody wrote down a boundary decision, which is a cost the cutover plan "
+        "reserves for changes that actually move a declaration."
+    ),
     "snapshots": (
         "frozen point-in-time warehouse sample (long_tail.json), hand-synced; a re-sync is "
         "not a change in the declarations."

--- a/build/details_payload.py
+++ b/build/details_payload.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 
+from build.vocabulary import axes
+
 #: What the modal's JavaScript actually reads off a product. It renders the three axes, the
 #: description and the identity line. It never reads `freshness`, `slug`, `org_slug`, `tier`,
 #: `maturity`, `mature` or `overall_score` - those belong to the table and the gap arithmetic.
@@ -54,7 +56,7 @@ def details_records(data: Mapping, order: Sequence[str]) -> dict[str, dict]:
         category = data["categories"][cid]
         for product in category["products"]:
             record = {k: product[k] for k in PRODUCT_KEYS if k in product}
-            for axis in ("openness", "adoption", "capability"):
+            for axis in axes():
                 if axis in record:
                     record[axis] = _trim_axis(record[axis])
             record["category_label"] = category["label"]

--- a/build/details_payload.py
+++ b/build/details_payload.py
@@ -1,0 +1,62 @@
+"""The per-product records the Details modal renders, and only those.
+
+Its own module because `build/render.py` is a marimo notebook: every function in it sits under
+an `@app.cell` decorator and is a cell, not an importable symbol. A helper defined there cannot
+be imported by a test, which is how the size test came to rebuild the payload with its own
+`{**product}` expansion instead of measuring the real one - so a trim in render.py changed
+nothing the test saw. That is the second self-confirming test in this repo in as many days, and
+the fix is the same one: one implementation, imported by both.
+
+WHY TRIMMING IS CORRECTNESS, NOT A SIZE TRICK. The payload is a single marimo cell output under
+a hard 8 MB cap. marimo does not raise when a cell exceeds it - it silently replaces the output,
+and the Details buttons are rendered by a DIFFERENT cell, so the notebook looks perfect while
+every button is wired to a handler that was never installed. That shipped on 2026-08-18.
+
+The payload grows linearly with the corpus. At 527 products the untrimmed record set measures
+close to the cap; a 135-product expansion put it at ~8.8 MB, over. Carrying a field the modal
+never reads was already a defect at 527 - the expansion is only what made it visible.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+#: What the modal's JavaScript actually reads off a product. It renders the three axes, the
+#: description and the identity line. It never reads `freshness`, `slug`, `org_slug`, `tier`,
+#: `maturity`, `mature` or `overall_score` - those belong to the table and the gap arithmetic.
+PRODUCT_KEYS = ("product", "org", "type", "description", "version_note", "lineage",
+                "openness", "adoption", "capability")
+
+#: Per axis. `bucket`, `governing_release` and `last_verified` are consumed elsewhere.
+AXIS_KEYS = ("score", "class", "level", "reach", "value", "basis", "basis_detail", "note",
+             "confidence", "components", "signal_type", "sources", "relative_to", "relation")
+
+#: Per source. The modal shows a link and what the document showed. `content_sha256` is the
+#: bulk of the excess - 64 hex characters per source, several sources per axis, three axes per
+#: product - and `accessed`, `http_status` and `establishes` are never rendered either.
+SOURCE_KEYS = ("url", "shows", "text")
+
+
+def _trim_axis(axis: object) -> object:
+    if not isinstance(axis, Mapping):
+        return axis
+    out = {k: v for k, v in axis.items() if k in AXIS_KEYS}
+    sources = out.get("sources")
+    if isinstance(sources, Sequence) and not isinstance(sources, (str, bytes)):
+        out["sources"] = [{k: v for k, v in s.items() if k in SOURCE_KEYS}
+                          for s in sources if isinstance(s, Mapping)]
+    return out
+
+
+def details_records(data: Mapping, order: Sequence[str]) -> dict[str, dict]:
+    """Payload keyed by product name, carrying only what the modal renders."""
+    payload: dict[str, dict] = {}
+    for cid in order:
+        category = data["categories"][cid]
+        for product in category["products"]:
+            record = {k: product[k] for k in PRODUCT_KEYS if k in product}
+            for axis in ("openness", "adoption", "capability"):
+                if axis in record:
+                    record[axis] = _trim_axis(record[axis])
+            record["category_label"] = category["label"]
+            payload[product["product"]] = record
+    return payload

--- a/build/render.py
+++ b/build/render.py
@@ -763,10 +763,10 @@ def details_payload(DATA, ORDER, mo):
     # Build a per-product payload keyed by product name, then install a delegated
     # click handler + modal via a hidden-iframe onload bootstrap (marimo strips
     # <script>, so we inject through the iframe into the parent document).
-    _payload = {}
-    for _cid in ORDER:
-        for _p in DATA["categories"][_cid]["products"]:
-            _payload[_p["product"]] = {**_p, "category_label": DATA["categories"][_cid]["label"]}
+    # Only what the modal reads, built by build/details_payload.py so the size test can
+    # import and measure the real payload rather than a second copy of this expansion.
+    from build.details_payload import details_records
+    _payload = details_records(DATA, ORDER)
     # Base64, not raw JSON. This payload is interpolated into an HTML *attribute*, so it
     # gets escaped (" -> &quot;), and a single astral character anywhere in it (a Hugging
     # Face emoji, in practice) widens the whole Python string to 4 bytes per character.

--- a/build/resolution.py
+++ b/build/resolution.py
@@ -1,0 +1,46 @@
+"""The resolution ledger: decisions about candidate repositories a person already made.
+
+See `sources/resolution_ledger.yaml` for why it exists. In short: a discovery sweep resolves a
+repository by hand and records the reasoning in a pull request, which no later run can read. The
+first corpus expansion duly recreated four repositories that #413 had already resolved - one of
+them a product the corpus carries under another name.
+
+This module is the reader. `build/validate.py` enforces the half that can be enforced
+mechanically, and a bulk pipeline is expected to consult `verdict_for` before proposing a
+product from a repository.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+LEDGER = ROOT / "sources" / "resolution_ledger.yaml"
+
+#: A repository resolved to one of these is not a new product.
+NOT_A_NEW_PRODUCT = frozenset({"existing_product", "sku_of", "excluded_boundary",
+                               "excluded_maintenance"})
+#: `unresolved` is deliberately not in that set: it means a person has to look, and a rerun
+#: proposing it again is the correct behaviour, not a regression.
+VERDICTS = NOT_A_NEW_PRODUCT | {"unresolved"}
+
+
+def load(path: Path = LEDGER) -> dict[str, dict]:
+    """Ledger keyed by lowercased `owner/repo`."""
+    if not path.exists():
+        return {}
+    doc = yaml.safe_load(path.read_text()) or {}
+    return {e["repo"].lower(): e for e in (doc.get("resolutions") or [])}
+
+
+def verdict_for(repo: str, ledger: Mapping[str, dict] | None = None) -> dict | None:
+    """The recorded decision for a repository, or None if it has never been resolved."""
+    return (load() if ledger is None else ledger).get((repo or "").lower())
+
+
+def blocks_new_product(repo: str, ledger: Mapping[str, dict] | None = None) -> dict | None:
+    """The entry that forbids minting a product from this repository, if any."""
+    entry = verdict_for(repo, ledger)
+    return entry if entry and entry.get("verdict") in NOT_A_NEW_PRODUCT else None

--- a/build/resolution.py
+++ b/build/resolution.py
@@ -27,12 +27,35 @@ NOT_A_NEW_PRODUCT = frozenset({"existing_product", "sku_of", "excluded_boundary"
 VERDICTS = NOT_A_NEW_PRODUCT | {"unresolved"}
 
 
+class DuplicateResolution(ValueError):
+    """Two entries resolve the same repository. For governance state that is never benign."""
+
+
 def load(path: Path = LEDGER) -> dict[str, dict]:
-    """Ledger keyed by lowercased `owner/repo`."""
+    """Ledger keyed by lowercased `owner/repo`.
+
+    A duplicate repository raises rather than resolving last-write-wins. The dict comprehension
+    this replaced would silently keep whichever entry came last, so `Foo/Bar: existing_product`
+    followed by `foo/bar: unresolved` would quietly discard the stronger decision - and the file
+    is hand-edited by people appending after each review, which is exactly how that happens.
+    `docs/reference/identity.md` records the same failure in the deleted slug-alias mapping:
+    two renames of one retired slug, and whichever came last won.
+    """
     if not path.exists():
         return {}
     doc = yaml.safe_load(path.read_text()) or {}
-    return {e["repo"].lower(): e for e in (doc.get("resolutions") or [])}
+    entries: dict[str, dict] = {}
+    for entry in (doc.get("resolutions") or []):
+        key = (entry.get("repo") or "").strip().removesuffix(".git").lower()
+        if key in entries:
+            raise DuplicateResolution(
+                f"{path.name}: {entry.get('repo')!r} is resolved twice - already "
+                f"{entries[key]['verdict']!r} from {entries[key].get('decided_in')}, now "
+                f"{entry.get('verdict')!r} from {entry.get('decided_in')}. Identity is compared "
+                f"lowercased and without a .git suffix, so these are one repository. Merge them."
+            )
+        entries[key] = entry
+    return entries
 
 
 def verdict_for(repo: str, ledger: Mapping[str, dict] | None = None) -> dict | None:
@@ -41,6 +64,26 @@ def verdict_for(repo: str, ledger: Mapping[str, dict] | None = None) -> dict | N
 
 
 def blocks_new_product(repo: str, ledger: Mapping[str, dict] | None = None) -> dict | None:
-    """The entry that forbids minting a product from this repository, if any."""
+    """The entry that PERMANENTLY forbids minting a product from this repository, if any.
+
+    This is what `build/validate.py` enforces, and it deliberately excludes `unresolved`: a
+    person may still add such a product by hand once they have settled the question, and the
+    build should not stop them.
+    """
     entry = verdict_for(repo, ledger)
     return entry if entry and entry.get("verdict") in NOT_A_NEW_PRODUCT else None
+
+
+def holds_bulk_promotion(repo: str, ledger: Mapping[str, dict] | None = None) -> dict | None:
+    """The entry that stops a BULK run from promoting this repository, if any.
+
+    Any entry at all, `unresolved` included. "Not permanently excluded" and "this proposal may
+    proceed" are different questions, and conflating them published a bug: the #418 review
+    recorded `ag-ui` as a protocol filed under agent frameworks, `serena` as an MCP retrieval
+    toolkit and `repomix` as document ingestion - and then the same run published all three in
+    `orchestration_agents`, the category the entry says is wrong.
+
+    `unresolved` means the repository may come back to a LATER sweep, not that the CURRENT
+    proposal is fit to publish. A bulk run parks it for a person; a person resolves it.
+    """
+    return verdict_for(repo, ledger)

--- a/build/validate.py
+++ b/build/validate.py
@@ -142,6 +142,39 @@ def validate_sources(data: dict) -> list[str]:
             if len(cat.get("products") or []) < 10:
                 errors.append(f"category {cid!r}: published category needs at least 10 scored products")
 
+    # --- resolution ledger ---
+    # A repository a person already resolved may not come back as a new product. The ledger
+    # exists because a decision recorded only in a pull request is invisible to the next bulk
+    # run: the first corpus expansion recreated `a2aproject/A2A` as a product called `a2a`
+    # though #413 had resolved it to `agent2agent-protocol`, and eleven more besides. Prose is
+    # not an input; this file is.
+    #
+    # `unresolved` is deliberately not enforced. It means a person still has to look, so a
+    # later run proposing the repository again is the intended behaviour rather than a
+    # regression, and failing the build on it would just delete the distinction.
+    from build.resolution import NOT_A_NEW_PRODUCT, load as load_ledger
+
+    ledger = load_ledger()
+    for slug, product in sorted((data.get("products") or {}).items()):
+        for artifact in (product.get("github") or []):
+            url = (artifact.get("url") or "").rstrip("/")
+            if "github.com/" not in url:
+                continue
+            repo = url.split("github.com/")[-1].removesuffix(".git").lower()
+            entry = ledger.get(repo)
+            if not entry or entry.get("verdict") not in NOT_A_NEW_PRODUCT:
+                continue
+            if entry.get("product") == slug:
+                continue
+            resolved_to = entry.get("product") or entry.get("boundary") or "out of scope"
+            errors.append(
+                f"products/{slug}.yaml: declares {repo!r}, which the resolution ledger "
+                f"resolves as {entry['verdict']} -> {resolved_to} "
+                f"(decided in {entry.get('decided_in', 'an earlier sweep')}). Either the "
+                f"ledger entry is wrong and a person should change it, or this product "
+                f"should not exist."
+            )
+
     # --- tail registry invariants ---
     # Tail rows are deliberately lighter than head product records, but identity is
     # not: a slug and a GitHub artifact may appear in only one tier and category.

--- a/sources/resolution_ledger.yaml
+++ b/sources/resolution_ledger.yaml
@@ -1,0 +1,1837 @@
+# Decisions about candidate repositories that a person has already made.
+#
+# WHY THIS FILE EXISTS. A discovery sweep resolves a repository by hand - "this is the spec repo
+# of a product we already carry", "this is a vendor's MCP surface, not a product", "this is
+# authored content, not software" - and records the reasoning in a pull request. The corpus then
+# holds the DECISION nowhere a machine can read it. The next bulk run re-derives the same
+# candidate from the same pool, finds no artifact that matches, and recreates it.
+#
+# That is not hypothetical. The first corpus expansion recreated `a2aproject/A2A` as a new
+# product called `a2a`, though #413 had resolved it to `agent2agent-protocol` by hand. It
+# recreated `firecrawl/firecrawl-mcp-server`, which #413 had called an MCP surface of
+# `firecrawl` rather than a product. And it created `anthropics/knowledge-work-plugins` and
+# `promptslab/Awesome-Prompt-Engineering` as software, though #413 had parked both as authored
+# content pending an ontology decision.
+#
+# The A2A case is the sharpest, because it was self-inflicted twice over: `agent2agent-protocol`
+# declares no github artifact precisely BECAUSE #415 left it undeclared pending a ruling on
+# adoption routing. Repo-level dedup could not see it, and nothing else in the repo could either.
+#
+# VERDICTS
+#   existing_product      the repository belongs to a product already in the corpus
+#   sku_of                a surface or edition of a product, not a product of its own
+#   excluded_boundary     out of scope for the map, with the boundary named
+#   excluded_maintenance  archived, or unmaintained past the sweep's declared window
+#   unresolved            identity genuinely undecided; needs a person, not a rerun
+#
+# A bulk run must consult this file before proposing a product and must never silently
+# overturn an entry. build/validate.py enforces the half that can be enforced: no product may
+# declare a repository this file resolves elsewhere.
+#
+# Seeded 2026-08-31 from the reviewed decisions in #413. Entries are appended by later sweeps;
+# a verdict is changed only deliberately, by a person, with `decided_in` updated.
+version: 1
+resolutions:
+- repo: 0x4m4/hexstrike-ai
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: abhigyanpatwari/gitnexus
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: adbar/trafilatura
+  verdict: excluded_boundary
+  boundary: generic-browser-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: generic browser automation and scraping, excluded by the sweep boundary unless the product is
+    packaged specifically as an agent tool, which is why Steel Browser and Lightpanda were accepted and
+    these were not
+- repo: agents365-ai/drawio-skill
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: agentscope-ai/agentteams
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: agricidaniel/claude-ads
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: agricidaniel/claude-seo
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: ahujasid/blender-mcp
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: aidenybai/react-grab
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: alchaincyf/huashu-design
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: alibaba/page-agent
+  verdict: excluded_boundary
+  boundary: gui-and-device-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: device and GUI automation agents rather than agent-facing tool services
+- repo: antfu/skills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: anthropics/claude-for-legal
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: anthropics/financial-services
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: anthropics/knowledge-work-plugins
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: anysearch-ai/anysearch-skill
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: apify/crawlee
+  verdict: excluded_boundary
+  boundary: generic-browser-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: generic browser automation and scraping, excluded by the sweep boundary unless the product is
+    packaged specifically as an agent tool, which is why Steel Browser and Lightpanda were accepted and
+    these were not
+- repo: apify/crawlee-python
+  verdict: excluded_boundary
+  boundary: generic-browser-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: generic browser automation and scraping, excluded by the sweep boundary unless the product is
+    packaged specifically as an agent tool, which is why Steel Browser and Lightpanda were accepted and
+    these were not
+- repo: arc53/docsgpt
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: BasedHardware/omi
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: a wearable/screen-capture assistant product rather than a stack layer
+- repo: bradautomates/claude-video
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: browser-act/skills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: browser-use/browser-harness
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: builderio/gpt-crawler
+  verdict: excluded_boundary
+  boundary: generic-browser-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: generic browser automation and scraping, excluded by the sweep boundary unless the product is
+    packaged specifically as an agent tool, which is why Steel Browser and Lightpanda were accepted and
+    these were not
+- repo: bytedance/dolphin
+  verdict: excluded_boundary
+  boundary: ocr-and-document-image-toolkits
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: OCR and document-image model toolkits. The corpus already places `olmocr`, a toolkit of exactly
+    this shape, in dataset_processing_tools, so these follow that precedent
+- repo: campfirein/byterover-cli
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: chenfei-wu/taskmatrix
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: chenhg5/cc-connect
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: chuspeeism/dashi-ppt-skill
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: clemenselflein/openmower
+  verdict: excluded_boundary
+  boundary: gui-and-device-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: device and GUI automation agents rather than agent-facing tool services
+- repo: cloudflare/computer
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: cocoindex-io/cocoindex
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: coderamp-labs/gitingest
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: colbymchenry/codegraph
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: cubiq/comfyui_ipadapter_plus
+  verdict: excluded_boundary
+  boundary: gui-and-device-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: device and GUI automation agents rather than agent-facing tool services
+- repo: cursortouch/windows-mcp
+  verdict: excluded_boundary
+  boundary: gui-and-device-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: device and GUI automation agents rather than agent-facing tool services
+- repo: czlonkowski/n8n-skills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: d4vinci/scrapling
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: danielmiessler/LifeOS
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: an intent-engineering platform, not a chat UI or an API gateway
+- repo: davila7/claude-code-templates
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: configuration templates for one agent, the content boundary
+- repo: deepseek-ai/deepseek-ocr
+  verdict: excluded_boundary
+  boundary: ocr-and-document-image-toolkits
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: OCR and document-image model toolkits. The corpus already places `olmocr`, a toolkit of exactly
+    this shape, in dataset_processing_tools, so these follow that precedent
+- repo: deusdata/codebase-memory-mcp
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: diffusionstudio/lottie
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: dmtrkovalenko/fff
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: dontbesilent2025/dbskill
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: dora-rs/dora
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: robotics dataflow middleware, outside the GPAIS thesis
+- repo: dotnet/skills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: droidrun/mobilerun
+  verdict: excluded_boundary
+  boundary: gui-and-device-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: device and GUI automation agents rather than agent-facing tool services
+- repo: dyoshikawa/rulesync
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: generates config files for coding agents
+- repo: earthtojake/text-to-cad
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: eastlondoner/vibe-tools
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: egonex-ai/understand-anything
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: elder-plinius/t3mp3st
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: entireio/cli
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: epiral/bb-browser
+  verdict: excluded_boundary
+  boundary: generic-browser-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: generic browser automation and scraping, excluded by the sweep boundary unless the product is
+    packaged specifically as an agent tool, which is why Steel Browser and Lightpanda were accepted and
+    these were not
+- repo: evermind-ai/everos
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: EveryInc/compound-engineering-plugin
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: an authored plugin for coding agents
+- repo: evolution-foundation/evolution-api
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: executeautomation/mcp-playwright
+  verdict: excluded_boundary
+  boundary: gui-and-device-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: device and GUI automation agents rather than agent-facing tool services
+- repo: eze-is/web-access
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: feyninc/chonkie
+  verdict: excluded_boundary
+  boundary: rag-frameworks-and-vector-search
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: RAG frameworks and search or vector engines. Vector databases belong to storage, where Qdrant,
+    Milvus and Pinecone were moved on 2026-08-18
+- repo: firerpa/lamda
+  verdict: excluded_boundary
+  boundary: gui-and-device-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: device and GUI automation agents rather than agent-facing tool services
+- repo: galaxy-dawn/claude-scholar
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: garrytan/gbrain
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: garrytan/gstack
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: gentleman-programming/engram
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: getbindu/bindu
+  verdict: excluded_boundary
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: identity, communication and payments for agents. The payments dimension has no peer anywhere in
+    the taxonomy, so the product cannot be placed without stretching a category
+- repo: getmaxun/maxun
+  verdict: excluded_boundary
+  boundary: generic-browser-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: generic browser automation and scraping, excluded by the sweep boundary unless the product is
+    packaged specifically as an agent tool, which is why Steel Browser and Lightpanda were accepted and
+    these were not
+- repo: getsentry/xcodebuildmcp
+  verdict: excluded_boundary
+  boundary: gui-and-device-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: device and GUI automation agents rather than agent-facing tool services
+- repo: getzep/graphiti
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: getzep/zep
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: google-labs-code/stitch-skills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: google/agents-cli
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: google/skills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: googleworkspace/cli
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: graphify-labs/graphify
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: greensock/gsap-skills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: grobidorg/grobid
+  verdict: excluded_boundary
+  boundary: ocr-and-document-image-toolkits
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: OCR and document-image model toolkits. The corpus already places `olmocr`, a toolkit of exactly
+    this shape, in dataset_processing_tools, so these follow that precedent
+- repo: gsd-build/gsd-2
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: guillaumemeyer/watermarks-remover
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: h4ckf0r0day/obscura
+  verdict: excluded_boundary
+  boundary: generic-browser-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: generic browser automation and scraping, excluded by the sweep boundary unless the product is
+    packaged specifically as an agent tool, which is why Steel Browser and Lightpanda were accepted and
+    these were not
+- repo: hardikpandya/stop-slop
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: headroomlabs-ai/headroom
+  verdict: excluded_boundary
+  boundary: rag-frameworks-and-vector-search
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: RAG frameworks and search or vector engines. Vector databases belong to storage, where Qdrant,
+    Milvus and Pinecone were moved on 2026-08-18
+- repo: herdrdev/herdr
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: heygen-com/hyperframes
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: hkuds/cli-anything
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: HKUDS/nanobot
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: a personal agent framework; ui_api is for the surface, not the framework
+- repo: hkuds/openharness
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: hkuds/openspace
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: hkuds/rag-anything
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: holaboss-ai/holaos
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: hypfer/valetudo
+  verdict: excluded_boundary
+  boundary: gui-and-device-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: device and GUI automation agents rather than agent-facing tool services
+- repo: iflytek/skillhub
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: integuru-ai/integuru
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: iofficeai/officecli
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: jackwener/opencli
+  verdict: excluded_boundary
+  boundary: generic-browser-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: generic browser automation and scraping, excluded by the sweep boundary unless the product is
+    packaged specifically as an agent tool, which is why Steel Browser and Lightpanda were accepted and
+    these were not
+- repo: jacob-bd/gemini-notebook-mcp-cli
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: jcodesmore/ai-website-cloner-template
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: jdepoix/youtube-transcript-api
+  verdict: excluded_boundary
+  boundary: generic-browser-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: generic browser automation and scraping, excluded by the sweep boundary unless the product is
+    packaged specifically as an agent tool, which is why Steel Browser and Lightpanda were accepted and
+    these were not
+- repo: jeffallan/claude-skills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: jgraph/drawio-mcp
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: jo-inc/camofox-browser
+  verdict: excluded_boundary
+  boundary: generic-browser-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: generic browser automation and scraping, excluded by the sweep boundary unless the product is
+    packaged specifically as an agent tool, which is why Steel Browser and Lightpanda were accepted and
+    these were not
+- repo: joeseesun/qiaomu-anything-to-notebooklm
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: k-dense-ai/scientific-agent-skills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: kangarooking/cangjie-skill
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: katanaml/sparrow
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: kepano/obsidian-skills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: kijai/comfyui-wanvideowrapper
+  verdict: excluded_boundary
+  boundary: gui-and-device-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: device and GUI automation agents rather than agent-facing tool services
+- repo: knockoutez/wigolo
+  verdict: excluded_boundary
+  boundary: generic-browser-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: generic browser automation and scraping, excluded by the sweep boundary unless the product is
+    packaged specifically as an agent tool, which is why Steel Browser and Lightpanda were accepted and
+    these were not
+- repo: labring/fastgpt
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: lakehq/sail
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: a Spark replacement for batch and stream processing, not AI deployment
+- repo: langchain-ai/openwiki
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: larksuite/cli
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: lastmile-ai/mcp-agent
+  verdict: excluded_boundary
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: builds agents on MCP with workflow patterns. That is an agent framework, which the sweep boundary
+    excludes and orchestration_agents already covers; it is not a tool server
+- repo: layout-parser/layout-parser
+  verdict: excluded_boundary
+  boundary: ocr-and-document-image-toolkits
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: OCR and document-image model toolkits. The corpus already places `olmocr`, a toolkit of exactly
+    this shape, in dataset_processing_tools, so these follow that precedent
+- repo: Leonxlnx/taste-skill
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: 'an authored agent skill, which is content rather than software; the boundary #413 parked pending
+    an ontology decision'
+- repo: linuxhsj/openclaw-zero-token
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: livekit/livekit
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: llmware-ai/llmware
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: lsdefine/genericagent
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: marker-inc-korea/autorag
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: marqo-ai/marqo
+  verdict: excluded_boundary
+  boundary: rag-frameworks-and-vector-search
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: RAG frameworks and search or vector engines. Vector databases belong to storage, where Qdrant,
+    Milvus and Pinecone were moved on 2026-08-18
+- repo: martian-engineering/lossless-claw
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: mattpocock/sandcastle
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: maziyarpanahi/openmed
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: mcp-ui-org/mcp-ui
+  verdict: excluded_boundary
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: UI over MCP, sitting between agent_tools_protocols and ui_api. The workflow says escalate a two-category
+    boundary rather than assign it
+- repo: mcp-use/mcp-use
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: mem0ai/mem0
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: mempalace/mempalace
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: memtensor/memos
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: memvid/memvid
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: metalbear-co/mirrord
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: micro/go-micro
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: microsoft/jarvis
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: microsoft/llmlingua
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: microsoft/omniparser
+  verdict: excluded_boundary
+  boundary: gui-and-device-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: device and GUI automation agents rather than agent-facing tool services
+- repo: microsoft/skills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: 'a skills and Agents.md catalogue, the content boundary #413 parked'
+- repo: microsoft/webwright
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: midudev/autoskills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: mindsdb/mindshub
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: minishlab/semble
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: mishushakov/llm-scraper
+  verdict: excluded_boundary
+  boundary: generic-browser-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: generic browser automation and scraping, excluded by the sweep boundary unless the product is
+    packaged specifically as an agent tool, which is why Steel Browser and Lightpanda were accepted and
+    these were not
+- repo: mksglu/context-mode
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: mobile-next/mobile-mcp
+  verdict: excluded_boundary
+  boundary: gui-and-device-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: device and GUI automation agents rather than agent-facing tool services
+- repo: mufeedvh/code2prompt
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: mukul975/anthropic-cybersecurity-skills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: mvanhorn/last30days-skill
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: 'an authored agent skill, which is content rather than software; the boundary #413 parked pending
+    an ontology decision'
+- repo: naibowang/easyspider
+  verdict: excluded_boundary
+  boundary: generic-browser-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: generic browser automation and scraping, excluded by the sweep boundary unless the product is
+    packaged specifically as an agent tool, which is why Steel Browser and Lightpanda were accepted and
+    these were not
+- repo: nangohq/nango
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: nanocoai/nanoclaw
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: an agent runtime in containers, not a chat UI
+- repo: naptha/tesseract.js
+  verdict: excluded_boundary
+  boundary: ocr-and-document-image-toolkits
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: OCR and document-image model toolkits. The corpus already places `olmocr`, a toolkit of exactly
+    this shape, in dataset_processing_tools, so these follow that precedent
+- repo: neilsonnn/image-blaster
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: neo4j-labs/llm-graph-builder
+  verdict: excluded_boundary
+  boundary: rag-frameworks-and-vector-search
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: RAG frameworks and search or vector engines. Vector databases belong to storage, where Qdrant,
+    Milvus and Pinecone were moved on 2026-08-18
+- repo: neomjs/neo
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: a JavaScript application framework, not an AI agent framework
+- repo: netease-youdao/LobsterAI
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: a desktop agent that executes work, not a chat UI
+- repo: neuml/txtai
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: nevamind-ai/memu
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: nextlevelbuilder/ui-ux-pro-max-skill
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: 'an authored agent skill, which is content rather than software; the boundary #413 parked pending
+    an ontology decision'
+- repo: ngxson/smolvlm-realtime-webcam
+  verdict: excluded_boundary
+  boundary: gui-and-device-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: device and GUI automation agents rather than agent-facing tool services
+- repo: nicobailon/visual-explainer
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: ningzimu/codex-ppt-skill
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: nrwl/nx
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: a monorepo build platform that added agent features; not an AI stack product
+- repo: ntegrals/openbrowser
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: numman-ali/openskills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: nyldn/claude-octopus
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: runs several models against one task; orchestration, not a tool
+- repo: obra/superpowers
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: an agent skills framework and methodology; authored content
+- repo: omnigent-ai/omnigent
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: op7418/guizang-ppt-skill
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: op7418/guizang-social-card-skill
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: open-mmlab/mmocr
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: openai/plugins
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: openai/skills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: openbb-finance/openbb
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: openbmb/ultrarag
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: openclaw/clawhub
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: openclaw/mcporter
+  verdict: excluded_boundary
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: calls MCP servers from TypeScript; a client-side convenience layer that sits in orchestration_agents,
+    not in the tool and protocol layer
+- repo: openclaw/peekaboo
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: opensensenova/sensenova-skills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: openspg/kag
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: opensquilla/opensquilla
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: paddlepaddle/paddleocr
+  verdict: excluded_boundary
+  boundary: ocr-and-document-image-toolkits
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: OCR and document-image model toolkits. The corpus already places `olmocr`, a toolkit of exactly
+    this shape, in dataset_processing_tools, so these follow that precedent
+- repo: parthjadhav/app-store-screenshots
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: pathwaycom/llm-app
+  verdict: excluded_boundary
+  boundary: rag-frameworks-and-vector-search
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: RAG frameworks and search or vector engines. Vector databases belong to storage, where Qdrant,
+    Milvus and Pinecone were moved on 2026-08-18
+- repo: pennyroyaltea/gibberlink
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: phuryn/pm-skills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: plastic-labs/honcho
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: pleaseprompto/notebooklm-skill
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: primeintellect-ai/prime-agent
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: promptslab/awesome-prompt-engineering
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: quivrhq/quivr
+  verdict: excluded_boundary
+  boundary: rag-frameworks-and-vector-search
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: RAG frameworks and search or vector engines. Vector databases belong to storage, where Qdrant,
+    Milvus and Pinecone were moved on 2026-08-18
+- repo: rapidai/rapidocr
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: rohitg00/agentmemory
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: rowboatlabs/rowboat
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: a desktop agent with memory, not a chat UI
+- repo: rtk-ai/rtk
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: run-llama/rags
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: saladday/cc-switch-cli
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: sawyerhood/dev-browser
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: sciphi-ai/r2r
+  verdict: excluded_boundary
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: between a retrieval service and a RAG framework; RAG frameworks are outside the sweep boundary
+- repo: semantica-agi/semantica
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: simoneavogadro/android-reverse-engineering-skill
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: simonlin1212/a-stock-data
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: siyuan-note/siyuan
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: a knowledge workspace; neither a chat UI nor an API gateway
+- repo: skyhook-io/radar
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: a Kubernetes UI; its MCP server does not make it AI observability
+- repo: stablyai/orca
+  verdict: excluded_boundary
+  boundary: gui-and-device-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: device and GUI automation agents rather than agent-facing tool services
+- repo: startrail-org/leann
+  verdict: excluded_boundary
+  boundary: rag-frameworks-and-vector-search
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: RAG frameworks and search or vector engines. Vector databases belong to storage, where Qdrant,
+    Milvus and Pinecone were moved on 2026-08-18
+- repo: startrail-org/pixelrag
+  verdict: excluded_boundary
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: pixel-native search index; same storage boundary as PageIndex
+- repo: steipete/agent-scripts
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: supermemoryai/supermemory
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: tencentcloud/tencentdb-agent-memory
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: The-PR-Agent/pr-agent
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: a pull-request reviewer; a domain application of coding agents
+- repo: timescale/pgai
+  verdict: excluded_boundary
+  boundary: rag-frameworks-and-vector-search
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: RAG frameworks and search or vector engines. Vector databases belong to storage, where Qdrant,
+    Milvus and Pinecone were moved on 2026-08-18
+- repo: tracer-cloud/opensre
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: tradesdontlie/tradingview-mcp
+  verdict: excluded_boundary
+  boundary: gui-and-device-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: device and GUI automation agents rather than agent-facing tool services
+- repo: ultraworkers/claw-code
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: unicity-aos/capsule-memory
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: unicity-sphere/sphere-sdk
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: unicitynetwork/whitepaper
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: usestrix/strix
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: an application penetration-testing tool; a domain application
+- repo: vectifyai/pageindex
+  verdict: excluded_boundary
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: a document index; sits on the storage boundary, where the vector databases went on 2026-08-18
+- repo: vectorize-io/hindsight
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: vercel-labs/agent-browser
+  verdict: excluded_boundary
+  boundary: generic-browser-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: generic browser automation and scraping, excluded by the sweep boundary unless the product is
+    packaged specifically as an agent tool, which is why Steel Browser and Lightpanda were accepted and
+    these were not
+- repo: vercel-labs/open-agents
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: vercel-labs/skills
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: vercel/eve
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: vincentwei1021/video-shotcraft
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: virgiliojr94/book-to-skill
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: vitali87/code-graph-rag
+  verdict: excluded_boundary
+  boundary: agent-memory-and-context-stores
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: agent memory is a coherent cluster with no home category. Placing it here would stretch agent_tools_protocols
+    into storage; it wants a category-proposal issue of its own
+- repo: volcengine/minecontext
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
+    this category
+- repo: volcengine/openviking
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: wanshuiyin/auto-claude-code-research-in-sleep
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: wavetermdev/waveterm
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: withastro/flue
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: withcoral/coral
+  verdict: excluded_boundary
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: one SQL interface over APIs, files and live sources; sits on the storage boundary
+- repo: worldwonderer/oh-story-claudecode
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: x-plug/mobileagent
+  verdict: excluded_boundary
+  boundary: gui-and-device-automation
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: device and GUI automation agents rather than agent-facing tool services
+- repo: xbuilderlab/cheat-on-content
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: yc-software/qm
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: yeachan-heo/oh-my-codex
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: YishenTu/claudian
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: an Obsidian plugin embedding a coding agent
+- repo: yizhiyanhua-ai/fireworks-tech-graph
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: yusufkaraaslan/skill_seekers
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: zai-org/open-autoglm
+  verdict: excluded_boundary
+  boundary: general-agent-frameworks
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: zhaoxuya520/reverse-skill
+  verdict: excluded_boundary
+  boundary: agent-skill-and-plugin-content
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
+    No category in the taxonomy holds authored agent content
+- repo: zhishile/codex-auth-helper
+  verdict: excluded_boundary
+  boundary: coding-agent-developer-tooling
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: tooling aimed at coding agents and developer workflow rather than at the agent tool and protocol
+    layer
+- repo: zilliztech/gptcache
+  verdict: excluded_boundary
+  boundary: rag-frameworks-and-vector-search
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: RAG frameworks and search or vector engines. Vector databases belong to storage, where Qdrant,
+    Milvus and Pinecone were moved on 2026-08-18
+- repo: zipstack/unstract
+  verdict: excluded_boundary
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: packaged as an API deployment and ETL pipeline rather than as a tool an agent calls
+- repo: zly2006/zhihu-plus-plus
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: a third-party Android client for one website
+- repo: airweave-ai/airweave
+  verdict: excluded_maintenance
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: archived, last push 2026-06-05
+- repo: browsermcp/mcp
+  verdict: excluded_maintenance
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: last push 2025-04-24, sixteen months before the sweep
+- repo: lauriewired/ghidramcp
+  verdict: excluded_maintenance
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: last push 2025-06-23, fourteen months before the sweep
+- repo: lharries/whatsapp-mcp
+  verdict: excluded_maintenance
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: last push 2025-07-13, thirteen months before the sweep
+- repo: quivrhq/megaparse
+  verdict: excluded_maintenance
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: last push 2025-02-21, eighteen months before the sweep
+- repo: transitive-bullshit/agentic
+  verdict: excluded_maintenance
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: archived, last push 2026-02-11
+- repo: a2aproject/a2a
+  verdict: existing_product
+  product: agent2agent-protocol
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: repository of head product `agent2agent-protocol`, which declares no github artifact. Canonical
+    casing is `a2aproject/A2A`
+- repo: modelcontextprotocol/modelcontextprotocol
+  verdict: existing_product
+  product: model-context-protocol
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: spec repository of head product `model-context-protocol`, which declares no github artifact, so
+    repo-level dedup misses it
+- repo: apify/apify-mcp-server
+  verdict: sku_of
+  product: apify
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: 'the MCP surface of the head product apify, the shape #413 called a SKU'
+- repo: exa-labs/exa-mcp-server
+  verdict: sku_of
+  product: exa-search-api
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: MCP surface of head product `exa-search-api`; a SKU, not a product
+- repo: firecrawl/firecrawl-mcp-server
+  verdict: sku_of
+  product: firecrawl
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: MCP surface of head product `firecrawl`; a SKU, not a product
+- repo: 567-labs/instructor
+  verdict: unresolved
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: structured output parsing for LLM calls; a library, not an agent that plans or executes
+- repo: ag-ui-protocol/ag-ui
+  verdict: unresolved
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: an agent-user interaction PROTOCOL; belongs with agent_tools_protocols, not with frameworks
+- repo: ByteDance-Seed/VeOmni
+  verdict: unresolved
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: a distributed training framework; ml_frameworks or finetuning_code, not settled
+- repo: diegosouzapw/OmniRoute
+  verdict: unresolved
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: an API gateway across 350 providers, which is ui_api's definition, not observability
+- repo: dottxt-ai/outlines
+  verdict: unresolved
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: structured generation; same shape as instructor
+- repo: kubeflow/trainer
+  verdict: unresolved
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: Kubeflow distributed training; sits between deployment and finetuning_code
+- repo: modelcontextprotocol/go-sdk
+  verdict: unresolved
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: the repository sits under the `modelcontextprotocol` org, and this corpus's own score record for
+    `model-context-protocol` puts governance with the Linux Foundation's AAIF. The three existing MCP
+    SDK products (`mcp-python-sdk`, `mcp-typescript-sdk`, `mcp-inspector`) are filed under `anthropic`,
+    precedent that predates the donation. Filing this row under `anthropic` extends stale precedent; filing
+    it under a new slug splits the SDK family across two orgs. Parked for a resolution that covers all
+    four records at once, not just this one
+- repo: modelcontextprotocol/java-sdk
+  verdict: unresolved
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: the MCP Java SDK, but `java-sdk` is not a product identity; needs the naming call the Go SDK is
+    already parked on
+- repo: mvanhorn/cli-printing-press
+  verdict: unresolved
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: the README does not establish what the product is
+- repo: open-metadata/OpenMetadata
+  verdict: unresolved
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: a data metadata platform; storage on this map means vector and retrieval stores
+- repo: opendatalab/pdf-extract-kit
+  verdict: unresolved
+  decided_in: '#413'
+  decided_on: '2026-08-30'
+  note: same org as the accepted `mineru` and functionally upstream of it. Whether these are one product
+    or two is an entity-resolution call, and the workflow says park an unresolved identity rather than
+    guess
+- repo: oraios/serena
+  verdict: unresolved
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: an MCP toolkit for semantic code retrieval; a tool, not an agent framework
+- repo: SemiAnalysisAI/InferenceX
+  verdict: unresolved
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: a continuous inference benchmark platform; closer to benchmark_eval_data
+- repo: yamadashy/repomix
+  verdict: unresolved
+  decided_in: '#418 review'
+  decided_on: '2026-08-31'
+  note: packs a repository into one AI-readable file; document ingestion rather than orchestration

--- a/tests/test_details_payload_size.py
+++ b/tests/test_details_payload_size.py
@@ -41,18 +41,19 @@ PAYLOAD = Path(__file__).resolve().parents[1] / "build" / "notebook_data.json"
 
 
 def _details_attribute() -> str:
-    """Rebuild exactly what build/render.py puts in the iframe's onload attribute."""
+    """Exactly what build/render.py puts in the iframe's onload attribute.
+
+    Built by importing the real payload builder. This function used to rebuild the payload
+    with its own `{**product}` expansion, which meant it measured a payload the notebook
+    never shipped: a trim in render.py changed nothing here, and this test would have gone
+    on passing or failing for reasons unrelated to what marimo actually receives.
+    """
+    from build.details_payload import details_records
+
     data = json.loads(PAYLOAD.read_text(encoding="utf-8"))
     order = data["order"] if isinstance(data.get("order"), list) else list(data["categories"])
-    payload = {}
-    for cid in order:
-        for product in data["categories"][cid]["products"]:
-            payload[product["product"]] = {
-                **product,
-                "category_label": data["categories"][cid]["label"],
-            }
     encoded = base64.b64encode(
-        json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        json.dumps(details_records(data, order), ensure_ascii=False).encode("utf-8")
     ).decode("ascii")
     # The attribute escaping render.py applies. A no-op on base64, deliberately.
     return encoded.replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;")
@@ -87,3 +88,49 @@ def test_the_payload_is_ascii_so_one_emoji_cannot_widen_it():
         "the payload is stored at more than 1 byte per character, which means a "
         "wide character crept in and doubled what marimo measures."
     )
+
+
+def test_the_payload_carries_only_what_the_modal_renders():
+    """The trim, asserted by key rather than by size.
+
+    A size assertion alone cannot tell a payload that is small because it is correct from one
+    that is small because the corpus shrank. These name the fields the modal never reads, so
+    re-adding one fails here rather than silently eating the headroom the cap leaves.
+    """
+    from build.details_payload import details_records
+
+    data = json.loads(PAYLOAD.read_text(encoding="utf-8"))
+    order = data["order"] if isinstance(data.get("order"), list) else list(data["categories"])
+    records = details_records(data, order)
+    assert records
+
+    for record in records.values():
+        assert not {"freshness", "slug", "org_slug", "tier", "maturity", "mature",
+                    "overall_score"} & set(record)
+        for axis in ("openness", "adoption", "capability"):
+            block = record.get(axis)
+            if not isinstance(block, dict):
+                continue
+            assert not {"bucket", "governing_release", "last_verified"} & set(block)
+            for source in block.get("sources") or []:
+                assert not {"content_sha256", "accessed", "http_status",
+                            "establishes"} & set(source)
+
+
+def test_the_trim_leaves_the_fields_the_modal_does_render():
+    """The other direction: a trim that dropped `note` or `sources` would shrink the payload
+    and gut the modal, and the size test would applaud."""
+    from build.details_payload import details_records
+
+    data = json.loads(PAYLOAD.read_text(encoding="utf-8"))
+    order = data["order"] if isinstance(data.get("order"), list) else list(data["categories"])
+    records = details_records(data, order)
+
+    with_sources = 0
+    for record in records.values():
+        assert record.get("description")
+        assert "category_label" in record
+        openness = record.get("openness") or {}
+        assert "score" in openness and "note" in openness
+        with_sources += bool(openness.get("sources"))
+    assert with_sources > len(records) * 0.9

--- a/tests/test_resolution_ledger.py
+++ b/tests/test_resolution_ledger.py
@@ -10,7 +10,15 @@ from pathlib import Path
 import pytest
 import yaml
 
-from build.resolution import LEDGER, NOT_A_NEW_PRODUCT, VERDICTS, blocks_new_product, load
+from build.resolution import (
+    LEDGER,
+    NOT_A_NEW_PRODUCT,
+    VERDICTS,
+    DuplicateResolution,
+    blocks_new_product,
+    holds_bulk_promotion,
+    load,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -58,6 +66,53 @@ def test_the_four_cases_that_produced_this_file(repo, verdict, target):
     assert entry["verdict"] == verdict
     if target:
         assert entry["product"] == target
+
+
+def test_a_repository_may_be_resolved_only_once(tmp_path):
+    """Governance state has no benign duplicate.
+
+    `load` used to be a dict comprehension, so two entries for one repository resolved
+    last-write-wins and the stronger decision vanished silently. The file is hand-edited by
+    people appending after each review, which is precisely how a second entry appears - and
+    docs/reference/identity.md records the same failure in the deleted slug-alias mapping.
+    """
+    ledger = tmp_path / "resolution_ledger.yaml"
+    ledger.write_text(
+        "version: 1\nresolutions:\n"
+        "- repo: Foo/Bar\n  verdict: existing_product\n  product: x\n"
+        "  decided_in: '#1'\n  note: the first decision, which must not be lost\n"
+        "- repo: foo/bar.git\n  verdict: unresolved\n"
+        "  decided_in: '#2'\n  note: a later entry for the same repository, differently cased\n"
+    )
+    with pytest.raises(DuplicateResolution) as raised:
+        load(ledger)
+    assert "Foo/Bar" in str(raised.value) or "foo/bar" in str(raised.value)
+
+
+def test_the_real_ledger_has_no_duplicate_identity():
+    """Asserted against the file itself, so appending a second entry fails here."""
+    assert load()
+
+
+def test_unresolved_holds_a_bulk_promotion_even_though_it_does_not_block_forever():
+    """The distinction that #420 got wrong.
+
+    `unresolved` means "this may come back to a later sweep", not "this proposal may publish".
+    The #418 review recorded ag-ui as a protocol filed under agent frameworks, serena as an MCP
+    retrieval toolkit and repomix as document ingestion - and the same run then published all
+    three in orchestration_agents, the category the entries say is wrong. A bulk run must park
+    them; a person may still resolve and add them by hand, which is why validate does not fail.
+    """
+    for repo in ("ag-ui-protocol/ag-ui", "oraios/serena", "yamadashy/repomix"):
+        assert blocks_new_product(repo) is None, f"{repo}: must not be a hard build error"
+        held = holds_bulk_promotion(repo)
+        assert held is not None, f"{repo}: a bulk run must park it"
+        assert held["verdict"] == "unresolved"
+
+
+def test_a_repo_with_no_entry_is_eligible():
+    """The other side of the hold: silence in the ledger is permission."""
+    assert holds_bulk_promotion("vllm-project/vllm") is None
 
 
 def test_unresolved_does_not_block():

--- a/tests/test_resolution_ledger.py
+++ b/tests/test_resolution_ledger.py
@@ -1,0 +1,98 @@
+"""The resolution ledger: decisions a person made, made readable by the next bulk run.
+
+The failure this file guards is not a bug in any one module. It is that the corpus recorded
+its identity and boundary decisions in pull request prose, where nothing could read them, and
+the first bulk expansion duly recreated twelve repositories that #413 had already resolved -
+one of them a product the corpus already carries under another name.
+"""
+from pathlib import Path
+
+import pytest
+import yaml
+
+from build.resolution import LEDGER, NOT_A_NEW_PRODUCT, VERDICTS, blocks_new_product, load
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_the_ledger_parses_and_every_verdict_is_known():
+    entries = load()
+    assert entries
+    for repo, entry in entries.items():
+        assert entry["verdict"] in VERDICTS, f"{repo}: unknown verdict {entry['verdict']!r}"
+        assert repo == repo.lower(), "keys are lowercased for identity comparison"
+        assert len(entry.get("note") or "") > 20, f"{repo}: a decision needs its reasoning"
+        assert entry.get("decided_in"), f"{repo}: a decision needs a provenance"
+
+
+def test_a_resolved_repo_names_what_it_resolved_to():
+    """`existing_product` and `sku_of` point at a product; `excluded_boundary` names a boundary.
+    Without that an entry blocks a candidate while saying nothing about why."""
+    for repo, entry in load().items():
+        if entry["verdict"] in ("existing_product", "sku_of"):
+            assert entry.get("product"), f"{repo}: {entry['verdict']} must name a product"
+        if entry["verdict"] == "excluded_boundary":
+            assert entry.get("boundary") or entry.get("note")
+
+
+def test_named_products_exist_in_the_corpus():
+    """A ledger pointing at a slug the corpus dropped is stale, and would block a candidate
+    on the authority of a product that is no longer there."""
+    slugs = {p.stem for p in (ROOT / "sources" / "products").glob("*.yaml")}
+    missing = {repo: e["product"] for repo, e in load().items()
+               if e.get("product") and e["product"] not in slugs}
+    assert not missing, f"ledger points at products that do not exist: {missing}"
+
+
+@pytest.mark.parametrize("repo,verdict,target", [
+    ("a2aproject/A2A", "existing_product", "agent2agent-protocol"),
+    ("firecrawl/firecrawl-mcp-server", "sku_of", "firecrawl"),
+    ("anthropics/knowledge-work-plugins", "excluded_boundary", None),
+    ("promptslab/Awesome-Prompt-Engineering", "excluded_boundary", None),
+])
+def test_the_four_cases_that_produced_this_file(repo, verdict, target):
+    """Named individually because each was recreated as a product by a bulk run that could
+    not see the decision. A regression here is the whole failure coming back."""
+    entry = blocks_new_product(repo)
+    assert entry is not None, f"{repo} must be blocked from becoming a new product"
+    assert entry["verdict"] == verdict
+    if target:
+        assert entry["product"] == target
+
+
+def test_unresolved_does_not_block():
+    """`unresolved` means a person still has to look. A rerun proposing the repository again
+    is the intended behaviour, so it must not be enforced like a decision."""
+    assert "unresolved" not in NOT_A_NEW_PRODUCT
+    unresolved = [r for r, e in load().items() if e["verdict"] == "unresolved"]
+    for repo in unresolved:
+        assert blocks_new_product(repo) is None
+
+
+def test_no_product_declares_a_repo_the_ledger_resolves_elsewhere():
+    """The corpus-wide invariant build/validate.py enforces, asserted here too so the failure
+    names the products rather than only the count."""
+    ledger = load()
+    offences = []
+    for path in sorted((ROOT / "sources" / "products").glob("*.yaml")):
+        product = yaml.safe_load(path.read_text()) or {}
+        for artifact in (product.get("github") or []):
+            url = (artifact.get("url") or "").rstrip("/")
+            if "github.com/" not in url:
+                continue
+            repo = url.split("github.com/")[-1].removesuffix(".git").lower()
+            entry = ledger.get(repo)
+            if (entry and entry["verdict"] in NOT_A_NEW_PRODUCT
+                    and entry.get("product") != path.stem):
+                offences.append(f"{path.stem} declares {repo} ({entry['verdict']})")
+    assert not offences, offences
+
+
+def test_the_ledger_is_hand_maintainable():
+    """It is a source file a person edits, so it stays legible: one flat list, no nesting."""
+    doc = yaml.safe_load(LEDGER.read_text())
+    assert doc["version"] == 1
+    assert isinstance(doc["resolutions"], list)
+    assert all(isinstance(e, dict) and set(e) <= {
+        "repo", "verdict", "product", "boundary", "decided_in", "decided_on", "note"}
+        for e in doc["resolutions"])


### PR DESCRIPTION
A decision a person made, recorded where the next bulk run can read it.

## What went wrong

#413 resolved a set of candidate repositories by hand: this one is the spec repo of a product we already carry, that one is a vendor's MCP surface rather than a product, these are authored content pending an ontology decision. The reasoning went into the pull request. The corpus kept the *outcome* nowhere a machine could see it.

The first corpus expansion then re-derived the same candidates from the same pool, found no artifact that matched, and recreated twelve of them — including `a2aproject/A2A` as a new product called `a2a`, though the corpus already carries that protocol as `agent2agent-protocol`.

**The A2A case is self-inflicted twice over.** `agent2agent-protocol` declares no `github` artifact *precisely because* #415 left it undeclared as a Group C case, pending a ruling on adoption routing. Repo-level dedup could not see it. Neither could anything else.

## What this adds

**`sources/resolution_ledger.yaml`** — 272 entries, five verdicts:

| verdict | meaning |
|---|---|
| `existing_product` | the repository belongs to a product already in the corpus |
| `sku_of` | a surface or edition of a product, not a product of its own |
| `excluded_boundary` | out of scope, with the boundary named |
| `excluded_maintenance` | archived, or unmaintained past the sweep's declared window |
| `unresolved` | identity genuinely undecided; needs a person, not a rerun |

Each entry carries its reasoning and a `decided_in` provenance. **`unresolved` deliberately does not block** — it means somebody still has to look, so a later run proposing the repository again is the intended behaviour rather than a regression, and enforcing it would erase the distinction between "we decided" and "we have not decided".

**`build/resolution.py`** reads it. **`build/validate.py`** fails any product declaring a repository the ledger resolves elsewhere. A bulk pipeline consults `blocks_new_product` before proposing anything.

## Provenance of the entries

- **234 seeded from #413** — its four hand-resolved product duplicates, its seventeen individually-named parks, and its cluster boundary decisions, each carrying the reason that review recorded.
- **38 added from the #418 review** — assignments that a hand review of the first expansion found wrong. Nine of those went in as `unresolved` rather than excluded: `ag-ui` is an agent-user interaction *protocol*, `serena` an MCP retrieval toolkit, `omniroute` an API gateway. They are probably real products in a *different* category, and recording them as excluded would be the same overreach in the other direction.

## Evidence that it encodes real decisions

The gate fires on **exactly the twelve** products the expansion resurrected, and on **zero** products in the corpus as it stands. A ledger that failed the existing corpus would be encoding this batch's mistakes rather than the corpus's decisions.

Four of the twelve were found by review; the other eight — `agentteams`, `orca`, `rtk`, `coral`, `omnigent`, `hyperframes`, `genericagent`, `cc-switch-cli` — only became visible once the decisions were machine-readable. That gap is the argument for the file.

## Tests

Ten, including the four cases named individually so a regression is the whole failure returning; that `unresolved` does not block; that an entry naming a product names one the corpus still has, so a stale ledger cannot block a candidate on the authority of a product that was dropped; and the corpus-wide invariant asserted by product name rather than by count.
