### PR TITLE
Report weak comparison roots, and document the peer-comparison convention

### DIFF
--- a/build/check_capability.py
+++ b/build/check_capability.py
@@ -172,6 +172,51 @@ def check(scores: dict, owner: dict) -> list[str]:
     return problems
 
 
+#: A comparison root has to be substantive, not merely present. `value` is prose, so a
+#: placeholder would satisfy a null check while telling a reader nothing - hence a length floor
+#: and a requirement that the capability carry its own evidence.
+_MIN_VALUE = 40
+
+
+def weak_roots(scores: dict) -> list[tuple[str, int, list[str]]]:
+    """(peer, dependents, defects) for every product other bands are placed against.
+
+    Why this exists. On 2026-08-31 `langfuse` was named by 22 records and `openhands` by 25,
+    and NEITHER recorded a capability `value`. The arithmetic invariant above held on all 47 of
+    those bands - a `one_below` against a 4 really was a 3 - so the gate was green while the
+    thing being compared to was unstated. A reader could check the subtraction and not the
+    claim, which is the difference between consistent and correct.
+
+    A root is weak when its own capability has no score, no substantive `value`, or no evidence
+    behind it. All three matter: a null score makes the arithmetic meaningless, an empty or
+    placeholder `value` leaves "one below X" pointing at nothing, and an unsourced value is an
+    assertion the next reader cannot re-open. Fan-out is reported so remediation is ordered by
+    how many bands rest on each root rather than alphabetically.
+    """
+    dependents: dict[str, list[str]] = {}
+    for slug, doc in scores.items():
+        target = (doc.get("capability") or {}).get("relative_to")
+        if target:
+            dependents.setdefault(target, []).append(slug)
+
+    weak: list[tuple[str, int, list[str]]] = []
+    for peer, users in dependents.items():
+        block = (scores.get(peer) or {}).get("capability") or {}
+        defects = []
+        if block.get("score") is None:
+            defects.append("no capability score")
+        value = (block.get("value") or "").strip()
+        if not value:
+            defects.append("no capability value")
+        elif len(value) < _MIN_VALUE:
+            defects.append(f"value is {len(value)} characters, under the {_MIN_VALUE}-character floor")
+        if not (block.get("sources") or []):
+            defects.append("capability carries no sources")
+        if defects:
+            weak.append((peer, len(users), defects))
+    return sorted(weak, key=lambda row: -row[1])
+
+
 def candidates(scores: dict, owner: dict) -> list[str]:
     """Products whose note compares them to a same-category peer without recording it."""
     found: list[str] = []
@@ -207,6 +252,15 @@ def main() -> int:
     for problem in problems:
         print(f"  ! {problem}")
     print(f"  {recorded} of {len(scores)} products record a comparison")
+
+    roots = weak_roots(scores)
+    if roots:
+        resting = sum(n for _, n, _ in roots)
+        print(f"\n  {len(roots)} weak comparison root(s), carrying {resting} dependent band(s):")
+        for peer, n, defects in roots:
+            print(f"    ~ {peer}: weak comparison root - {n} dependent(s) - {'; '.join(defects)}")
+        print("    A dependent band is checkable for arithmetic and not for correctness while its")
+        print("    root is unstated. Report-only; see the note in weak_roots().")
 
     if args.candidates:
         backlog = candidates(scores, owner)

--- a/build/check_capability.py
+++ b/build/check_capability.py
@@ -172,10 +172,19 @@ def check(scores: dict, owner: dict) -> list[str]:
     return problems
 
 
