### PR TITLE
Ledger: the settled deployment boundary decisions

### DIFF
--- a/sources/resolution_ledger.yaml
+++ b/sources/resolution_ledger.yaml
@@ -249,7 +249,7 @@ resolutions:
     this category
 - repo: cloudposse/atmos
   verdict: excluded_boundary
-  boundary: domain-applications
+  boundary: general-purpose-infrastructure
   decided_in: '#428 deployment boundary ruling'
   decided_on: '2026-08-31'
   note: builds, authenticates and ships Terraform, OpenTofu, Kubernetes, Helm and containers from declarative
@@ -304,7 +304,7 @@ resolutions:
   note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
 - repo: dagucloud/dagu
   verdict: excluded_boundary
-  boundary: domain-applications
+  boundary: general-purpose-infrastructure
   decided_in: '#428 deployment boundary ruling'
   decided_on: '2026-08-31'
   note: a single-binary local-first workflow engine running YAML-defined DAGs over shell commands, containers,
@@ -611,7 +611,7 @@ resolutions:
     No category in the taxonomy holds authored agent content
 - repo: hatchet-dev/hatchet
   verdict: excluded_boundary
-  boundary: domain-applications
+  boundary: general-purpose-infrastructure
   decided_in: '#428 deployment boundary ruling'
   decided_on: '2026-08-31'
   note: a Postgres-backed task queue and durable-execution engine. Workers are the caller's own processes,
@@ -792,7 +792,7 @@ resolutions:
     No category in the taxonomy holds authored agent content
 - repo: kestra-io/kestra
   verdict: excluded_boundary
-  boundary: domain-applications
+  boundary: general-purpose-infrastructure
   decided_in: '#428 deployment boundary ruling'
   decided_on: '2026-08-31'
   note: event-driven and scheduled workflow orchestration defined in declarative YAML, with a plugin ecosystem

--- a/sources/resolution_ledger.yaml
+++ b/sources/resolution_ledger.yaml
@@ -247,6 +247,15 @@ resolutions:
   decided_on: '2026-08-30'
   note: domain applications, demos, whitepapers and other repositories outside the stack-map thesis for
     this category
+- repo: cloudposse/atmos
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#428 deployment boundary ruling'
+  decided_on: '2026-08-31'
+  note: builds, authenticates and ships Terraform, OpenTofu, Kubernetes, Helm and containers from declarative
+    stacks. General-purpose infrastructure tooling that happens to be usable for AI work, not an AI stack
+    product, and it scores nothing on the deployment category's discriminators - no isolation boundary,
+    no cold start, no accelerator scheduling, and it hosts neither models nor workloads.
 - repo: cocoindex-io/cocoindex
   verdict: excluded_boundary
   boundary: domain-applications
@@ -293,6 +302,13 @@ resolutions:
   decided_in: '#413'
   decided_on: '2026-08-30'
   note: general agent frameworks, excluded by the sweep boundary and adjacent to orchestration_agents
+- repo: dagucloud/dagu
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#428 deployment boundary ruling'
+  decided_on: '2026-08-31'
+  note: a single-binary local-first workflow engine running YAML-defined DAGs over shell commands, containers,
+    Kubernetes jobs and SSH. Deliberately the opposite of a multi-tenant runtime, and general-purpose.
 - repo: danielmiessler/LifeOS
   verdict: excluded_boundary
   boundary: general-agent-frameworks
@@ -593,6 +609,14 @@ resolutions:
   decided_on: '2026-08-30'
   note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
     No category in the taxonomy holds authored agent content
+- repo: hatchet-dev/hatchet
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#428 deployment boundary ruling'
+  decided_on: '2026-08-31'
+  note: a Postgres-backed task queue and durable-execution engine. Workers are the caller's own processes,
+    so it supplies no execution boundary and no cold-start behaviour of its own; its scheduling is task
+    assignment, not compute placement. General-purpose infrastructure rather than an AI stack product.
 - repo: headroomlabs-ai/headroom
   verdict: excluded_boundary
   boundary: rag-frameworks-and-vector-search
