### PR TITLE
The resolution ledger never shrinks

### DIFF
--- a/tests/test_resolution_ledger.py
+++ b/tests/test_resolution_ledger.py
@@ -89,6 +89,44 @@ def test_a_repository_may_be_resolved_only_once(tmp_path):
     assert "Foo/Bar" in str(raised.value) or "foo/bar" in str(raised.value)
 
 
+#: Floor on the number of recorded decisions. Raise it deliberately when a pass appends;
+#: never lower it. 290 as of the #433 rebase.
+LEDGER_FLOOR = 290
+
+
+def test_the_ledger_never_shrinks():
+    """Uniqueness protects identity integrity. It does not protect completeness.
+
+    Three per-category tranches ran serially in one session, and each rebase conflicted on
+    this file because every pass appends to it. The tempting resolution is to take one side.
+    Doing so would have been invisible to every other guard here: dropping the two entries
+    #431 appended (`tinker-cookbook`, `mlx-vlm`) produces no duplicate, leaves the four
+    sentinel cases below intact, and loads clean. Two governance decisions would simply have
+    been gone, and the next bulk run would have recreated both.
+
+    So the ledger needs a second property alongside uniqueness: it is append-only, and a
+    resolution once recorded stays recorded. A count floor is the cheap form of that. A digest
+    over the whole key set would also catch a swap, but it would change on every legitimate
+    append and so would be noise rather than signal - and a swap is not how a side-pick fails.
+    A side-pick drops a block.
+
+    Correct resolution when this file conflicts: keep BOTH sides. Every entry is an append.
+
+    Deliberately a floor and not a set of named entries. Pinning the specific decisions a
+    given pass appended would couple this test to the order those passes merge in, which is
+    the one thing a serialized queue cannot promise.
+    """
+    entries = load()
+    assert len(entries) >= LEDGER_FLOOR, (
+        f"the ledger holds {len(entries)} decisions, below the floor of {LEDGER_FLOOR}. "
+        "A resolution that was recorded has been lost - most likely a merge or rebase that "
+        "took one side of a conflict in this file instead of merging both. Recover the "
+        "missing entries from git history rather than lowering this number: "
+        "`git log -p --follow sources/resolution_ledger.yaml`. Raise the floor only when a "
+        "pass has legitimately appended."
+    )
+
+
 def test_the_real_ledger_has_no_duplicate_identity():
     """Asserted against the file itself, so appending a second entry fails here."""
     assert load()

--- a/tests/test_resolution_ledger.py
+++ b/tests/test_resolution_ledger.py
@@ -90,8 +90,11 @@ def test_a_repository_may_be_resolved_only_once(tmp_path):
 
 
 #: Floor on the number of recorded decisions. Raise it deliberately when a pass appends;
-#: never lower it. 290 as of the #433 rebase.
-LEDGER_FLOOR = 290
+#: never lower it. Deliberately a hand-written constant rather than derived from the file:
+#: a floor that computes itself from the current ledger would happily derive 289 from a
+#: damaged one and prove itself correct. The independent number is what gives this test
+#: memory. 291 after the three 2026-08-31 category passes.
+LEDGER_FLOOR = 291
 
 
 def test_the_ledger_never_shrinks():


### PR DESCRIPTION
Uniqueness protects identity integrity. It does not protect completeness. The ledger only had the first.

## The gap

Three per-category tranches ran serially tonight (#431, #432, #433) and each rebase conflicted on `sources/resolution_ledger.yaml`, because every pass appends to it. The tempting resolution is to take one side — and doing so is invisible to every guard the file already has.

Demonstrated rather than argued. Simulating a side-pick that drops the two entries #431 appended:

```
real entries: 290 | floor: 290
side-pick drops #431's block: 290 -> 288
  loads clean, no DuplicateResolution: 288 entries  <- uniqueness misses it
  floor check 288 >= 290? -> the floor CATCHES it
```

The dropped file produces no duplicate, leaves the four sentinel cases in `test_the_four_cases_that_produced_this_file` intact, and loads without error. Two governance decisions would simply be gone, and the next bulk run would recreate both — which is the exact failure the ledger was built in #419 to prevent.

## What this adds

One invariant: `len(load()) >= LEDGER_FLOOR`, currently 290. Raise it deliberately when a pass appends; never lower it. The failure message points at `git log -p --follow` for recovery rather than inviting a lower number.

## Two design choices worth stating

**A count floor, not a digest over the key set.** A digest would also catch a swap, but it changes on every legitimate append, so it would be noise rather than signal. And a side-pick does not swap — it drops a block, which a count catches.

**A floor, not named entries.** The first draft of this pinned one entry per recent tranche, and it failed immediately on `Mai-with-u/MaiBot` because that decision is still sitting in open PR #433. Pinning specific decisions couples the test to the order passes merge in, which is the one thing a serialized queue cannot promise. That failure is the argument for the floor, so the docstring records it.

## Note on ordering

Floor is 290, which is main today. #433 appends one more, so after it lands the floor can be raised to 291 — but it does not need to be for this to be correct: a floor is a lower bound, and leaving it one behind main costs only the sensitivity to a single-entry loss. Raise it at the next convenient pass.