### PR TITLE
Attest the twelve comparisons the shakedown tranches dropped (#436)

### DIFF
--- a/build/axis_assessments.py
+++ b/build/axis_assessments.py
@@ -149,10 +149,20 @@ def _adoption_basis(
 
 
 def _capability_basis(capability: Mapping) -> tuple[str | None, str | None]:
-    """(the recorded `basis` verbatim, the anchor comparison if one is recorded)."""
+    """(the recorded `basis` verbatim, the anchor comparison if one is recorded).
+
+    The attestation date rides inside this string rather than in a column of its own. Adding a
+    column to a deployed static model fails on the platform - the ALTER is multi-column and the
+    only fix is delete-and-recreate - so an optional third clause is the cheap shape here.
+    """
     relative_to = capability.get("relative_to")
     relation = capability.get("relation")
-    detail = f"relative_to={relative_to};relation={relation}" if (relative_to or relation) else None
+    if not (relative_to or relation):
+        return capability.get("basis"), None
+    detail = f"relative_to={relative_to};relation={relation}"
+    attested = (capability.get("comparison") or {}).get("last_attested")
+    if attested:
+        detail += f";attested={attested}"
     return capability.get("basis"), detail
 
 

--- a/build/check_capability.py
+++ b/build/check_capability.py
@@ -39,6 +39,16 @@ nobody re-read. This is the structural analogue of the openness invariant, which
 worth the trouble: it is the same insight, that a date is only as good as the least recently
 confirmed thing underneath it.
 
+**An attested edge dates itself.** The rule above binds the dependent's *whole-axis* date to the
+root's *whole-axis* date, and those are two different claims about two different products. As the
+corpus grows, every new product's natural root is older than the product, so the comparison graph
+stops growing at the periphery (#436). A product may instead record `capability.comparison`: the
+date the spacing itself was last judged, and the read of the root that judged it. That record
+carries its own freshness requirements — a source read on or after the date, with a fetch behind
+it — and in exchange the root's axis date no longer bounds the dependent's. What it does not do is
+let a spacing be reaffirmed on unchanged bytes: a comparison can go false with nothing changing on
+either product, because the falsifier is a third product.
+
 ## What this does NOT do
 
 It does not make capability derivable, and it produces no score from evidence. The comparison
@@ -155,6 +165,11 @@ def check(scores: dict, owner: dict) -> list[str]:
             )
 
         claimed = parse_date(block.get("last_verified"))
+        comparison = block.get("comparison") or {}
+        if comparison:
+            problems.extend(_attestation_problems(slug, target, comparison, claimed))
+            continue
+
         if claimed is None:
             continue
         anchor_date = parse_date(other.get("last_verified"))
@@ -170,6 +185,82 @@ def check(scores: dict, owner: dict) -> list[str]:
                 f"confirmed {anchor_date}. The comparison was not re-derived"
             )
     return problems
+
+
+def _attestation_problems(
+    slug: str, target: str, comparison: dict, claimed: date | None
+) -> list[str]:
+    """What an attested edge must satisfy to stand on its own date.
+
+    The attestation is what lets a band be placed against a peer the corpus last confirmed
+    weeks ago. That is only sound if the date rests on a real read of the root, so the
+    requirements mirror `check_verification`'s two: the date needs a source `accessed` on or
+    after it, and that source needs a fetch to point at. Without them the mechanism becomes a
+    way to write a fresher date for less reading, which is the failure the whole apparatus
+    exists to prevent.
+
+    What is deliberately NOT here: the root's own `capability.last_verified`. Freeing the
+    dependent from it is the point. Where the root has since been re-read, `stale_attestations`
+    reports the edge for re-judgment rather than failing it.
+    """
+    problems: list[str] = []
+    attested = parse_date(comparison.get("last_attested"))
+    if attested is None:
+        # The schema requires it. Repeated here for the same reason the half-a-comparison
+        # check is: a gate that assumes another gate ran passes silently when it did not.
+        return [
+            f"{slug}:capability: records a comparison against {target} with no last_attested, "
+            f"so nothing dates the spacing"
+        ]
+
+    if claimed is not None and claimed > attested:
+        problems.append(
+            f"{slug}:capability: claims last_verified {claimed}, but the comparison against "
+            f"{target} was attested {attested}. `relative_to` and `relation` are part of this "
+            f"axis's score, so a whole-axis confirmation cannot outrun one of its parts"
+        )
+
+    sources = [s for s in (comparison.get("sources") or []) if isinstance(s, dict)]
+    covering = [s for s in sources if (parse_date(s.get("accessed")) or date.min) >= attested]
+    if not covering:
+        problems.append(
+            f"{slug}:capability: attests the comparison against {target} on {attested}, but no "
+            f"attestation source was read on or after that date. The date rests on nothing"
+        )
+        return problems
+
+    for source in covering:
+        missing = [k for k in ("http_status", "content_sha256") if not source.get(k)]
+        if missing:
+            problems.append(
+                f"{slug}:capability: the attestation source {source.get('url')!r} carries the "
+                f"{attested} date but records no {' or '.join(missing)}. A claimed confirmation "
+                f"needs a fetch to point at"
+            )
+    return problems
+
+
+def stale_attestations(scores: dict) -> list[tuple[str, str, date, date]]:
+    """(dependent, root, attested, root confirmed) for every edge the root has outrun.
+
+    Report-only, and the queue this mechanism exists to make visible. The root has been
+    re-read since the spacing was judged, so the judgment may rest on a description that has
+    since moved. The arithmetic check already fires when the root's SCORE moves; this catches
+    the case where its `value` moved and its score did not, which is exactly what `openhands`
+    turned out to have done under 25 dependent bands.
+    """
+    out: list[tuple[str, str, date, date]] = []
+    for slug, doc in sorted(scores.items()):
+        block = doc.get("capability") or {}
+        target = block.get("relative_to")
+        comparison = block.get("comparison") or {}
+        if not target or not comparison:
+            continue
+        attested = parse_date(comparison.get("last_attested"))
+        root_date = parse_date(((scores.get(target) or {}).get("capability") or {}).get("last_verified"))
+        if attested and root_date and attested < root_date:
+            out.append((slug, target, attested, root_date))
+    return out
 
 
 #: A comparison root has to be substantive, not merely present. A null check alone would let the
@@ -272,6 +363,25 @@ def main() -> int:
     for problem in problems:
         print(f"  ! {problem}")
     print(f"  {recorded} of {len(scores)} products record a comparison")
+
+    attested = sum(
+        1
+        for d in scores.values()
+        if (d.get("capability") or {}).get("relative_to")
+        and (d.get("capability") or {}).get("comparison")
+    )
+    print(
+        f"  {recorded} comparison(s) recorded, {attested} attested, {recorded - attested} "
+        f"resting on their root's axis date"
+    )
+
+    outrun = stale_attestations(scores)
+    if outrun:
+        print(f"\n  {len(outrun)} attested comparison(s) their root has been re-read since:")
+        for dep, root, when, root_date in outrun:
+            print(f"    ~ {dep} at {root}: attested {when}, {root} re-confirmed {root_date}")
+        print("    The spacing may rest on a description that has since moved. Report-only;")
+        print("    re-judge the edge and re-attest it.")
 
     roots = weak_roots(scores)
     if roots:

--- a/build/check_refetch.py
+++ b/build/check_refetch.py
@@ -249,22 +249,32 @@ def load_sources(product: str | None = None) -> list[Source]:
             block = score.get(axis) or {}
             if not isinstance(block, dict):
                 continue
-            for source in block.get("sources") or []:
-                if not isinstance(source, dict):
-                    continue
-                digest = source.get("content_sha256")
-                if not digest:
-                    continue
-                out.append(
-                    Source(
-                        product=path.stem,
-                        axis=axis,
-                        url=str(source.get("url") or ""),
-                        digest=str(digest),
-                        status=source.get("http_status"),
-                        accessed=source.get("accessed"),
+            lists = [(axis, block.get("sources"))]
+            # A comparison attestation cites the ROOT of a peer comparison, so it lives in its
+            # own list rather than in capability.sources — folding it in would let another
+            # product's page count as this one's evidence. It is still a recorded fetch, and
+            # it is the one kind of citation nobody re-reads on the product's own refresh, so
+            # the weekly re-fetch wants it more than most.
+            comparison = block.get("comparison")
+            if isinstance(comparison, dict):
+                lists.append((f"{axis}.comparison", comparison.get("sources")))
+            for label, sources in lists:
+                for source in sources or []:
+                    if not isinstance(source, dict):
+                        continue
+                    digest = source.get("content_sha256")
+                    if not digest:
+                        continue
+                    out.append(
+                        Source(
+                            product=path.stem,
+                            axis=label,
+                            url=str(source.get("url") or ""),
+                            digest=str(digest),
+                            status=source.get("http_status"),
+                            accessed=source.get("accessed"),
+                        )
                     )
-                )
     return out
 
 

--- a/docs/reference/capability.md
+++ b/docs/reference/capability.md
@@ -32,6 +32,7 @@ them, are not capable of anything the axis measures, and abstain rather than sco
 | `value` | the recorded observation the band rests on: exact and quoted for a benchmark or arena placement, and often a synthesized summary of documented features for a `feature_matrix` band, not a verbatim quote. |
 | `relative_to` | the slug of the product this band was placed **against**, when placed by comparison rather than measured. |
 | `relation` | how this band sits against `relative_to`: `at`, `one_below`, `two_below`, `one_above`. Required with `relative_to`, meaningless without it. |
+| `comparison` | when the spacing recorded by `relative_to`/`relation` was last judged still to hold (`last_attested`), and what was read on the peer to judge it (`sources`). Optional. |
 | `confidence` | the curator's certainty (`high`/`medium`/`low`). Note it does not encode the strength of the instrument — a `high` can sit on a feature-matrix judgment with no measurement under it. |
 | `note` | the prose behind the band: what the product does well, what it sits below, and against whom. |
 | `sources` | the evidence, at least one for a non-null score. |
@@ -94,10 +95,64 @@ answerable and a sentence never did:
    Megatron-LM's capability was last confirmed in June and `trl` claims today, `trl` is
    claiming to have re-derived a comparison against a fact nobody re-read. This is the openness
    invariant applied to a different dependency: a date is only as good as the least recently
-   confirmed thing underneath it.
+   confirmed thing underneath it. Unless the edge carries an attestation of its own — see
+   below.
 
 The gate ratchets like the others — it covers the products that record a comparison and does
 not block the ones that do not.
+
+### Dating the edge itself
+
+Transitive freshness as written binds the dependent's **whole-axis** date to the peer's
+**whole-axis** date, and those are two claims about two different products. The consequence
+shows up as the corpus grows: every new product's natural peer was confirmed before the
+product existed, so a tranche can compare its own members to each other and to nothing else.
+That happened three times in one week in August 2026, and the comparisons were dropped into
+prose rather than asserted on a re-derivation nobody performed.
+
+`capability.comparison` records the edge's own confirmation:
+
+```yaml
+capability:
+  score: 4
+  basis: feature_matrix
+  relative_to: verl
+  relation: one_below
+  comparison:
+    last_attested: 2026-08-31
+    sources:
+      - url: https://github.com/volcengine/verl
+        shows: "the algorithm catalogue, still wider than this product's"
+        accessed: 2026-08-31
+        http_status: 200
+        content_sha256: <64 hex>
+```
+
+`last_attested` dates the **spacing**, not either product. The sources are a separate list from
+`capability.sources` on purpose: they are citations about somebody else's product, and folding
+them in would let a peer's page count as this product's own evidence and would make the
+weak-root check read the wrong thing.
+
+What the gate then asks, and why each one:
+
+- the axis's `last_verified` may not be later than `last_attested` — `relative_to` and
+  `relation` are part of the score, so a whole-axis confirmation cannot outrun one of its parts;
+- at least one attestation source must record `accessed` on or after `last_attested`, or the
+  date rests on nothing;
+- that source must carry `http_status` and `content_sha256`. The judgment needs a real read of
+  the peer, and without this requirement the first pass under time pressure attests off the
+  peer's `value` as this repository already recorded it, which confirms nothing.
+
+In exchange, the peer's whole-axis date no longer bounds the dependent's. Where the peer *has*
+been re-read since the spacing was judged, `check_capability` reports the edge rather than
+failing it: the arithmetic check already fires if the peer's score moved, and this catches the
+case where its `value` moved and its score did not.
+
+One fetch attests every edge against the same peer, so a tranche pays per peer rather than per
+product. And an attestation may not re-date the peer's own `capability.last_verified` as a side
+effect — unless the read happened to cover every source that axis cites, in which case the peer
+really has been re-derived and the curator may date it. Nine of thirteen peers in the August
+backlog cited exactly one source, so that is common rather than exotic.
 
 ### Do not force every comparison through the category anchor
 
@@ -195,7 +250,9 @@ harnesses. One name for a group of products reads as a shared measurement that d
 - [ ] A comparison-placed band records `relative_to` (same category) and `relation`, and the
       arithmetic holds against the peer's score.
 - [ ] A non-null score cites at least one source.
-- [ ] `last_verified`, if present, satisfies the transitive-freshness rule.
+- [ ] `last_verified`, if present, satisfies the transitive-freshness rule — or the edge carries
+      a `comparison` block whose `last_attested` is no earlier than it and is backed by a fetched
+      source read on or after that date.
 
 ## Related
 

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -599,9 +599,46 @@ to have re-derived a comparison against a fact nobody re-read. This is the openn
 insight applied to a different dependency: a date is worth no more than the least recently
 confirmed thing underneath it.
 
+### The evidence date and the comparison date are two dates
+
+Stated as the rule, because the two get conflated and the conflation is what stopped the
+comparison graph growing.
+
+`capability.last_verified` dates **this product's own capability evidence**: the feature matrix
+still reads as described, the benchmark number is still the published one. It ages the way any
+axis ages, on the 30-day window the freshness gate applies.
+
+`capability.comparison.last_attested` dates **the spacing between this product and a peer**. It
+has a different lifecycle, because a comparison can go false with neither product changing: the
+peer improves, a third product lands between them, or the category's discriminating rung is
+rewritten. It is never derived from a source's `accessed` date, for the same reason
+`last_verified` is not — opening a URL is a weaker claim than re-judging a conclusion.
+
+The rule above binds the dependent's whole-axis date to the peer's whole-axis date. That is
+sound but coarse, and it makes the comparison graph unable to grow: as the corpus expands, every
+new product's natural peer was confirmed before the product existed, so a tranche can compare
+its members only to each other. An edge that records its own attestation is freed from the
+peer's axis date, and pays for that with its own evidence requirement: a source read on or after
+`last_attested`, carrying `http_status` and `content_sha256`. The gate is
+`build/check_capability.py`; `docs/reference/capability.md` is normative on the field shape.
+
+**What a `content_sha256` match may prove, and what it may never prove.** A recorded digest that
+reproduces from a live body is proof the fetch was real — SHA-256 preimages are not guessable, so
+those bytes could only have come from that body. Where **every** source an axis cites reproduces,
+that is a defensible basis for re-dating that axis's own `last_verified`, and it is worth
+building. It is never a basis for dating a comparison. Not when the peer's sources reproduce, not
+when both products' sources reproduce, because the thing that falsifies a spacing is a third
+product that neither one cites. An attestation written on the strength of unchanged bytes is the
+rubber stamp this apparatus was built to stop, wearing a digest.
+
+So an attestation costs a real read of the peer. It is cheaper than a full anchor refresh in what
+it **claims**, not in what it costs, and anyone who sells it as a shortcut will get the failure
+mode back.
+
 With that recorded, a capability `last_verified` means: **the feature matrix still reads as
 described, and the comparison the band rests on has been re-derived against a peer confirmed at
-least as recently.** It does not mean the band was measured. Where `basis: benchmark`, it also
+least as recently, or attested on its own date under the split below.** It does not mean the band
+was measured. Where `basis: benchmark`, it also
 does not mean the benchmark was re-run — re-reading a published number is the claim, and the
 number is a property of a harness-plus-model pairing rather than of the product alone.
 

--- a/docs/schemas/score.schema.json
+++ b/docs/schemas/score.schema.json
@@ -283,6 +283,30 @@
             "one_above"
           ],
           "description": "How this product's band sits against `relative_to`. Required with it, and meaningless without it. Deliberately tiny and domain-free, so it generalizes across categories as different as edge_hardware and benchmark_eval_data without asserting anything about what capability means in either."
+        },
+        "comparison": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "last_attested",
+            "sources"
+          ],
+          "description": "When the spacing recorded by `relative_to`/`relation` was last judged still to hold, and what was read on the root to judge it. Optional: an edge without it stays under the rule that the root's whole-axis confirmation must be at least as recent as this one's. Recording it is what lets a band be placed against a peer the corpus confirmed weeks ago, which is otherwise impossible as the corpus grows (issue #436). It says nothing without the pointers that name the spacing, so it requires both - spelled in `dependencies` because this file declares draft-07, where `dependentRequired` is not a keyword and is read by nothing; both spellings are carried so the constraint survives a later draft bump.",
+          "properties": {
+            "last_attested": {
+              "type": "string",
+              "format": "date",
+              "description": "The date on which the RELATIVE POSITION recorded by relative_to/relation was last judged still to hold. Distinct from capability.last_verified, which dates this product's own capability evidence. A comparison can become false with neither product changing - the peer improves, a third product lands between them, or the category's discriminating rung is rewritten - so it has its own lifecycle and its own date. Never derived from any source's accessed date."
+            },
+            "sources": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/source"
+              },
+              "description": "What was read on THE ROOT to make that judgment. Its own list, not capability.sources, because these are citations about a different product: folding them in would let a root's page count as this product's own evidence and would corrupt the weak-root check, which reads capability.sources as the root's evidence."
+            }
+          }
         }
       },
       "dependentRequired": {
@@ -291,6 +315,22 @@
         ],
         "relation": [
           "relative_to"
+        ],
+        "comparison": [
+          "relative_to",
+          "relation"
+        ]
+      },
+      "dependencies": {
+        "relative_to": [
+          "relation"
+        ],
+        "relation": [
+          "relative_to"
+        ],
+        "comparison": [
+          "relative_to",
+          "relation"
         ]
       },
       "additionalProperties": false