@@ -766,6 +790,13 @@ resolutions:
   decided_on: '2026-08-30'
   note: content libraries (skills, plugins, prompt packs) rather than tools or protocols an agent calls.
     No category in the taxonomy holds authored agent content
+- repo: kestra-io/kestra
+  verdict: excluded_boundary
+  boundary: domain-applications
+  decided_in: '#428 deployment boundary ruling'
+  decided_on: '2026-08-31'
+  note: event-driven and scheduled workflow orchestration defined in declarative YAML, with a plugin ecosystem
+    for running scripts against databases, cloud storage and APIs. A general workflow engine, not AI-specific.
 - repo: kijai/comfyui-wanvideowrapper
   verdict: excluded_boundary
   boundary: gui-and-device-automation
@@ -1825,6 +1856,17 @@ resolutions:
   decided_in: '#418 review'
   decided_on: '2026-08-31'
   note: an MCP toolkit for semantic code retrieval; a tool, not an agent framework
+- repo: rapidsai/raft
+  verdict: unresolved
+  decided_in: '#428 deployment boundary ruling'
+  decided_on: '2026-08-31'
+  note: 'a CUDA header-only primitives library for machine learning and information retrieval - linear
+    algebra, reductions, factorization, solvers, sampling. Held on a literal category-fit question rather
+    than on a band: does it transform model computation toward hardware, which is what the compilers ladder
+    measures, or does it supply primitives to systems that do? The guide puts a kernel library at a ceiling
+    of 3 for exactly that reason, and its ANN work has since moved to cuVS, so the answer may be that
+    compilers is the wrong category rather than that the band is wrong. Moving it re-opens the instrument,
+    not just the score.'
 - repo: SemiAnalysisAI/InferenceX
   verdict: unresolved
   decided_in: '#418 review'


### PR DESCRIPTION
Five decisions that are already settled, recorded before the taxonomy discussion they sit next to, so the discussion does not delay them.

## Four exclusions

Each is general-purpose infrastructure that happens to be usable for AI, not an AI stack product — the test the corpus already applies when it excluded domain apps as off the stack-map thesis. Each also scores nothing on `deployment`'s actual discriminators: no isolation boundary, no cold-start behaviour, no accelerator scheduling, and it hosts neither models nor workloads.

| repo | what it is |
|---|---|
| `cloudposse/atmos` | ships Terraform, OpenTofu, Kubernetes, Helm and containers from declarative stacks |
| `hatchet-dev/hatchet` | a Postgres-backed task queue; workers are the caller's own processes, so its "scheduling" is task assignment, not compute placement |
| `kestra-io/kestra` | general event-driven and scheduled YAML workflow orchestration |
| `dagucloud/dagu` | a single-binary local-first DAG runner, deliberately single-node |

## One hold

**`rapidsai/raft` → `unresolved`**, on a literal category question rather than a band: does it transform model computation toward hardware, which is what the `compilers` ladder measures, or supply primitives to systems that do?

The guide caps a kernel library at 3 for exactly that reason, and RAFT's ANN work has since moved to cuVS — so the answer may be that `compilers` is the wrong category rather than that the band is wrong. Moving it re-opens the instrument, not just the score, which is why it is held rather than filed at a rung.

## Deliberately not here

`flyte` and `zenml` are real AI stack products with no home. That is a taxonomy proposal, not a boundary exclusion, and it travels with `ray` as a migration candidate — `ray`'s own capability note already concedes it is "a distributed compute, training, tuning, data and serving framework rather than an isolation boundary", which makes it the anomaly in `deployment` rather than the precedent that admits the other two.

## Gates

`build.preflight` with pytest: **all 15 locally-runnable CI steps pass**, exit 0.