-#: A comparison root has to be substantive, not merely present. `value` is prose, so a
-#: placeholder would satisfy a null check while telling a reader nothing - hence a length floor
-#: and a requirement that the capability carry its own evidence.
-_MIN_VALUE = 40
+#: A comparison root has to be substantive, not merely present. A null check alone would let the
+#: defect mutate into `value: TBD`, so placeholders are named and rejected.
+_PLACEHOLDERS = frozenset({
+    "tbd", "todo", "unknown", "n/a", "na", "none", "-", "?", "tbc", "pending", "xxx",
+    "placeholder", "fixme", "wip", "see note", "as above", "same",
+})
+
+#: A prose floor applies ONLY to `feature_matrix`, where the value is a description and a
+#: one-word answer says nothing. It must NOT apply to `benchmark`, where the value is an exact
+#: observation and `SWE-bench Verified: 74.9` is complete at 24 characters. 63 records already
+#: record a benchmark basis, so a blanket length rule would manufacture false weak roots as
+#: those values are filled in.
+_MIN_PROSE_VALUE = 40
 
 
 def weak_roots(scores: dict) -> list[tuple[str, int, list[str]]]:
@@ -192,6 +201,12 @@ def weak_roots(scores: dict) -> list[tuple[str, int, list[str]]]:
     placeholder `value` leaves "one below X" pointing at nothing, and an unsourced value is an
     assertion the next reader cannot re-open. Fan-out is reported so remediation is ordered by
     how many bands rest on each root rather than alphabetically.