--- a/docs/workflows/add-product.md
+++ b/docs/workflows/add-product.md
@@ -57,11 +57,22 @@ workflow that clears its row, so this is the only place it happens.
    entry. Adoption may be left for the warehouse to band from artifacts. See
    [`../reference/openness.md`](../reference/openness.md), [`../reference/adoption.md`](../reference/adoption.md),
    [`../reference/capability.md`](../reference/capability.md).
-5. **Update both rosters** (category and org), and the org file if the org is new. A slug
+5. **Attest the spine, if the batch places bands by comparison.** A capability band placed
+   against a peer records `relative_to` + `relation`, and the peer will almost always have been
+   confirmed before this product existed. Do not drop the comparison into prose, and do not
+   re-date the peer's whole axis to get around it. Pick the two or three peers the batch compares
+   against, `uv run python -m build.fetch_source <the discriminating URL>` on each, read the body,
+   confirm the feature or scale claim separating the peer from the new products still reads as
+   its `value` says, and write a `comparison` block per edge. One fetch serves every edge against
+   that peer. The peer's own `last_verified` stays where it is — unless the read covered every
+   source its capability axis cites, in which case it has been re-derived and may be dated.
+   `uv run python -m build.check_refetch --product <peer>` first is cheap triage: where everything
+   reproduces, the peer's recorded values are known unchanged and the read is a formality.
+6. **Update both rosters** (category and org), and the org file if the org is new. A slug
    appears in exactly one of each. **If the product came from a registry row, delete that row
    now** — see the sixth file above. If it was the last row in the file, leave `products: []`
    rather than deleting the file: the file pairs with a category, not with its contents.
-6. **For a batch,** generate the files with a small script (dump for new files, and a helper
+7. **For a batch,** generate the files with a small script (dump for new files, and a helper
    that inserts `- <slug>` lines under existing `products:` blocks so their formatting is
    preserved). Never load-modify-dump an existing corpus file. Re-check the two hand-authored
    things a batch disturbs: category straplines and `sources/snapshots/long_tail.json`.
@@ -71,6 +82,7 @@ workflow that clears its row, so this is the only place it happens.
 uv run python -m build.validate            # must print 0 error(s)
 uv run python -m build.check_recipe        # the ladder accepts the new score
 uv run python -m build.check_verification  # producible pair; invariant if you dated it
+uv run python -m build.check_capability    # the comparisons and their attestations hold
 ```
 Preview only, never commit: `build/notebook_data.json`, `notebooks/ai-stack-map.py` (bot-owned).
 

--- a/docs/workflows/refresh-category.md
+++ b/docs/workflows/refresh-category.md
@@ -39,6 +39,13 @@ the exact failure this apparatus exists to prevent.
    Put anchors at the front and date them in the same run. Where the peer is in another category
    or an earlier run, leave `relative_to`/`relation` unset and report it; never substitute a
    different peer to satisfy the arithmetic.
+
+   This stays mandatory here. A refresh pass is where a re-read that moves a score belongs, and
+   the anchor read is the one that finds a peer whose surface has changed under the bands resting
+   on it — `openhands` is the case. The `capability.comparison` attestation
+   ([`../reference/capability.md`](../reference/capability.md)) is an alternative for
+   [`add-product.md`](add-product.md), so a batch is not blocked between refresh cycles. It is not
+   a way to skip the anchor here, and an attested edge does not exempt its peer from this run.
 3. **Preflight, gathered once.** The roster from the category file (never retyped); the recorded
    openness dimensions per product from the repo's own helpers; the warehouse signal rows for the
    whole category in one query. Respect `signal_routing.yaml`'s `never` routes.

--- a/sources/scores/accelerate.yaml
+++ b/sources/scores/accelerate.yaml
@@ -68,11 +68,11 @@ capability:
     with mixed precision via minimal code changes.'
   confidence: high
   note: Central infrastructure for distributed training but scoped to orchestration, not modeling.
-  last_verified: '2026-08-13'
+  last_verified: '2026-08-31'
   sources:
   - url: https://github.com/huggingface/accelerate
     shows: README still describes running raw PyTorch training across CPU, multi-GPU and TPU with mixed
       precision from a few lines of change
-    accessed: '2026-08-13'
+    accessed: '2026-08-31'
     http_status: 200
-    content_sha256: cfea9f3018826db8aa75755b06bf20678774df531143b8e5ba98581602c972eb
+    content_sha256: 53dc983aca6293181a80b55177990ddce94c66430983c9ee98e4399c5f327185

--- a/sources/scores/airi.yaml
+++ b/sources/scores/airi.yaml
@@ -65,6 +65,20 @@ capability:
     out, vision, three form factors - is real and is what puts it at the top of that band, but it organizes a character
     conversation rather than providing the retrieval, tool and document surface that places anythingllm and open-webui
     at 4.
+  relative_to: sillytavern
+  relation: at
+  comparison:
+    last_attested: '2026-08-31'
+    sources:
+    - url: https://github.com/SillyTavern/SillyTavern
+      shows: The README still describes a single unified interface for many LLM APIs (KoboldAI/CPP, Horde, NovelAI,
+        Ooba, Tabby, OpenAI, OpenRouter, Claude, Mistral and more) with Visual Novel Mode, Automatic1111 and ComfyUI
+        image generation, TTS, WorldInfo lorebooks and third-party extensions, and still describes itself as a locally
+        installed interface with no multi-user surface. That is the companion front-end class this band shares with
+        it.
+      accessed: '2026-08-31'
+      http_status: 200
+      content_sha256: 578dfe730c7c05004d6b5f6d8f6f09efe3bc48067d9055014d00961e031afde4
   last_verified: '2026-08-31'
   sources:
   - url: https://raw.githubusercontent.com/moeru-ai/airi/main/README.md

--- a/sources/scores/anythingllm.yaml
+++ b/sources/scores/anythingllm.yaml
@@ -54,10 +54,10 @@ capability:
     and vector-DB breadth plus no-code agents put it on par with LibreChat and Open WebUI. Scheduled cron
     tasks, managed memories and intelligent skill selection are also present. Level 5 is held for the OSI
     leaders on raw breadth.
-  last_verified: '2026-08-13'
+  last_verified: '2026-08-31'
   sources:
   - url: https://github.com/Mintplex-Labs/anything-llm
     shows: 40+ LLM providers, RAG, multi-user permissioning, no-code agents with web browsing
-    accessed: '2026-08-13'
+    accessed: '2026-08-31'
     http_status: 200
-    content_sha256: 144242e11172f75c6ea72fc627d7aaf4caacf031c7b0bbc30ec3cdb835349056
+    content_sha256: dc714d7518633ad9df0a862b110d093eca5ded72b37bef73ef97c537d168aeba

--- a/sources/scores/areal.yaml
+++ b/sources/scores/areal.yaml
@@ -75,6 +75,19 @@ capability:
     It is scored at OpenRLHF rather than above it because the two cover the same ground from different angles -
     OpenRLHF on Ray-scheduled RLHF at 70B+, AReaL on asynchronous agentic RL - and neither reaches the method catalogue
     of verl or nemo-rl.'
+  relative_to: openrlhf
+  relation: at
+  comparison:
+    last_attested: '2026-08-31'
+    sources:
+    - url: https://raw.githubusercontent.com/OpenRLHF/OpenRLHF/main/README.md
+      shows: The State-of-the-Art RL Algorithms section still lists PPO, REINFORCE++, REINFORCE++-baseline, GRPO,
+        RLOO and Dr. GRPO in its estimator table, over the Ray + vLLM + DeepSpeed ZeRO-3 architecture separating
+        Actor/Reward/Reference/Critic for models up to 70B+ parameters. That is the same order of distributed-RL
+        breadth AReaL's support matrix documents, and neither reaches verl's method catalogue.
+      accessed: '2026-08-31'
+      http_status: 200
+      content_sha256: aabe426d4df1487dd525f983bec5f46958ff27733c67713818a28091984681c0
   last_verified: '2026-08-31'
   sources:
   - url: https://raw.githubusercontent.com/areal-project/AReaL/main/README.md

--- a/sources/scores/areal.yaml
+++ b/sources/scores/areal.yaml
@@ -84,7 +84,7 @@ capability:
       shows: The State-of-the-Art RL Algorithms section still lists PPO, REINFORCE++, REINFORCE++-baseline, GRPO,
         RLOO and Dr. GRPO in its estimator table, over the Ray + vLLM + DeepSpeed ZeRO-3 architecture separating
         Actor/Reward/Reference/Critic for models up to 70B+ parameters. That is the same order of distributed-RL
-        breadth AReaL's support matrix documents, and neither reaches verl's method catalogue.
+        breadth AReaL's support matrix documents, and neither reaches verl's method catalog.
       accessed: '2026-08-31'
       http_status: 200
       content_sha256: aabe426d4df1487dd525f983bec5f46958ff27733c67713818a28091984681c0

--- a/sources/scores/deepchat.yaml
+++ b/sources/scores/deepchat.yaml
@@ -68,6 +68,20 @@ capability:
     MCP tools, the Agent Client Protocol, a skills system and run tracing, which is the extensible-platform behaviour
     that places anythingllm and open-webui at 4. It stays below librechat at 5, which carries multi-user authentication
     and a wider native provider matrix.
+  relative_to: anythingllm
+  relation: at
+  comparison:
+    last_attested: '2026-08-31'
+    sources:
+    - url: https://github.com/Mintplex-Labs/anything-llm
+      shows: The feature list still records custom AI agents and a no-code agent builder with in-workspace web browsing,
+        scheduled cron tasks, multi-modal support and multi-user instance support and permissioning, over a supported-provider
+        section listing around forty LLM providers and eight vector databases. The agent and tool surface is what
+        places it at 4, and it is the surface this product's MCP tools, Agent Client Protocol and skills system
+        match.
+      accessed: '2026-08-31'
+      http_status: 200
+      content_sha256: dc714d7518633ad9df0a862b110d093eca5ded72b37bef73ef97c537d168aeba
   last_verified: '2026-08-31'
   sources:
   - url: https://raw.githubusercontent.com/ThinkInAIXYZ/deepchat/dev/README.md

--- a/sources/scores/miles.yaml
+++ b/sources/scores/miles.yaml
@@ -69,6 +69,19 @@ capability:
     one band below verl because verl publishes a substantially wider algorithm catalogue (PPO, GRPO, RLOO, ReMax,
     REINFORCE++, GSPO, PRIME, DAPO, DrGRPO plus SFT/DPO) while Miles documents PPO and GRPO; method breadth is what
     separates the top two bands in this category.
+  relative_to: verl
+  relation: one_below
+  comparison:
+    last_attested: '2026-08-31'
+    sources:
+    - url: https://github.com/volcengine/verl
+      shows: Key Features still lists reinforcement learning with PPO, GRPO, GSPO, ReMax, REINFORCE++, RLOO, PRIME,
+        DAPO and DrGRPO, alongside supervised fine-tuning, over FSDP/FSDP2/Megatron-LM training backends with vLLM,
+        SGLang and HF Transformers rollout. That catalogue is still substantially wider than the PPO and GRPO Miles
+        documents, which is the spacing this band rests on.
+      accessed: '2026-08-31'
+      http_status: 200
+      content_sha256: c1ad6b970072c2000b9884f2a7d4d1c834e8b42f8ccb0e19123435e4dd01010e
   last_verified: '2026-08-31'
   sources:
   - url: https://raw.githubusercontent.com/radixark/miles/main/README.md

--- a/sources/scores/miles.yaml
+++ b/sources/scores/miles.yaml
@@ -77,7 +77,7 @@ capability:
     - url: https://github.com/volcengine/verl
       shows: Key Features still lists reinforcement learning with PPO, GRPO, GSPO, ReMax, REINFORCE++, RLOO, PRIME,
         DAPO and DrGRPO, alongside supervised fine-tuning, over FSDP/FSDP2/Megatron-LM training backends with vLLM,
-        SGLang and HF Transformers rollout. That catalogue is still substantially wider than the PPO and GRPO Miles
+        SGLang and HF Transformers rollout. That catalog is still substantially wider than the PPO and GRPO Miles
         documents, which is the spacing this band rests on.
       accessed: '2026-08-31'
       http_status: 200

--- a/sources/scores/mlx.yaml
+++ b/sources/scores/mlx.yaml
@@ -69,7 +69,20 @@ capability:
   note: 'Scored 4 rather than 5 on reach of hardware rather than depth of design. MLX has the shape of a foundational
     framework - its own array type, composable transforms and autodiff, and an ecosystem built on it - but it runs
     on Apple silicon alone, where pytorch, tensorflow and jax at 5 are hardware-portable. openvino sets the precedent
-    in this category at 4: a technically strong framework scoped to one vendor''s hardware. Stated here rather than recorded as relative_to because no candidate root has been confirmed as recently as this pass.'
+    in this category at 4: a technically strong framework scoped to one vendor''s hardware.'
+  relative_to: openvino
+  relation: at
+  comparison:
+    last_attested: '2026-08-31'
+    sources:
+    - url: https://github.com/openvinotoolkit/openvino
+      shows: The README still describes a toolkit for optimizing and deploying deep learning models, with Flexible
+        Model Support converting from PyTorch, TensorFlow, ONNX, Keras, PaddlePaddle and JAX/Flax, running inference
+        on CPU, Intel integrated and discrete GPU, and Intel NPU. That is the precedent this band rests on, a technically
+        strong framework scoped to one vendor's hardware, held at 4 rather than 5 for the same reason MLX is.
+      accessed: '2026-08-31'
+      http_status: 200
+      content_sha256: a60992e91bebccb743b5cebecc30854665f17294180a2d687dde8ec2b4c9f3ad
   last_verified: '2026-08-31'
   sources:
   - url: https://raw.githubusercontent.com/ml-explore/mlx/main/README.md

--- a/sources/scores/ogam.yaml
+++ b/sources/scores/ogam.yaml
@@ -73,6 +73,20 @@ capability:
     generation, all on device - is wider than most of that band and is what holds it at the top of it, but it targets
     one person's phone and laptop rather than providing the multi-backend, document and agent platform surface that
     places open-webui and anythingllm at 4.
+  relative_to: jan
+  relation: at
+  comparison:
+    last_attested: '2026-08-31'
+    sources:
+    - url: https://github.com/janhq/jan
+      shows: The feature list still records local models downloaded and run from HuggingFace (Llama, Gemma, Qwen,
+        GPT-oss), cloud integration with OpenAI, Anthropic, Mistral, Groq and MiniMax, custom assistants, an OpenAI-compatible
+        local server on localhost:1337 and Model Context Protocol integration, on a single-user desktop application.
+        That local-application class, rather than a server-side platform surface, is the band this product shares
+        with it.
+      accessed: '2026-08-31'
+      http_status: 200
+      content_sha256: 4ab148b9cf1dff30a4c5080c13f087085de0203012e1ac0ae9fdb2cb33c50a1d
   last_verified: '2026-08-31'
   sources:
   - url: https://raw.githubusercontent.com/off-grid-ai/OGAM/main/README.md

--- a/sources/scores/openrlhf.yaml
+++ b/sources/scores/openrlhf.yaml
@@ -84,14 +84,14 @@ capability:
     scheduling, vLLM-accelerated rollout and DeepSpeed, scaling to 70B+ models across many GPUs, with multi-turn
     agent RL as well. Its method scope is RL-centric rather than full-spectrum, and it does not reach Megatron-LM''s
     frontier scale, so it sits one band below the top.'
-  last_verified: '2026-08-09'
+  last_verified: '2026-08-31'
   sources:
   - url: https://raw.githubusercontent.com/OpenRLHF/OpenRLHF/main/README.md
     shows: Architecture section still describes Ray separating Actor/Reward/Reference/Critic models "up
       to 70B+ parameters," vLLM for high-throughput rollout generation, and DeepSpeed ZeRO-3/AutoTP/RingAttention
       for training; the algorithm table still lists PPO, REINFORCE++, REINFORCE++-baseline, RLOO, GRPO,
-      and Dr. GRPO. A new experimental "Molt" backend is noted as an alternative to DeepSpeed, not yet the
-      primary path.
-    accessed: '2026-08-09'
+      and Dr. GRPO. A "New Backend" callout offers Molt, an Automodel-powered alternative described as more
+      powerful than DeepSpeed, but the Architecture Foundation section is still Ray + vLLM + DeepSpeed.
+    accessed: '2026-08-31'
     http_status: 200
-    content_sha256: ce9e32beb7153b42fc266fa39a43878b5327cf93f0784fcaec2794e880c25553
+    content_sha256: aabe426d4df1487dd525f983bec5f46958ff27733c67713818a28091984681c0

--- a/sources/scores/openvino.yaml
+++ b/sources/scores/openvino.yaml
@@ -69,11 +69,11 @@ capability:
     conversion.
   confidence: high
   note: Broad inference runtime with model conversion and GenAI API, primarily Intel-hardware oriented.
-  last_verified: '2026-08-13'
+  last_verified: '2026-08-31'
   sources:
   - url: https://github.com/openvinotoolkit/openvino
     shows: README still describes inference optimization and deployment across Intel CPU, GPU and NPU with
       conversion from PyTorch, TensorFlow and ONNX
-    accessed: '2026-08-13'
+    accessed: '2026-08-31'
     http_status: 200
-    content_sha256: a14e8dae9600cfab00f871e2d62ccd80445622eff33f4201a8860caa33598f28
+    content_sha256: a60992e91bebccb743b5cebecc30854665f17294180a2d687dde8ec2b4c9f3ad

--- a/sources/scores/paddle.yaml
+++ b/sources/scores/paddle.yaml
@@ -81,8 +81,8 @@ capability:
     - url: https://github.com/pytorch/pytorch
       shows: The README's two-line summary still reads "Tensor computation (like NumPy) with strong GPU acceleration"
         and "Deep neural networks built on a tape-based autograd system", with a Dynamic Neural Networks section
-        under it. PyTorch's 5 rests on owning the tensor engine, autograd and distributed execution, which is the
-        same framework scope Paddle claims for its own graph engine and deployment path.
+        under it. PyTorch's 5 rests on owning the tensor engine and the autograd built on it, which is the same
+        framework scope Paddle claims for its own graph engine and deployment path.
       accessed: '2026-08-31'
       http_status: 200
       content_sha256: 3c8e06bc5967dedcd298237484a14f667abc9d41980e148b557f59de39976e49

--- a/sources/scores/paddle.yaml
+++ b/sources/scores/paddle.yaml
@@ -72,7 +72,20 @@ capability:
   note: 'Scored 5 on framework scope. Paddle is a foundational framework in the same sense as pytorch and tensorflow,
     which both sit at 5 here: it owns its own graph engine, distributed execution and deployment path rather than
     building on somebody else''s. Its automatic-parallelism and integrated training-inference design are the distinguishing
-    claims. The comparison is stated here rather than recorded as relative_to because no candidate root in this category has been confirmed as recently as this pass, and a comparison cannot claim a fresher verification date than its root.'
+    claims.'
+  relative_to: pytorch
+  relation: at
+  comparison:
+    last_attested: '2026-08-31'
+    sources:
+    - url: https://github.com/pytorch/pytorch
+      shows: The README's two-line summary still reads "Tensor computation (like NumPy) with strong GPU acceleration"
+        and "Deep neural networks built on a tape-based autograd system", with a Dynamic Neural Networks section
+        under it. PyTorch's 5 rests on owning the tensor engine, autograd and distributed execution, which is the
+        same framework scope Paddle claims for its own graph engine and deployment path.
+      accessed: '2026-08-31'
+      http_status: 200
+      content_sha256: 3c8e06bc5967dedcd298237484a14f667abc9d41980e148b557f59de39976e49
   last_verified: '2026-08-31'
   sources:
   - url: https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/README.md

--- a/sources/scores/private-gpt.yaml
+++ b/sources/scores/private-gpt.yaml
@@ -78,6 +78,20 @@ capability:
     surface is the same order as anythingllm and open-webui, both 4 here, and broader than a front end like jan
     at 3. It stops short of 5 because it deliberately ships no interface: librechat at 5 covers multi-provider chat,
     multi-user authentication and agents together, where this covers the API layer alone.'
+  relative_to: anythingllm
+  relation: at
+  comparison:
+    last_attested: '2026-08-31'
+    sources:
+    - url: https://github.com/Mintplex-Labs/anything-llm
+      shows: The feature list still records multi-modal support, multi-user instance support and permissioning,
+        a no-code AI agent builder with in-workspace web browsing, scheduled cron tasks on a schedule, and drag-and-drop
+        document ingestion with source citations, over a supported-provider section listing around forty LLM providers
+        and eight vector databases. That retrieval, tool and connector surface is the same order as this product's,
+        which is what holds the two level.
+      accessed: '2026-08-31'
+      http_status: 200
+      content_sha256: dc714d7518633ad9df0a862b110d093eca5ded72b37bef73ef97c537d168aeba
   last_verified: '2026-08-31'
   sources:
   - url: https://raw.githubusercontent.com/zylon-ai/private-gpt/main/README.md

--- a/sources/scores/pytorch-lightning.yaml
+++ b/sources/scores/pytorch-lightning.yaml
@@ -77,7 +77,20 @@ capability:
   note: Scored 4 as a library built on a framework rather than a framework. It structures and distributes a PyTorch
     training loop, which is the same shape as accelerate at 4 in this category, and depends on PyTorch for the tensor
     engine and autograd that put pytorch at 5. Its breadth of accelerator and strategy coverage is what holds it
-    at the top of that band. Stated here rather than recorded as relative_to because accelerate has not been confirmed as recently as this pass, and a comparison cannot claim a fresher verification date than its root.
+    at the top of that band.
+  relative_to: accelerate
+  relation: at
+  comparison:
+    last_attested: '2026-08-31'
+    sources:
+    - url: https://github.com/huggingface/accelerate
+      shows: The README still says Accelerate "abstracts exactly and only the boilerplate code related to multi-GPUs/TPU/fp16
+        and leaves the rest of your code unchanged", adding five lines to a standard PyTorch script to run on single
+        CPU, single GPU, multi-GPU or TPU with or without fp8, fp16 or bf16 mixed precision. Structuring and distributing
+        somebody else's tensor engine is the shape this band shares with it.
+      accessed: '2026-08-31'
+      http_status: 200
+      content_sha256: 53dc983aca6293181a80b55177990ddce94c66430983c9ee98e4399c5f327185
   last_verified: '2026-08-31'
   sources:
   - url: https://raw.githubusercontent.com/Lightning-AI/pytorch-lightning/master/README.md

--- a/sources/scores/qwenpaw.yaml
+++ b/sources/scores/qwenpaw.yaml
@@ -80,6 +80,20 @@ capability:
   note: 'Scored 4 alongside anythingllm and open-webui: an extensible platform with tools, plugins and memory rather
     than a front end over a model endpoint, which is what places jan and sillytavern at 3. It does not reach librechat
     at 5, which adds multi-user authentication and a broader native provider matrix.'
+  relative_to: anythingllm
+  relation: at
+  comparison:
+    last_attested: '2026-08-31'
+    sources:
+    - url: https://github.com/Mintplex-Labs/anything-llm
+      shows: The feature list still records a no-code AI agent builder with in-workspace web browsing, custom AI
+        agents, scheduled cron tasks, multi-modal support and multi-user instance support and permissioning, over
+        a supported-provider section listing around forty LLM providers and eight vector databases. It remains an
+        extensible platform with tools, memory and agents rather than a front end over a model endpoint, which is
+        the class this band shares with it.
+      accessed: '2026-08-31'
+      http_status: 200
+      content_sha256: dc714d7518633ad9df0a862b110d093eca5ded72b37bef73ef97c537d168aeba
   last_verified: '2026-08-31'
   sources:
   - url: https://raw.githubusercontent.com/agentscope-ai/QwenPaw/main/README.md

--- a/sources/scores/risuai.yaml
+++ b/sources/scores/risuai.yaml
@@ -66,6 +66,20 @@ capability:
   note: Scored 3 in the same companion front-end class as sillytavern, which it resembles closely in purpose and
     feature set. Its README is short and documents a smaller surface than airi's, so it sits at the lower end of
     the band rather than the top, but the class placement is what the score records.
+  relative_to: sillytavern
+  relation: at
+  comparison:
+    last_attested: '2026-08-31'
+    sources:
+    - url: https://github.com/SillyTavern/SillyTavern
+      shows: The README still describes a locally installed interface for many LLM APIs (KoboldAI/CPP, Horde, NovelAI,
+        Ooba, Tabby, OpenAI, OpenRouter, Claude, Mistral and more) with Visual Novel Mode, Automatic1111 and ComfyUI
+        image generation, TTS, WorldInfo lorebooks, character sharing and third-party extensions. The character-card,
+        memory, plugin and image-generation surface this product documents is the same class, which is what the
+        band records.
+      accessed: '2026-08-31'
+      http_status: 200
+      content_sha256: 578dfe730c7c05004d6b5f6d8f6f09efe3bc48067d9055014d00961e031afde4
   last_verified: '2026-08-31'
   sources:
   - url: https://raw.githubusercontent.com/kwaroran/Risuai/main/README.md

--- a/sources/scores/sillytavern.yaml
+++ b/sources/scores/sillytavern.yaml
@@ -58,10 +58,10 @@ capability:
   note: Feature-rich for its niche, broad backend coverage, image-gen/TTS, extensions, character/roleplay
     tooling (Visual Novel mode). Specialized toward roleplay rather than general-purpose assistant work;
     mid-tier on the general chat-UI matrix.
-  last_verified: '2026-08-13'
+  last_verified: '2026-08-31'
   sources:
   - url: https://github.com/SillyTavern/SillyTavern
     shows: multi-backend, image-gen, TTS, extensions, Visual Novel mode
-    accessed: '2026-08-13'
+    accessed: '2026-08-31'
     http_status: 200
-    content_sha256: 913396e188c8ef5e84e46847279e65992adcbf72337e666c475853ed5ec45c91
+    content_sha256: 578dfe730c7c05004d6b5f6d8f6f09efe3bc48067d9055014d00961e031afde4

--- a/sources/scores/xtuner.yaml
+++ b/sources/scores/xtuner.yaml
@@ -77,6 +77,20 @@ capability:
     and publishes weak- and strong-scaling benchmarks, whereas XTuner is specialized to MoE and its throughput claim
     is stated in the README rather than in a published scaling study. The same one_below relation places swift and
     llama-factory.
+  relative_to: megatron-lm
+  relation: one_below
+  comparison:
+    last_attested: '2026-08-31'
+    sources:
+    - url: https://github.com/NVIDIA/Megatron-LM
+      shows: Megatron Core still advertises composable TP, PP, DP, EP and CP with FP16, BF16, FP8 and FP4 mixed
+        precision, and Performance Benchmarking still reports training from 2B to 462B parameters across thousands
+        of GPUs, a 462B model benchmarked on 6,144 H100 GPUs with MFU rising from 41% to 47-48%, and a GPT-3 of
+        slightly more than 175 billion parameters strong-scaled from 96 to 4,608 H100 GPUs. The composable general-purpose
+        parallelism and the published scaling study are what hold XTuner's MoE-specialized story one band below.
+      accessed: '2026-08-31'
+      http_status: 200
+      content_sha256: 7c7a75d3ca90f4b9e41eee29630d359164b715fc07ebd8157a6ffffdf924d454
   last_verified: '2026-08-31'
   sources:
   - url: https://raw.githubusercontent.com/InternLM/xtuner/main/README.md

--- a/tests/test_axis_assessments.py
+++ b/tests/test_axis_assessments.py
@@ -204,6 +204,17 @@ def test_capability_basis_helper_carries_the_anchor():
     assert "relative_to=gpt-4" in detail and "relation=peer" in detail
 
 
+def test_capability_basis_helper_carries_the_attestation_date_when_there_is_one():
+    """In the detail string, not a column: a column add fails on the deployed static model."""
+    _, plain = _capability_basis({"basis": "feature_matrix", "relative_to": "b", "relation": "at"})
+    assert "attested" not in plain
+    _, attested = _capability_basis({
+        "basis": "feature_matrix", "relative_to": "b", "relation": "at",
+        "comparison": {"last_attested": "2026-08-31", "sources": []},
+    })
+    assert attested == "relative_to=b;relation=at;attested=2026-08-31"
+
+
 # --- status internals, fail-closed (my strict contract) --------------------------
 
 

--- a/tests/test_axis_assessments.py
+++ b/tests/test_axis_assessments.py
@@ -32,7 +32,11 @@ TEST_DVID = "test-declaration-version"
 TEST_SHA = "test-git-sha"
 
 AXIS_ROW_COUNT = 1659
-AXIS_ASSESSMENTS_DIGEST = "6637509b40118c5a3a9d26a21bfcc447242788c9fd6a18661abdd563aadc5de3"
+# Moved by the #436 attestation pass: 12 capability rows gained
+# `relative_to=X;relation=Y;attested=DATE` in `basis_detail`, and five comparison roots
+# (openrlhf, accelerate, openvino, anythingllm, sillytavern) moved `last_verified` to the day
+# their axis was re-read. No score changed and the row count is unchanged.
+AXIS_ASSESSMENTS_DIGEST = "a4b69eddcec2ad8a907b582d86a2bc574cb8294e9d5bf8792a64542f457fca58"
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_check_capability.py
+++ b/tests/test_check_capability.py
@@ -17,9 +17,22 @@ from pathlib import Path
 
 import pytest
 
-from build.check_capability import candidates, check
+from build.check_capability import candidates, check, stale_attestations
 
 CATS = {"a": "cat", "b": "cat", "c": "cat", "far": "other"}
+
+
+def attestation(attested, accessed=None, **overrides) -> dict:
+    """A well-formed comparison block, so a test can spoil exactly one thing."""
+    source = {
+        "url": "https://github.com/example/b",
+        "shows": "the parallelism claim the band rests on",
+        "accessed": accessed or attested,
+        "http_status": 200,
+        "content_sha256": "0" * 64,
+    }
+    source.update(overrides)
+    return {"last_attested": attested, "sources": [source]}
 
 
 def scores(**products) -> dict:
@@ -117,6 +130,139 @@ def test_an_undated_band_needs_no_anchor_date():
         b={"score": 5, "basis": "feature_matrix"},
     )
     assert check(data, CATS) == []
+
+
+# --- the attestation on the comparison edge (#436) -------------------------------------------
+#
+# One row per state in the design's semantics table. The row that is not here is the one above:
+# a comparison with no attestation block stays on the old rule, and
+# `test_a_derived_band_cannot_be_fresher_than_what_it_derives_from` pins it unchanged.
+
+
+def test_an_attested_comparison_frees_the_band_from_the_roots_axis_date():
+    """The unlock. The root's whole-axis date no longer bounds the dependent's."""
+    data = scores(
+        a={
+            "score": 4, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below",
+            "last_verified": date(2026, 8, 31),
+            "comparison": attestation(date(2026, 8, 31)),
+        },
+        b={"score": 5, "basis": "feature_matrix", "last_verified": date(2026, 8, 13)},
+    )
+    assert check(data, CATS) == []
+
+
+def test_a_whole_axis_date_cannot_outrun_the_attestation_it_contains():
+    """`relative_to`/`relation` are part of the axis's score, so the part dates the whole."""
+    data = scores(
+        a={
+            "score": 4, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below",
+            "last_verified": date(2026, 8, 31),
+            "comparison": attestation(date(2026, 8, 20)),
+        },
+        b={"score": 5, "basis": "feature_matrix", "last_verified": date(2026, 8, 31)},
+    )
+    problems = check(data, CATS)
+    assert len(problems) == 1
+    assert "attested 2026-08-20" in problems[0]
+
+
+def test_an_attestation_needs_a_source_read_on_or_after_the_date_it_claims():
+    data = scores(
+        a={
+            "score": 4, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below",
+            "last_verified": date(2026, 8, 20),
+            "comparison": attestation(date(2026, 8, 31), accessed=date(2026, 8, 20)),
+        },
+        b={"score": 5, "basis": "feature_matrix", "last_verified": date(2026, 8, 13)},
+    )
+    problems = check(data, CATS)
+    assert len(problems) == 1
+    assert "no attestation source was read on or after" in problems[0]
+
+
+@pytest.mark.parametrize("missing", ["http_status", "content_sha256"])
+def test_the_source_that_carries_the_date_must_carry_a_fetch(missing):
+    """Without this the first pass under pressure attests off the repo's own recorded value."""
+    block = attestation(date(2026, 8, 31))
+    del block["sources"][0][missing]
+    data = scores(
+        a={
+            "score": 4, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below",
+            "last_verified": date(2026, 8, 31), "comparison": block,
+        },
+        b={"score": 5, "basis": "feature_matrix", "last_verified": date(2026, 8, 13)},
+    )
+    problems = check(data, CATS)
+    assert len(problems) == 1
+    assert missing in problems[0]
+
+
+def test_an_uncovering_source_may_be_thin_as_long_as_one_covering_source_is_not():
+    """The requirement is on the source that carries the date, not on every citation."""
+    block = attestation(date(2026, 8, 31))
+    block["sources"].append(
+        {"url": "https://example.com/older", "shows": "context", "accessed": date(2026, 8, 1)}
+    )
+    data = scores(
+        a={
+            "score": 4, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below",
+            "last_verified": date(2026, 8, 31), "comparison": block,
+        },
+        b={"score": 5, "basis": "feature_matrix", "last_verified": date(2026, 8, 13)},
+    )
+    assert check(data, CATS) == []
+
+
+def test_a_root_re_read_since_the_spacing_was_judged_is_reported_not_failed():
+    """The root's `value` can move without its score moving, and the arithmetic will not see it."""
+    data = scores(
+        a={
+            "score": 4, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below",
+            "last_verified": date(2026, 8, 20),
+            "comparison": attestation(date(2026, 8, 20)),
+        },
+        b={"score": 5, "basis": "feature_matrix", "last_verified": date(2026, 8, 31)},
+    )
+    assert check(data, CATS) == []
+    assert stale_attestations(data) == [("a", "b", date(2026, 8, 20), date(2026, 8, 31))]
+
+
+def test_an_attestation_the_root_has_not_outrun_is_not_in_the_queue():
+    data = scores(
+        a={
+            "score": 4, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below",
+            "last_verified": date(2026, 8, 31),
+            "comparison": attestation(date(2026, 8, 31)),
+        },
+        b={"score": 5, "basis": "feature_matrix", "last_verified": date(2026, 8, 13)},
+    )
+    assert stale_attestations(data) == []
+
+
+def test_an_undated_attestation_is_caught_here_too():
+    """The schema requires `last_attested`. A gate that assumes another gate ran passes silently."""
+    data = scores(
+        a={
+            "score": 4, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below",
+            "last_verified": date(2026, 8, 31),
+            "comparison": {"sources": [{"url": "https://example.com", "shows": "x"}]},
+        },
+        b={"score": 5, "basis": "feature_matrix", "last_verified": date(2026, 8, 13)},
+    )
+    assert "no last_attested" in check(data, CATS)[0]
+
+
+def test_an_undated_band_with_an_attestation_still_needs_the_attestation_to_hold():
+    """The escape hatch for an undated axis does not extend to the edge's own record."""
+    data = scores(
+        a={
+            "score": 4, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below",
+            "comparison": attestation(date(2026, 8, 31), accessed=date(2026, 8, 1)),
+        },
+        b={"score": 5, "basis": "feature_matrix"},
+    )
+    assert "no attestation source was read on or after" in check(data, CATS)[0]
 
 
 def test_a_comparison_must_stay_inside_the_category():
@@ -223,3 +369,31 @@ def test_a_relation_outside_capability_is_rejected_by_the_schema():
         stray[axis]["relation"] = "at"
         with pytest.raises(jsonschema.ValidationError, match="Additional properties"):
             jsonschema.validate(stray, schema)
+
+
+def test_an_attestation_without_the_comparison_it_attests_to_is_rejected_by_the_schema():
+    """`comparison` dates a spacing, so it says nothing without the pointers that name one."""
+    import json
+
+    import jsonschema
+    import yaml
+
+    root = Path(__file__).resolve().parents[1]
+    schema = json.loads((root / "docs/schemas/score.schema.json").read_text())
+    doc = yaml.safe_load((root / "sources/scores/trl.yaml").read_text())
+    doc["capability"].pop("relative_to", None)
+    doc["capability"].pop("relation", None)
+    doc["capability"]["comparison"] = {
+        "last_attested": "2026-08-31",
+        "sources": [
+            {
+                "url": "https://example.com/root",
+                "shows": "the discriminator still reads as recorded",
+                "accessed": "2026-08-31",
+                "http_status": 200,
+                "content_sha256": "0" * 64,
+            }
+        ],
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(doc, schema)

--- a/tests/test_check_refetch.py
+++ b/tests/test_check_refetch.py
@@ -216,3 +216,40 @@ def test_a_wall_whose_digest_matches_is_never_confirmed():
         outcome, detail = refetch(source, 5.0)
     assert outcome != "confirmed"
     assert "never read" in detail
+
+
+def test_load_sources_walks_the_comparison_attestation(tmp_path, monkeypatch):
+    """A comparison attestation cites the ROOT, so it is exactly the kind of claim that
+    benefits from a weekly re-fetch. It sits outside `capability.sources` deliberately, which
+    means the walker has to be told about it or it re-checks nothing."""
+    import build.check_refetch as mod
+
+    folder = tmp_path / "sources" / "scores"
+    folder.mkdir(parents=True)
+    (folder / "a.yaml").write_text(
+        "product: a\n"
+        "capability:\n"
+        "  score: 4\n"
+        "  basis: feature_matrix\n"
+        "  relative_to: b\n"
+        "  relation: one_below\n"
+        "  sources:\n"
+        "    - url: https://example.com/a\n"
+        "      shows: what a does\n"
+        "      accessed: 2026-08-31\n"
+        f"      content_sha256: {DIGEST_A}\n"
+        "  comparison:\n"
+        "    last_attested: 2026-08-31\n"
+        "    sources:\n"
+        "      - url: https://example.com/b\n"
+        "        shows: what b still does\n"
+        "        accessed: 2026-08-31\n"
+        f"        content_sha256: {DIGEST_B}\n"
+    )
+    monkeypatch.setattr(mod, "ROOT", tmp_path)
+
+    found = {(s.axis, s.url, s.digest) for s in mod.load_sources()}
+    assert found == {
+        ("capability", "https://example.com/a", DIGEST_A),
+        ("capability.comparison", "https://example.com/b", DIGEST_B),
+    }


### PR DESCRIPTION
Exercises the mechanism from #439 on the backlog that motivated it. Stacks on
`carl/comparison-edge-attestation`; retarget to `main` once #439 merges.

## What was attested

Twelve edges the shakedown tranches (#431, #432, #433) dropped for freshness, all of whose
arithmetic already held against the peers' current scores:

| dependent | peer | relation |
|---|---|---|
| miles | verl | one_below |
| areal | openrlhf | at |
| xtuner | megatron-lm | one_below |
| paddle | pytorch | at |
| mlx | openvino | at |
| pytorch-lightning | accelerate | at |
| private-gpt | anythingllm | at |
| qwenpaw | anythingllm | at |
| deepchat | anythingllm | at |
| airi | sillytavern | at |
| risuai | sillytavern | at |
| ogam | jan | at |

Nine peers, nine fetches through `build.fetch_source`, all HTTP 200. One fetch serves every
edge against the same peer, so anythingllm covers three and sillytavern two. Each body was
read and the discriminating claim checked against what the peer's `value` records:

- **verl** — Key Features still lists PPO, GRPO, GSPO, ReMax, REINFORCE++, RLOO, PRIME, DAPO
  and DrGRPO plus supervised fine-tuning, still wider than the PPO and GRPO Miles documents.
- **openrlhf** — the estimator table still lists PPO, REINFORCE++, REINFORCE++-baseline, GRPO,
  RLOO and Dr. GRPO over Ray + vLLM + DeepSpeed ZeRO-3 at 70B+.
- **megatron-lm** — composable TP/PP/DP/EP/CP with FP16/BF16/FP8/FP4, 462B on 6,144 H100 GPUs
  at 47-48% MFU, GPT-3 strong-scaled 96 to 4,608 GPUs.
- **pytorch** — tensor computation with strong GPU acceleration on a tape-based autograd system.
- **openvino** — conversion from PyTorch, TensorFlow, ONNX, Keras, PaddlePaddle and JAX/Flax,
  inference on CPU, Intel integrated and discrete GPU, and Intel NPU.
- **accelerate** — "abstracts exactly and only the boilerplate code related to multi-GPUs/TPU/fp16".
- **anythingllm** — multi-user permissioning, a no-code agent builder with web browsing,
  scheduled tasks, around forty LLM providers and eight vector databases.
- **sillytavern** — one interface for many LLM APIs, Visual Novel Mode, image generation, TTS,
  WorldInfo lorebooks, extensions, and still no multi-user surface.
- **jan** — local GGUF models, cloud providers, custom assistants, an OpenAI-compatible server
  on localhost:1337, MCP, single-user desktop.

**No edge was held.** Every peer's recorded value still holds, so no score moved and nothing
was routed to a refresh pass.

## Peers re-dated, and why that is legitimate

`docs/reference/capability.md`'s rule is that an attestation may not re-date the peer's own axis as a
side effect, with one exception: where the read covered *every* source that axis cites, the
peer really has been re-derived. Five peers cite exactly one capability source and their read
was the whole axis, so they carry a new `capability.last_verified` and their source entry
carries the accessed date, status and digest from this fetch:

`openrlhf`, `accelerate`, `openvino`, `anythingllm`, `sillytavern`.

Two more qualified on source count and were deliberately **not** re-dated. `verl` and
`pytorch` are themselves dependents — `verl at megatron-lm`, `pytorch at tensorflow` — so
moving their axis dates to today made them outrun their own peers and `check_capability`
failed on both. Attesting those two upstream edges would have meant reading tensorflow, which
is outside this pass. Their dates stay where they were; the fetches are cited on the dependent
edges, where they belong, and the mechanism does the rest. The plan's estimate of "nine peers
get a free re-date" did not account for peers that are also dependents.

`megatron-lm` (three sources) and `jan` (two) were never candidates, as planned.

One correction fell out of the openrlhf read: its capability `shows` described Molt as a new
experimental backend "not yet the primary path". The README now presents it as a New Backend
callout described as more powerful than DeepSpeed, while the Architecture Foundation section
is still Ray + vLLM + DeepSpeed. The extract now says what the served body says. The band is
unchanged at 4.

Three notes lost a trailing clause that had become false: paddle, mlx and pytorch-lightning
each explained that the comparison was stated in prose rather than recorded as `relative_to`
because no peer had been confirmed recently enough. It is recorded now.

A follow-up commit tightens three extracts after review: American spelling in the miles and
areal extracts, and the paddle extract no longer asserts distributed execution, which the
PyTorch README does not claim outside an install note about Windows prototype support.

## Fan-out

Twelve of the fourteen products added that week move from the periphery into the comparison
graph. `anythingllm` goes 0 to 3 dependents, `sillytavern` 0 to 2. `ai-toolkit at onetrainer`
is deliberately excluded: `onetrainer` already records `at ai-toolkit`, and writing the inverse
would create a reciprocal cycle nothing detects yet.

## Gates

```
capability-anchors  a recorded comparison that does not hold  [OK]
  193 of 553 products record a comparison
  193 comparison(s) recorded, 12 attested, 181 resting on their root's axis date
```

The re-judge queue prints nothing, so it is empty: no attested edge has a peer that has been
re-read since the spacing was judged.

`uv run python -m build.validate` prints 0 error(s). `uv run python -m build.preflight` passes
all 14 locally-runnable CI steps. `uv run python -m pytest tests/` is 1,272 passed.

The `axis_assessments` golden moved and is updated in this commit. The delta was checked row
by row against HEAD: exactly 17 rows differ, all `capability`, all on products this PR touches
— 12 gaining `relative_to=X;relation=Y;attested=DATE` in `basis_detail` and 5 moving
`last_verified`. Row count stays 1,659 and no `score` field changed.

## Stage impact

**None, anywhere.** The serialized payload was diffed before and after: every category's
`stage`, `gaps`, and every product's capability score and blended maturity are byte-identical.
Attestation and a peer re-date that confirms an unchanged value cannot move a score, and this
pass moved none.