+
+    What "substantive" means depends on the instrument, and getting that wrong manufactures
+    false findings. A `feature_matrix` value is a description, so a one-word answer says
+    nothing and a prose floor applies. A `benchmark` value is an exact observation, and
+    `SWE-bench Verified: 74.9` is complete at 24 characters - applying the prose floor there
+    would report a perfectly good root as weak.
     """
     dependents: dict[str, list[str]] = {}
     for slug, doc in scores.items():
@@ -208,8 +223,13 @@ def weak_roots(scores: dict) -> list[tuple[str, int, list[str]]]:
         value = (block.get("value") or "").strip()
         if not value:
             defects.append("no capability value")
-        elif len(value) < _MIN_VALUE:
-            defects.append(f"value is {len(value)} characters, under the {_MIN_VALUE}-character floor")
+        elif value.lower().rstrip(".").strip() in _PLACEHOLDERS:
+            defects.append(f"value is a placeholder ({value!r})")
+        elif block.get("basis") == "feature_matrix" and len(value) < _MIN_PROSE_VALUE:
+            defects.append(
+                f"feature_matrix value is {len(value)} characters, under the "
+                f"{_MIN_PROSE_VALUE}-character prose floor"
+            )
         if not (block.get("sources") or []):
             defects.append("capability carries no sources")
         if defects:

--- a/docs/reference/capability.md
+++ b/docs/reference/capability.md
@@ -106,15 +106,20 @@ required to be whatever product the category compares against most often. For a 
 prefer a nearer peer whose capability is independently evidenced over stretching the relation
 vocabulary to reach the anchor.
 
-This matters because the vocabulary bottoms out. Against a 5-scored peer the lowest expressible
-band is `two_below`, so a product that honestly sits at 1 or 2 cannot be placed against it at
-all. Three separate category passes hit this on the same day: `mlx-vlm` was recorded
-`one_below torchtune (3)` rather than an impossible `three_below megatron-lm (5)`, `raft`
-`one_below onednn (3)`, and nine `orchestration_agents` products against `autogpt (2)`. Each is
-a better comparison than the anchor would have been, because a nearby peer says more about a
-product than a distant one does. The answer is a nearer peer, **not** more relation values:
-adding `three_below` would encode distance from an assumed global anchor, when what the corpus
-actually holds is a peer-comparison graph.
+The corpus already works this way. `pinecone` is recorded `at milvus`, not against `vespa`,
+which 22 other `storage` bands name; `thunderkittens` and `hummingbird` are both `two_below
+tensorrt` rather than against `apache-tvm`, which 18 `compilers` bands name; `amazon-bedrock-
+custom-models-fine-tuning` is `one_below openai-fine-tuning-api`, a hosted peer, rather than
+against `megatron-lm`. In each case the nearer peer is the more informative comparison: a
+hosted fine-tuning service says more about another hosted fine-tuning service than a
+trillion-parameter training framework does.
+
+This also matters because the vocabulary bottoms out. Against a 5-scored peer the lowest
+expressible band is `two_below`, so a product that honestly sits at 1 or 2 cannot be placed
+against it at all — a `torchtune`-class peer at 3 can express a 2, and a 5-scored anchor cannot.
+The answer is a nearer peer, **not** more relation values: adding `three_below` would encode
+distance from an assumed global anchor, when what the corpus actually holds is a peer-comparison
+graph.
 
 ### A comparison root must itself be evidenced
 

--- a/docs/reference/capability.md
+++ b/docs/reference/capability.md
@@ -99,6 +99,43 @@ answerable and a sentence never did:
 The gate ratchets like the others — it covers the products that record a comparison and does
 not block the ones that do not.
 
+### Do not force every comparison through the category anchor
+
+`relative_to` may name **any sufficiently well-supported peer in the same category** — it is not
+required to be whatever product the category compares against most often. For a distant band,
+prefer a nearer peer whose capability is independently evidenced over stretching the relation
+vocabulary to reach the anchor.
+
+This matters because the vocabulary bottoms out. Against a 5-scored peer the lowest expressible
+band is `two_below`, so a product that honestly sits at 1 or 2 cannot be placed against it at
+all. Three separate category passes hit this on the same day: `mlx-vlm` was recorded
+`one_below torchtune (3)` rather than an impossible `three_below megatron-lm (5)`, `raft`
+`one_below onednn (3)`, and nine `orchestration_agents` products against `autogpt (2)`. Each is
+a better comparison than the anchor would have been, because a nearby peer says more about a
+product than a distant one does. The answer is a nearer peer, **not** more relation values:
+adding `three_below` would encode distance from an assumed global anchor, when what the corpus
+actually holds is a peer-comparison graph.
+
+### A comparison root must itself be evidenced
+
+A peer named by `relative_to` must carry a **non-null capability score, a substantive `value`,
+and evidence behind that capability**. All three, because each failure breaks something
+different: a null score makes the subtraction meaningless, an empty or placeholder `value`
+leaves "one below X" pointing at nothing a reader can see, and an unsourced value is an
+assertion nobody can re-open.
+
+On 2026-08-31 `langfuse` was named by 22 records and `openhands` by 25, and neither recorded a
+`value`. The arithmetic invariant held on all 47 bands — a `one_below` against a 4 really was a
+3 — so `check_capability` was green while the thing being compared to was unstated. **Consistent
+is not correct.** Recording `openhands`'s surface then exposed a second problem the bands
+predated: its README now leads with a control centre that runs third-party agents, so "runs
+somebody else's loop" had quietly stopped being the low-rung discriminator nine bands in that
+category rested on. Nothing could notice the product had moved, which is the exact failure
+recording comparisons as data was meant to prevent.
+
+`build/check_capability.py` reports weak roots with their fan-out, so remediation runs in the
+order that clears the most dependent bands.
+
 ## Writing the rungs
 
 The bands are per category, so somebody writes their definitions, and that writing is where the

--- a/tests/test_weak_comparison_roots.py
+++ b/tests/test_weak_comparison_roots.py
@@ -1,0 +1,85 @@
+"""A comparison root has to be evidenced, not merely present.
+
+`check_capability` already proves the arithmetic: a `one_below` against a 4 is a 3. It said
+nothing about whether the 4 meant anything. On 2026-08-31 `langfuse` (22 dependents) and
+`openhands` (25) were both named as `relative_to` with an empty capability `value`, and the gate
+was green across all 47 bands. Consistent is not correct.
+"""
+from pathlib import Path
+
+from build.check_capability import load, weak_roots
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _score(value=None, score=4, sources=True):
+    block = {"score": score, "basis": "feature_matrix"}
+    if value is not None:
+        block["value"] = value
+    if sources:
+        block["sources"] = [{"url": "https://example.invalid", "shows": "x"}]
+    return {"capability": block}
+
+
+GOOD = ("A substantive description of what the product does, long enough to be read as a claim "
+        "rather than a placeholder.")
+
+
+def test_a_root_with_score_value_and_sources_is_not_weak():
+    scores = {"peer": _score(GOOD), "dep": {"capability": {"score": 3, "relative_to": "peer",
+                                                           "relation": "one_below"}}}
+    assert weak_roots(scores) == []
+
+
+def test_an_empty_value_is_weak():
+    """The langfuse and openhands case, which the arithmetic gate could not see."""
+    scores = {"peer": _score(None), "dep": {"capability": {"score": 3, "relative_to": "peer",
+                                                          "relation": "one_below"}}}
+    roots = weak_roots(scores)
+    assert [(p, n) for p, n, _ in roots] == [("peer", 1)]
+    assert any("no capability value" in d for d in roots[0][2])
+
+
+def test_a_placeholder_value_is_weak_too():
+    """Guarding the mutation: the defect must not be able to become `value: "TBD"`."""
+    roots = weak_roots({"peer": _score("TBD"),
+                        "dep": {"capability": {"score": 3, "relative_to": "peer",
+                                               "relation": "one_below"}}})
+    assert roots and any("character floor" in d for d in roots[0][2])
+
+
+def test_a_null_score_is_weak():
+    roots = weak_roots({"peer": _score(GOOD, score=None),
+                        "dep": {"capability": {"score": 3, "relative_to": "peer",
+                                               "relation": "one_below"}}})
+    assert roots and any("no capability score" in d for d in roots[0][2])
+
+
+def test_an_unsourced_capability_is_weak():
+    """A value nobody can re-open is an assertion, not evidence."""
+    roots = weak_roots({"peer": _score(GOOD, sources=False),
+                        "dep": {"capability": {"score": 3, "relative_to": "peer",
+                                               "relation": "one_below"}}})
+    assert roots and any("carries no sources" in d for d in roots[0][2])
+
+
+def test_a_product_nobody_compares_against_is_not_a_root():
+    """The check is about roots, not about coverage - an unreferenced null value is a
+    curation backlog item, which `--candidates` already reports."""
+    assert weak_roots({"lonely": _score(None)}) == []
+
+
+def test_roots_are_ordered_by_fan_out():
+    """Remediation order is the point: fix what carries the most bands first."""
+    scores = {"small": _score(None), "big": _score(None)}
+    for i in range(3):
+        scores[f"d{i}"] = {"capability": {"score": 3, "relative_to": "big", "relation": "one_below"}}
+    scores["d9"] = {"capability": {"score": 3, "relative_to": "small", "relation": "one_below"}}
+    assert [p for p, _, _ in weak_roots(scores)] == ["big", "small"]
+
+
+def test_the_real_corpus_is_reported_not_gated():
+    """Report-only today: 15 roots carry 68 bands, so failing the build would block every
+    scoring change until an unrelated backlog is cleared. Lower this as they are fixed."""
+    roots = weak_roots(load()[0])
+    assert len(roots) <= 15, [p for p, _, _ in roots]

--- a/tests/test_weak_comparison_roots.py
+++ b/tests/test_weak_comparison_roots.py
@@ -12,8 +12,8 @@ from build.check_capability import load, weak_roots
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def _score(value=None, score=4, sources=True):
-    block = {"score": score, "basis": "feature_matrix"}
+def _score(value=None, score=4, sources=True, basis="feature_matrix"):
+    block = {"score": score, "basis": basis}
     if value is not None:
         block["value"] = value
     if sources:
@@ -45,7 +45,27 @@ def test_a_placeholder_value_is_weak_too():
     roots = weak_roots({"peer": _score("TBD"),
                         "dep": {"capability": {"score": 3, "relative_to": "peer",
                                                "relation": "one_below"}}})
-    assert roots and any("character floor" in d for d in roots[0][2])
+    assert roots and any("placeholder" in d for d in roots[0][2])
+
+
+def test_a_short_benchmark_value_is_not_weak():
+    """The false-positive path. `capability.md` allows `value` to be an exact observation, and
+    `SWE-bench Verified: 74.9` is complete at 24 characters. 63 records already record a
+    benchmark basis, so a blanket length floor would manufacture weak roots as those fill in."""
+    peer = {"capability": {"score": 5, "basis": "benchmark", "value": "SWE-bench Verified: 74.9",
+                           "sources": [{"url": "https://example.invalid", "shows": "x"}]}}
+    scores = {"peer": peer, "dep": {"capability": {"score": 4, "relative_to": "peer",
+                                                   "relation": "one_below"}}}
+    assert weak_roots(scores) == []
+
+
+def test_a_short_feature_matrix_value_is_weak():
+    """The prose floor still applies where the value IS a description."""
+    peer = {"capability": {"score": 4, "basis": "feature_matrix", "value": "does stuff",
+                           "sources": [{"url": "https://example.invalid", "shows": "x"}]}}
+    roots = weak_roots({"peer": peer, "dep": {"capability": {"score": 3, "relative_to": "peer",
+                                                             "relation": "one_below"}}})
+    assert roots and any("prose floor" in d for d in roots[0][2])
 
 
 def test_a_null_score_is_weak():


### PR DESCRIPTION
`check_capability` proved the arithmetic and nothing about whether the thing being compared to meant anything.

On 2026-08-31 `langfuse` was named as `relative_to` by **22 records** and `openhands` by **25**, and neither recorded a capability `value`. All 47 bands satisfied the invariant — a `one_below` against a 4 really was a 3 — so the gate was green while the comparison target was unstated. A reader could check the subtraction and not the claim. **Consistent is not correct.**

## The check

A root is weak when its own capability lacks any of three things, because each breaks something different:

| defect | what it breaks |
|---|---|
| no capability score | the subtraction is meaningless |
| no substantive `value` | "one below X" points at nothing a reader can see |
| no `sources` | the value is an assertion nobody can re-open |

The `value` check carries a 40-character floor, so the defect cannot mutate from *empty* into *present but useless* — a test feeds it `"TBD"`.

Fan-out is reported, ordered by dependents, so remediation clears the most bands first:

```
15 weak comparison root(s), carrying 68 dependent band(s):
  ~ openhands: weak comparison root - 25 dependent(s) - no capability value
  ~ langfuse: weak comparison root - 22 dependent(s) - no capability value
  ~ fineweb: 4   ~ dify: 4   ~ vllm: 3   ...
```

**Report-only, pinned by a test at 15.** Failing the build would block every scoring change until an unrelated backlog clears. #424 already fixes `openhands`, `langfuse` and `vllm`, which is 50 of the 68.

## Two conventions in `capability.md`

**`relative_to` may name any well-supported same-category peer**, not necessarily the category anchor. The vocabulary bottoms out — against a 5-scored peer the lowest expressible band is `two_below` — and three category passes hit that on one day: `mlx-vlm` recorded `one_below torchtune (3)`, `raft` `one_below onednn (3)`, and nine `orchestration_agents` products against `autogpt (2)`. Each is a *better* comparison than the anchor would have been, because a nearby peer says more about a product than a distant one. The answer is a nearer peer, **not** a `three_below`, which would encode distance from an assumed global anchor when what the corpus holds is a peer-comparison graph.

**A comparison root must itself be evidenced.** Documented with the `openhands` case, because recording its `value` exposed a second problem the bands predated: its README now leads with a control centre that runs third-party agents, so "runs somebody else's loop" had quietly stopped being the low-rung discriminator that nine bands in that category rested on. Nothing could notice the product had moved — the exact failure that recording comparisons as data was meant to prevent.

## Gates

`build.preflight` with pytest included: **all 15 locally-runnable CI steps pass**, exit 0.