### PR TITLE
Adoption-channel authority: keep policy A, gate the under-coverage ladder (#435)

### DIFF
--- a/.github/workflows/channel-authority.yml
+++ b/.github/workflows/channel-authority.yml
@@ -1,0 +1,64 @@
+name: channel-authority
+
+# Is the channel a band was read off still the channel the product ships through?
+#
+# `select_route` keeps the authoritative usage route ahead of stars, which is what stopped a
+# star count overstating use. #435 asked whether a verified but non-primary channel should
+# abstain instead; it should not, because abstention moves no published number. What it left
+# open is the case the issue was right about: a band read off a registry release line nobody
+# has published to in a year. `docs/reference/adoption.md`'s under-coverage ladder already says
+# what to do with one; nothing checked that anybody did it. The reasoning is in
+# build/check_channel_authority.py.
+#
+# Two legs. The prose leg reads the corpus and is pinned by a test, so it runs on every PR
+# through the pytest suite and needs nothing here. The release-line leg reads the live PyPI
+# JSON API and the GitHub releases/tags API, which is what --live turns on and why this is a
+# schedule rather than a PR check: it fails on the passage of a release, not on the diff in
+# front of you, and an outside contributor could not clear it from inside their own PR.
+#
+# Weekly, on Monday, for the reason parity.yml records: a gate's cadence has to match the
+# chain it polices, and this one reads a line that moves when a project cuts a release. Placed
+# at 09:00, after the signal refreshes at 07:00 and the age gate at 08:00, so the week's
+# adoption worklist arrives in one place.
+#
+# Report-only. `--strict` exists and CI does not pass it yet: seven products currently fire the
+# release-line leg and fifteen the prose leg, and a gate that fails on the day it lands gets
+# switched off rather than fixed. Turn it on once the findings hold at zero.
+#
+# GITHUB_TOKEN is the built-in Actions token here, used only to raise the GitHub API rate limit
+# above the 60/hour an unauthenticated caller gets. 146 pypi-routed products need more than
+# that, and an exhausted limit reads as "no repository tag" — which the module treats as no
+# evidence rather than as a finding, so the failure would be a silently shrinking report.
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+    inputs:
+      strict:
+        description: "Exit non-zero on any finding"
+        type: boolean
+        default: false
+
+jobs:
+  channel-authority:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --locked
+      - name: Check every banded channel against the release line it was read off
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          # Through the environment rather than interpolated into the script body: an input
+          # expanded inline is substituted before the shell parses the line.
+          STRICT: ${{ inputs.strict }}
+        run: |
+          if [ "$STRICT" = "true" ]; then
+            uv run python -m build.check_channel_authority --live --strict
+          else
+            uv run python -m build.check_channel_authority --live
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,8 @@ Editing library    components, the only supported way to edit openness.component
 
 Gates              check_*, one module per question. Four families:
                      scoring    check_rubric, check_recipe, check_capability, check_adoption,
-                                check_instrument, check_components
+                                check_instrument, check_components,
+                                check_channel_authority
                      evidence   check_verification, check_freshness, check_refetch
                      payload    check_payload, check_retirement, check_parity
                      coverage   check_routing, check_artifacts

--- a/build/check_channel_authority.py
+++ b/build/check_channel_authority.py
@@ -1,0 +1,444 @@
+"""Report a band read off a distribution channel that has stopped carrying the product.
+
+`select_route` picks the highest-precedence declared artifact and, once an authoritative
+usage route exists, forbids falling through to `stars_fallback`. That rule is what stopped a
+large star count overstating use, which is the direction ~45 corrections all ran in during
+the August adoption sweep, and it stays. #435 asked whether a verified but non-primary
+channel should keep winning or abstain instead. It keeps winning: abstention moves no
+published number, because `_stage_and_gaps` reads `L` off a >= 4.5 count and `B` off a
+`max()`, and the trigger only ever fires at the bottom of the distribution.
+
+What the answer leaves open is the thing #435 was actually right about. A band read off a
+registry release nobody has published to in a year is a real number about the wrong thing,
+and `docs/reference/adoption.md`'s under-coverage ladder already says what to do with one.
+Until now nothing checked that anybody did it. This is that check.
+
+## Two legs, because there are two ways to see the same defect
+
+  1. **The release line.** The newest release on the registry is at least one stable major
+     line behind the repository's newest stable release or tag. That is mechanical: two
+     public APIs, two version strings, one comparison. It is the ONLY form of "demonstrably
+     non-primary" that can be audited, and it is narrow — a stale release line, not primacy
+     in general.
+  2. **The note.** A record whose own prose says the signal understates (or is inflated by CI
+     and mirror traffic) with a band recorded on that signal anyway. That tell is named in
+     `adoption.md` and implemented in `build/sweep_status.py`; it is imported here rather
+     than restated, so the two cannot drift.
+
+The legs agree on the cases that motivated #435 and disagree with the ratio test that
+motivated the issue's framing, which is the useful result. Both catch `areal` and `xtuner`.
+Neither catches `qwenpaw`, whose PyPI release `2.2.0b5` was uploaded the same day as the repo
+tag `v2.2.0-beta.5` — its registry is exactly current and only its downloads-to-stars ratio
+looked wrong. Neither catches `atropos`, a dormant project accurately measured.
+
+## What is deliberately excluded
+
+  * **A pre-release repo tag.** A beta ahead of the registry is ordinary publishing, not a
+    trailing channel, so a repo tag carrying `a`/`b`/`rc`/`alpha`/`beta`/`dev`/`preview` is
+    reported as an exclusion rather than a finding. Excluding it is what keeps `qwenpaw`
+    clear. Four records are excluded this way today — `flash-attention`, `khoj`, `lance`,
+    `mineru` — and the report prints the list, so this docstring does not become a second
+    copy of a count that moves.
+  * **A repo tag that does not parse to a version.** Date stamps, model names, per-package
+    monorepo tags. Undecidable is not clean: the comparison could not be made, and saying so
+    is different from saying there is no lag. Two records today: `chroma` and `mlflow`, both
+    tagging `latest`.
+  * **Everything that is not a registry channel.** A Hugging Face model or dataset repo IS
+    the artifact; there is no registry-version-against-source-version gap to measure, which
+    puts four categories out of leg 1's reach entirely. npm and crates are unbridged.
+  * **The downloads-against-stars ratio.** Computable, and wrong. The precedence rule exists
+    to stop stars setting a band; a test that lets stars decide whether a usage measurement
+    counts hands stars a veto instead of a vote, which is the closed failure re-entering one
+    level up.
+
+**This split is not the one the #435 simulation reported, on purpose.** The simulation had
+three pre-release exclusions and fourteen undecidable where this gate has four and two, and the
+difference is two widenings rather than a disagreement: this gate falls back to `/tags` where a
+repository publishes no releases at all, which reaches a verdict on most of the simulation's
+undecidable products instead of abandoning them, and `parse_version` reads a version out of a
+decorated tag like `fa4-v4.0.0.beta28`, which the simulation left unparsed. **The seven fires
+are identical** — `areal`, `gpt-researcher`, `langtrace`, `openlit`, `sageattention`,
+`swe-agent`, `xtuner` — and the fires are the part any ruling rests on.
+
+## Report, never re-band
+
+The same instruction #426 carries, for the same reason. A trailing channel and a monorepo
+versioning its application separately from its pip package are indistinguishable from here, and
+only one of them is a finding: `openlit` tags `openlit-2.0.0` and `gpt-researcher` versions an
+app three lines ahead of its package. Nothing available decides which is which, and re-banding
+on a guess attaches a level to a judgment nobody made.
+
+Report-only also because the direction of the error matters. Applied to the prose tell as
+written, abstention erases `gvisor` — level 5 on container distribution its note describes
+honestly — and demotes `deployment` from stage 5 to 4 on the strength of a candid note. A
+gate that punishes candor gets its notes rewritten rather than its bands fixed.
+
+Ships non-strict, per this repo's convention (`check_adoption`, `check_instrument`,
+`check_artifacts`). `--strict` is what CI passes once the backlog is clear.
+
+Usage:
+    uv run python -m build.check_channel_authority           # the prose leg, no network
+    uv run python -m build.check_channel_authority --live    # add the release-line leg
+    uv run python -m build.check_channel_authority --strict  # exit 1 on any finding
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import time
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import yaml
+
+from build.adoption_measurements import all_routes, load_inputs, route_scopes, select_route
+from build.propose_artifacts import _get_json, check_token
+from build.serialize_registry import artifact_id
+from build.sweep_status import under_coverage
+
+# Stay polite across a few hundred calls, the same pace propose_artifacts uses for the same
+# APIs. Leg 1 makes up to three requests per pypi-routed product (one PyPI, one releases, one
+# tags fallback), so a full run is a few hundred requests rather than a handful.
+_PACE_SECONDS = 0.12
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# A repo tag that is a pre-release of a line the registry has not reached yet. Matched on the
+# suffix rather than by full PEP 440 parsing, because a GitHub tag is not a PEP 440 version:
+# `v2.2.0-beta.5`, `v12.0.0-beta.6`, `v4.0.0a6` and `2.0.0-beta.28` are all real tags in this
+# corpus and only the third would parse.
+#
+# The digit lookbehind is load-bearing rather than defensive. A word-boundary alternative
+# reads `v4.0.0a6` as stable, because `0` and `a` are both word characters and there is no
+# boundary between them - which put MinerU's alpha tag in the findings as a whole major line
+# ahead of its registry, the exact false positive this exclusion exists to prevent.
+_PRERELEASE = re.compile(
+    r"(?:[-_.]|(?<=\d))(?:a|b|c|rc|alpha|beta|dev|pre|preview|nightly|snapshot)\.?\d*$",
+    re.IGNORECASE,
+)
+_VERSION = re.compile(r"(?:^|[^0-9])v?(\d+)\.(\d+)(?:\.(\d+))?")
+
+# An instrument other than `usage_volume` is not banding on the registry count, so a trailing
+# release line says nothing about the level it carries. Those are the records the ladder has
+# already been applied to.
+_BANDS_ON_THE_REGISTRY = "usage_volume"
+
+
+def is_prerelease(tag: str) -> bool:
+    """True when a tag names a pre-release of the line it belongs to."""
+    return bool(_PRERELEASE.search((tag or "").strip()))
+
+
+def parse_version(tag: str) -> tuple[int, int, int] | None:
+    """(major, minor, patch) from a tag, or None when it does not carry a version.
+
+    None is a real answer and is reported as undecidable rather than folded into "clear".
+    A tag like `2026-08-01` or `openlit-2.0.0` is not evidence of an absent lag; it is
+    evidence that this comparison could not be made.
+    """
+    matched = _VERSION.search((tag or "").strip())
+    if not matched:
+        return None
+    return (int(matched.group(1)), int(matched.group(2)), int(matched.group(3) or 0))
+
+
+def lag_verdict(pypi_version: str, repo_tag: str) -> tuple[str, int]:
+    """(verdict, majors behind) for one registry version against one repository tag.
+
+    Verdicts: `fires`, `clear`, `prerelease`, `undecidable`. Stable against stable, and
+    strictly on the major line — a minor or patch lag is ordinary release cadence, and a
+    threshold looser than a whole major would fire on most of the corpus.
+    """
+    registry, source = parse_version(pypi_version), parse_version(repo_tag)
+    if registry is None or source is None:
+        return ("undecidable", 0)
+    behind = source[0] - registry[0]
+    if behind <= 0:
+        return ("clear", 0)
+    if is_prerelease(repo_tag):
+        # Reported only where it would otherwise have fired: a pre-release tag on a line the
+        # registry already carries is not an exclusion, it is simply clean.
+        return ("prerelease", behind)
+    return ("fires", behind)
+
+
+def pypi_routed(root: Path | None = None) -> dict[str, str]:
+    """slug -> declared package, for every product whose winning adoption route is PyPI."""
+    tables, _bands, category_of, declared, recorded = load_inputs(root or ROOT)
+    routes, scopes = all_routes(tables), route_scopes(tables)
+    base = root or ROOT
+    out: dict[str, str] = {}
+    for slug in sorted(declared):
+        route = select_route(
+            declared[slug], recorded.get(slug), category_of.get(slug), routes, scopes
+        )
+        if not route or route.get("artifact_kind") != "pypi":
+            continue
+        product = _load(base / "sources" / "products" / f"{slug}.yaml")
+        for entry in product.get("pypi") or []:
+            ident = artifact_id("pypi", entry.get("url") or "")
+            if ident:
+                out[slug] = ident
+                break
+    return out
+
+
+def _load(path: Path) -> dict:
+    return (yaml.safe_load(path.read_text()) or {}) if path.exists() else {}
+
+
+def declared_repo_id(slug: str, root: Path | None = None) -> str | None:
+    """`owner/repo` for the product's first declared GitHub artifact.
+
+    Named `_id` rather than `declared_repo` because `propose_artifacts.declared_repo` already
+    exists and answers a different question — what a PACKAGE's metadata claims, not what the
+    product record declares. Two functions with one name and opposite inputs is how a wrong
+    repository gets attached to a product.
+    """
+    product = _load((root or ROOT) / "sources" / "products" / f"{slug}.yaml")
+    for entry in product.get("github") or []:
+        ident = artifact_id("github", entry.get("url") or "")
+        if ident:
+            return ident
+    return None
+
+
+def newest_pypi_release(package: str) -> tuple[str, str] | None:
+    """(version, ISO upload timestamp) for the package's newest release, or None.
+
+    Read off the release history rather than off `info.version`, because the upload date is
+    half the finding: "one major behind" and "one major behind for four hundred days" are
+    different sentences to a reviewer.
+    """
+    body = _get_json(f"https://pypi.org/pypi/{package}/json", None)
+    if not body:
+        return None
+    version = ((body.get("info") or {}).get("version") or "").strip()
+    if not version:
+        return None
+    uploaded = ""
+    for file_entry in (body.get("releases") or {}).get(version) or []:
+        stamp = file_entry.get("upload_time_iso_8601") or file_entry.get("upload_time") or ""
+        if stamp and (not uploaded or stamp < uploaded):
+            uploaded = stamp
+    return (version, uploaded)
+
+
+def newest_repo_tag(repo: str, token: str | None = None) -> str | None:
+    """The repository's newest release tag, falling back to its newest git tag.
+
+    Releases first: a release carries an explicit publication order, where `/tags` does not
+    and a repository that tags without releasing is common enough to need the fallback.
+    `/releases` is ordered by creation, NOT by version, so the first entry is the most
+    recently cut release and not necessarily the highest version — a backport to an older
+    line published today would come back ahead of the current major.
+
+    **The `prerelease` flag on the release is discarded on purpose.** GitHub's flag is a
+    checkbox the publisher ticks; the version string is the release's own semantic claim, and
+    `lag_verdict` compares strings. The case that decides it is `xtuner`, whose `v1.0.1` is
+    flagged `prerelease: true` while its README documents XTuner V1 as the current release and
+    the registry sits on `0.2.0`. Honoring the flag would call that registry current, which is
+    the opposite of what the project's own documentation says. `qwenpaw` is protected by the
+    string test instead (`v2.2.0-beta.5`), which is where the protection belongs. Reading the
+    flag would flip both, so do not "tidy" this into the return value without re-deciding it —
+    `tests/test_check_channel_authority.py` pins the boundary.
+    """
+    releases = _get_json(f"https://api.github.com/repos/{repo}/releases?per_page=1", token)
+    if isinstance(releases, list) and releases:
+        tag = (releases[0].get("tag_name") or "").strip()
+        if tag:
+            return tag
+    time.sleep(_PACE_SECONDS)
+    tags = _get_json(f"https://api.github.com/repos/{repo}/tags?per_page=1", token)
+    if isinstance(tags, list) and tags:
+        return (tags[0].get("name") or "").strip() or None
+    return None
+
+
+def _age_days(uploaded: str, today: date | None = None) -> int | None:
+    if not uploaded:
+        return None
+    try:
+        when = datetime.fromisoformat(uploaded.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    reference = today or datetime.now(timezone.utc).date()
+    return (reference - when.astimezone(timezone.utc).date()).days
+
+
+def release_lines(root: Path | None = None, token: str | None = None) -> dict:
+    """Leg 1, live. `{fires, prerelease, undecidable, considered, skipped}`.
+
+    The three lists hold per-product rows. `considered` is the population — every pypi-routed
+    product — and `skipped` counts the ones no verdict could be reached for, broken down by
+    which lookup came back empty.
+
+    A product whose package or repository could not be read is not a finding: a transport
+    failure is not evidence of a trailing channel, and treating it as one would make the count
+    a function of PyPI's availability. But it is not nothing either, and the first draft
+    dropped it silently. A run degraded by 503s or an exhausted rate limit then reports fewer
+    findings and looks *healthier* than a clean one, which is the worst failure mode a report
+    can have. So the skips are counted and printed against the denominator.
+    """
+    base = root or ROOT
+    scores = base / "sources" / "scores"
+    routed = pypi_routed(base)
+    out: dict = {
+        "fires": [], "prerelease": [], "undecidable": [],
+        "considered": len(routed),
+        "skipped": {"declare no repository": 0, "package unreadable": 0, "repository unreadable": 0},
+    }
+    for slug, package in routed.items():
+        repo = declared_repo_id(slug, base)
+        if not repo:
+            out["skipped"]["declare no repository"] += 1
+            continue
+        release = newest_pypi_release(package)
+        if not release:
+            out["skipped"]["package unreadable"] += 1
+            continue
+        version, uploaded = release
+        time.sleep(_PACE_SECONDS)
+        tag = newest_repo_tag(repo, token)
+        if not tag:
+            out["skipped"]["repository unreadable"] += 1
+            continue
+        time.sleep(_PACE_SECONDS)
+        verdict, behind = lag_verdict(version, tag)
+        if verdict == "clear":
+            continue
+        adoption = (_load(scores / f"{slug}.yaml").get("adoption") or {})
+        row = {
+            "slug": slug,
+            "package": package,
+            "version": version,
+            "repo": repo,
+            "tag": tag,
+            "behind": behind,
+            "age_days": _age_days(uploaded),
+            "instrument": adoption.get("signal_type") or "",
+            "banded_quantity": adoption.get("banded_quantity") or "",
+        }
+        out["prerelease" if verdict == "prerelease" else
+            "undecidable" if verdict == "undecidable" else "fires"].append(row)
+    return out
+
+
+def skipped_total(legs: dict) -> int:
+    return sum((legs.get("skipped") or {}).values())
+
+
+def unremedied(fires: list[dict]) -> list[dict]:
+    """Release-line fires whose band still rests on the registry count, unremedied.
+
+    `docs/reference/adoption.md`'s ladder offers two remedies and this recognizes both, because
+    a gate that advertises two and accepts one is a gate that flags a fixed product forever.
+
+      * **Relabel.** A record on an instrument other than `usage_volume` no longer claims to be
+        a download count of the product, so the trailing line says nothing about its level.
+      * **Name the quantity.** A `banded_quantity` says what the figure actually counts, which
+        is the whole remedy for the `langflow` and `semantic-kernel` shape — the band stands, a
+        reader can see what stands behind it, and nobody is misled by a precise number about
+        the wrong channel.
+
+    The second is taken at face value: nothing here can read a `banded_quantity` and judge
+    whether it describes the release line honestly. That is why the report still prints EVERY
+    fire and marks only the unremedied ones — the remedied rows stay visible for a reviewer,
+    they just stop counting as findings.
+    """
+    return [
+        row for row in fires
+        if row["instrument"] == _BANDS_ON_THE_REGISTRY and not row.get("banded_quantity")
+    ]
+
+
+REMEDY = (
+    "Remedy, per docs/reference/adoption.md's under-coverage ladder: either record a\n"
+    "  `banded_quantity` naming what the figure actually counts (a trailing release line, a\n"
+    "  minority channel, a lifetime average admitted as a floor), or relabel the record\n"
+    "  `reported_traction` with `reach` null and a digested source behind the level. Never\n"
+    "  substitute the star count: the precedence rule exists to stop that."
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--live", action="store_true",
+                        help="add the release-line leg, which reads PyPI and the GitHub API")
+    parser.add_argument("--strict", action="store_true", help="exit 1 on any finding")
+    args = parser.parse_args()
+
+    findings = 0
+    fires: list[dict] = []
+
+    if args.live:
+        # The rate limit is the difference between a short report and a wrong one. Leg 1 makes
+        # up to three calls per product; unauthenticated GitHub allows 60 an hour, and an
+        # exhausted limit returns an error body that reads here as "no repository tag" — a
+        # skip, not a finding. So the report would quietly shrink rather than fail.
+        token = check_token(os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN"))
+        if not token:
+            print("warning: no working GITHUB_TOKEN. GitHub allows 60 unauthenticated requests")
+            print("an hour and this leg needs a few hundred, so most repositories will come back")
+            print("unreadable and be counted as skipped rather than checked. Read the skipped")
+            print("line below before trusting the findings.\n")
+        legs = release_lines(ROOT, token)
+        fires, flagged = legs["fires"], unremedied(legs["fires"])
+        marked = {row["slug"] for row in flagged}
+        findings += len(flagged)
+        checked = legs["considered"] - skipped_total(legs)
+        print(f"{len(fires)} pypi-routed product(s) publish a release line at least one stable")
+        print(f"major behind their repository; {len(flagged)} still band on that registry count.")
+        print(f"{checked} of {legs['considered']} pypi-routed products were readable"
+              + (f" ({skipped_total(legs)} skipped: "
+                 + ", ".join(f"{n} {k}" for k, n in legs["skipped"].items() if n) + ")"
+                 if skipped_total(legs) else "") + ".\n")
+        for row in sorted(fires, key=lambda r: r["slug"]):
+            age = f"{row['age_days']}d" if row["age_days"] is not None else "age unknown"
+            mark = "~" if row["slug"] in marked else " "
+            print(f"  {mark} {row['slug']:<22} {row['package']}=={row['version']} "
+                  f"({age}) vs {row['repo']} {row['tag']} — {row['behind']} major(s) behind, "
+                  f"{row['instrument'] or 'no instrument'}")
+        if legs["prerelease"]:
+            print(f"\n{len(legs['prerelease'])} excluded: the repository's newest tag is a "
+                  "pre-release, which is")
+            print("ordinary publishing rather than a trailing channel.")
+            for row in sorted(legs["prerelease"], key=lambda r: r["slug"]):
+                print(f"    {row['slug']:<22} {row['package']}=={row['version']} vs {row['tag']}")
+        if legs["undecidable"]:
+            print(f"\n{len(legs['undecidable'])} undecidable: the repository's newest tag does "
+                  "not parse to a version, so")
+            print("no comparison was made. Not the same as no lag.")
+            for row in sorted(legs["undecidable"], key=lambda r: r["slug"]):
+                print(f"    {row['slug']:<22} {row['package']}=={row['version']} vs {row['tag']!r}")
+        print()
+    else:
+        print("release-line leg skipped; pass --live to read PyPI and the GitHub API.\n")
+
+    prose = under_coverage()
+    findings += len(prose)
+    print(f"{len(prose)} measured band(s) whose own note says the signal does not measure the")
+    print("product, with a band recorded on that signal anyway.\n")
+    for slug, direction, phrase in sorted(prose):
+        print(f"  ~ {slug:<28} {direction:<12} {phrase!r}")
+
+    print(f"\n{REMEDY}")
+    print("\nReport-only unless --strict. Nothing here re-bands a product.")
+    if args.live and fires:
+        # No count and no classification here on purpose. An earlier draft narrated "five of
+        # the seven read as trailing channels and two look like a monorepo", which is a copy of
+        # a count that drifts on the next release AND a judgment this module cannot make. The
+        # heuristic that would derive it (does the tag look package-scoped) is a guess wearing a
+        # derivation's clothes, which is worse than saying plainly that a human decides.
+        print(f"Each of the {len(fires)} release-line fire(s) needs a person: a trailing channel")
+        print("and a monorepo versioning its application apart from its package look identical")
+        print("from here, and only one of them is a finding.")
+    return 1 if findings and args.strict else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/operations/deploy-models.md
+++ b/docs/operations/deploy-models.md
@@ -79,6 +79,7 @@ holds it against the `cron:` lines it quotes.
 | `parity` gate | Monday 06:00 | `.github/workflows/parity.yml` |
 | `artifacts` | Monday 07:00 | `.github/workflows/artifacts.yml` |
 | `freshness` report | Monday 08:00 | `.github/workflows/freshness.yml` |
+| `channel-authority` report | Monday 09:00 | `.github/workflows/channel-authority.yml` |
 
 The chain lands two hours before parity grades it, and the warehouse is at most a week behind
 the repo.

--- a/docs/reference/adoption.md
+++ b/docs/reference/adoption.md
@@ -472,6 +472,57 @@ floor and its note says so.
 The tell to look for when reviewing: **a note that describes the signal as understating the
 product, followed by a band recorded on that signal anyway.**
 
+### The gate: `build/check_channel_authority.py`
+
+The ladder above was a habit for its first two weeks, and habits are not applied evenly. Eight
+products had already taken remedy 3 — `helm`, `laminar`, `swe-bench` and five others record
+`reported_traction` with `reach` omitted while their winning route is a bridged usage channel —
+and nothing said whether the ones that had not were exceptions or oversights. The gate is what
+makes the ladder answerable.
+
+It reports two legs and re-bands nothing.
+
+1. **The release line.** For every pypi-routed product, the newest release on the registry
+   against the repository's newest release or tag. A registry at least one **stable major line**
+   behind is a band read off a version nobody is on. Stable against stable: a pre-release repo
+   tag is a beta ahead of the registry, which is ordinary publishing, and is listed as an
+   exclusion. A repo tag that does not parse to a version is listed as undecidable, which is not
+   the same as no lag.
+2. **The note**, which is the tell above, imported from `build/sweep_status.py` rather than
+   restated so the two cannot drift.
+
+A finding leaves the report when the record stops resting on the channel: a `banded_quantity`
+naming what the figure actually counts, or a relabel to `reported_traction` with `reach` null
+and a digested source behind the level. Substituting the star count is not a remedy, and the
+precedence rule exists to stop it.
+
+**A relabel moves the instrument and nothing else.** "When a re-read may re-band" above already
+says it — move it to `reported_traction`, drop the numeric `reach`, and *leave the level alone*
+— and the temptation runs the other way every time, because the record now looks unjustified
+without a number under it. `areal` and `xtuner` are the worked examples: both correct a
+`usage_volume` claim made over a trailing release line, both keep level 1, and both say in the
+note that raising the level would be a separate judgment needing its own standing evidence. The
+only other signal either has is its star count, which is exactly what the gate's own remedy text
+forbids substituting. A relabel that also raises the level is policy C arriving through the back
+door, one product at a time.
+
+**Why it reports rather than abstains**, which is the #435 answer in one line: abstention moves
+no published number — `_stage_and_gaps` reads `L` off a count at ≥ 4.5 and `B` off a `max()`,
+and this trigger only ever fires at the bottom of a distribution — while applied to the prose
+tell as written it erases `gvisor`'s real adoption and demotes `deployment` from stage 5 to 4 on
+the strength of an honest note. Understating remains the safer error; the remedy is to say what
+was counted, not to stop counting.
+
+**The narrowness is the point.** Leg 1 is the only mechanical form of "this channel is not how
+the product ships", and it is undefined for a Hugging Face model or dataset, where the repo IS
+the artifact. The ratio test it replaces — downloads an order below stars — was rejected for
+handing stars a veto over a usage measurement, which is the overstatement failure re-entering
+one level up. `qwenpaw` is the case that settles it: its PyPI release was uploaded the same day
+as its repo tag, and only the ratio ever looked wrong.
+
+Report-only, weekly on the Monday chain (`.github/workflows/channel-authority.yml`), because it
+reads a live release line and a gate's cadence has to match the thing it polices.
+
 ## The third trap: the package that is not the product
 
 Both traps above are about ATTRIBUTION - a real count of the product credited to the wrong
@@ -536,6 +587,9 @@ category rather than a defect in it. Docker pull counts would fix most of them; 
 - [ ] The band follows from the figure in the note, in the same direction and order of
       magnitude.
 - [ ] No band was copied from a computed signal — those are observations, not scores.
+- [ ] The registry release the band was read off is on the line the repository is publishing.
+      `check_channel_authority --live` asks this; a band a whole major line behind needs the
+      under-coverage ladder applied to it.
 
 ## Related
 

--- a/sources/scores/areal.yaml
+++ b/sources/scores/areal.yaml
@@ -40,19 +40,36 @@ openness:
     - core-gated
 adoption:
   level: 1
-  reach: <10K
-  signal_type: usage_volume
+  signal_type: reported_traction
   confidence: medium
-  banded_quantity: 45 PyPI downloads in the last 30 days for the areal package
-  note: Banded on the authoritative PyPI route rather than on stars, which the routing table ranks below every real
-    usage signal. The figure is small - 45 downloads in 30 days against 5,705 GitHub stars - because this project
-    is consumed by cloning and installing from source rather than from the registry. Recording the authoritative
-    measurement understates reach; substituting the larger star count would overstate use, and the routing table
-    forbids falling through to a weaker signal when an authoritative one exists.
+  banded_quantity: 45 monthly downloads of areal 1.0.4, a release line the repository left behind at v2.1.0 -
+    a count of a superseded version rather than a count of use
+  note: 'What changed here is the instrument, not the level. The PyPI package publishes 1.0.4, uploaded 2026-06-10
+    and the only release the project has ever made, against repository release v2.1.0 of 2026-08-25 - a whole
+    major line, so anyone on the current version reached it another way and a download count off that line
+    measures a superseded release. A usage_volume record claims to be a download count of the product; this one
+    was a download count of a version the project has moved past, which is the wrong claim rather than a wrong
+    number. The record therefore states no count: reported_traction, no numeric reach, and the 45 downloads kept
+    only as corroboration of the trailing channel. The level is deliberately left where the earlier reading put
+    it. Raising it is a separate judgment needing its own standing evidence, and the only other signal available
+    is the star count, which the routing precedence exists to keep out of an adoption band.'
   last_verified: '2026-08-31'
   sources:
+  - url: https://pypi.org/pypi/areal/json
+    shows: 'info.version 1.0.4 with a single entry in `releases`, uploaded 2026-06-10T06:48:31Z. The package has
+      made no other release, so the registry line has never moved past 1.x while the repository is on 2.1.0.'
+    accessed: '2026-08-31'
+    http_status: 200
+    content_sha256: 0d186632b2f12deeeefad7706aba8dd5287a71e0e8982ead3ea3550fcc815792
+  - url: https://api.github.com/repos/areal-project/AReaL/releases/latest
+    shows: 'tag_name v2.1.0, published_at 2026-08-25T10:23:59Z, prerelease false - the current stable release
+      line, one major above the sole PyPI release.'
+    accessed: '2026-08-31'
+    http_status: 200
+    content_sha256: e3f5128c637992ae56bac603d35bac1dd6659bc922aa492c0123090eeb4491d1
   - url: https://pypistats.org/api/packages/areal/recent
-    shows: last_month 45, last_week 9, last_day 3 for the areal package.
+    shows: last_month 45, last_week 9, last_day 3 for the areal package. Recorded as a measurement of the trailing
+      registry line, explicitly NOT as the basis of the band.
     accessed: '2026-08-31'
     http_status: 200
     content_sha256: c199dbab35142f6ab9d8cbf15f7e1aaef408b6bbf3b716110eca5a9fb42ae7bc

--- a/sources/scores/xtuner.yaml
+++ b/sources/scores/xtuner.yaml
@@ -40,19 +40,39 @@ openness:
     - core-gated
 adoption:
   level: 1
-  reach: <10K
-  signal_type: usage_volume
+  signal_type: reported_traction
   confidence: medium
-  banded_quantity: 1,159 PyPI downloads in the last 30 days for the xtuner package
-  note: Banded on the authoritative PyPI route rather than on stars, which the routing table ranks below every real
-    usage signal. The figure is small - 1,159 downloads in 30 days against 5,187 GitHub stars - because this project
-    is consumed by cloning and installing from source rather than from the registry. Recording the authoritative
-    measurement understates reach; substituting the larger star count would overstate use, and the routing table
-    forbids falling through to a weaker signal when an authoritative one exists.
+  banded_quantity: 1,159 monthly downloads of xtuner 0.2.0, a release line 416 days old that the repository left
+    behind at v1.0.1 - a count of a superseded version rather than a count of use
+  note: 'What changed here is the instrument, not the level. The PyPI package publishes 0.2.0, uploaded 2025-07-11
+    and 416 days old, while the repository has since released v1.0.1 on 2026-05-15 and the README documents XTuner
+    V1. The registry never followed the project onto that line, so a count off 0.2.0 measures the version the
+    documentation has moved past. GitHub labels v1.0.1 a pre-release even though the version string reads stable,
+    which is the publisher''s own checkbox rather than a claim about the version; the documented current release
+    is V1 either way. A usage_volume record claims to be a download count of the product, and this one counted a
+    superseded version, which is the wrong claim rather than a wrong number. The record therefore states no count:
+    reported_traction, no numeric reach, and the 1,159 downloads kept only as corroboration of the trailing
+    channel. The level is deliberately left where the earlier reading put it. Raising it is a separate judgment
+    needing its own standing evidence, and the only other signal available is the star count, which the routing
+    precedence exists to keep out of an adoption band.'
   last_verified: '2026-08-31'
   sources:
+  - url: https://pypi.org/pypi/xtuner/json
+    shows: 'info.version 0.2.0, uploaded 2025-07-11T05:43:58Z, newest of 27 releases; nothing on a 1.x line has
+      ever been published to the registry.'
+    accessed: '2026-08-31'
+    http_status: 200
+    content_sha256: 58f1487d059d62f4a3821a2c7f18b1d9d1b4f98ee419ecafce2dd1286fa93fd5
+  - url: https://api.github.com/repos/InternLM/xtuner/releases?per_page=3
+    shows: 'Newest three releases: v1.0.1 published 2026-05-15T06:57:47Z (prerelease true, draft false), v1.0.0rc0
+      of 2025-11-18, and v0.2.0 of 2025-07-11T05:43:37Z - the last release the registry matched, published the
+      same day as the PyPI upload.'
+    accessed: '2026-08-31'
+    http_status: 200
+    content_sha256: fe5b422a23ab5525be418ff584567b4a17b70848a97918b71bc35a5ea41a2419
   - url: https://pypistats.org/api/packages/xtuner/recent
-    shows: last_month 1159, last_week 112, last_day 11 for the xtuner package.
+    shows: last_month 1159, last_week 112, last_day 11 for the xtuner package. Recorded as a measurement of the
+      trailing registry line, explicitly NOT as the basis of the band.
     accessed: '2026-08-31'
     http_status: 200
     content_sha256: 486948dd5e2d3aca93bb6089fdf10282e435b7488525c34ea1cb838968c6d0e2

--- a/tests/test_adoption_evaluation.py
+++ b/tests/test_adoption_evaluation.py
@@ -43,7 +43,10 @@ TEST_DVID = "test-declaration-version"
 
 BASELINE_SNAPSHOT_ID = "9bd4d93a6fc67a2b9d89d91adeb4bb3f4fd9b612cc26e6647c67210c9a37a8d4"
 MEASUREMENTS_DIGEST = "f1ccad234b9e91906b2feb4e9f4d40f82489f4d2d62bb7bb016ac2ae38629742"
-RECONCILIATION_DIGEST = "a9a036c20a69e5e3eea19686855dc51799c1ea5fcff91bc9f6f71e826b811d27"
+# Moved 2026-09-01 by the areal and xtuner relabels (#435): a recorded instrument change
+# is a declaration change, which is one of the four things this digest tracks. Both
+# levels stay where they were.
+RECONCILIATION_DIGEST = "0bdd78f2cb1a40374c6e02d633412b09796ce31e1da26ea8e68d5ae71ac4f69c"
 
 MEASUREMENT_COUNT = 377
 RECORDED_ASSESSMENT_COUNT = 553

--- a/tests/test_axis_assessments.py
+++ b/tests/test_axis_assessments.py
@@ -32,11 +32,15 @@ TEST_DVID = "test-declaration-version"
 TEST_SHA = "test-git-sha"
 
 AXIS_ROW_COUNT = 1659
-# Moved by the #436 attestation pass: 12 capability rows gained
-# `relative_to=X;relation=Y;attested=DATE` in `basis_detail`, and five comparison roots
-# (openrlhf, accelerate, openvino, anythingllm, sillytavern) moved `last_verified` to the day
-# their axis was re-read. No score changed and the row count is unchanged.
-AXIS_ASSESSMENTS_DIGEST = "a4b69eddcec2ad8a907b582d86a2bc574cb8294e9d5bf8792a64542f457fca58"
+# Moved 2026-09-01 by two combined passes: the #436 attestation pass (12 capability rows
+# gained `relative_to=X;relation=Y;attested=DATE` in `basis_detail`, and five comparison
+# roots - openrlhf, accelerate, openvino, anythingllm, sillytavern - moved `last_verified`
+# to the day their axis was re-read) and the areal/xtuner relabels (#435, both adoption
+# axes change instrument, which is a declaration change and exactly what this digest
+# tracks). No score changed and the row count is unchanged; the levels do NOT move - the
+# ladder's rule is to correct the instrument and leave the level to its own evidence - so
+# nothing published follows from either pass.
+AXIS_ASSESSMENTS_DIGEST = "3e19fde04ac90d31f392c5d7cd56b22660a758b45d7c1ff2edff69231dbc26e4"
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_check_channel_authority.py
+++ b/tests/test_check_channel_authority.py
@@ -1,0 +1,208 @@
+"""The channel-authority report: what the release-line comparison decides, and what it flags.
+
+No test here touches the network. The release-line leg is exercised against fixtures — the
+comparison is the part that can be wrong, and the two API calls behind it are not — and the
+prose leg reads the committed corpus, which is where the pinned count lives.
+"""
+from pathlib import Path
+
+from build import check_channel_authority as gate
+from build.check_channel_authority import (
+    is_prerelease,
+    lag_verdict,
+    newest_repo_tag,
+    parse_version,
+    release_lines,
+    skipped_total,
+    unremedied,
+)
+from build.sweep_status import under_coverage
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_a_stable_major_behind_a_stable_major_fires():
+    """`xtuner` as it stood: 0.2.0 on PyPI against v1.0.1 in the repository."""
+    assert lag_verdict("0.2.0", "v1.0.1") == ("fires", 1)
+
+
+def test_the_lag_counts_major_lines():
+    """`gpt-researcher`, three lines behind, which reads differently from one."""
+    assert lag_verdict("0.16.0", "v3.6.1") == ("fires", 3)
+
+
+def test_the_same_major_line_is_clear():
+    """A minor or patch lag is release cadence. Only a whole major line is the finding."""
+    assert lag_verdict("1.45.0", "v1.46.2") == ("clear", 0)
+
+
+def test_a_registry_ahead_of_the_repository_is_clear():
+    assert lag_verdict("3.0.0", "v2.9.1") == ("clear", 0)
+
+
+def test_a_prerelease_repo_tag_is_excluded_rather_than_flagged():
+    """`khoj`: the repo's newest tag is 2.0.0-beta.28 and PyPI is on the 1.x line. A beta
+    ahead of the registry is ordinary publishing, so it is reported as an exclusion."""
+    assert lag_verdict("1.42.10", "2.0.0-beta.28") == ("prerelease", 1)
+
+
+def test_a_prerelease_suffix_with_no_separator_is_still_a_prerelease():
+    """The false positive the exclusion exists to prevent. `v4.0.0a6` has no word boundary
+    between the `0` and the `a`, so a boundary-based test reads MinerU's alpha tag as a
+    stable major line ahead of its registry and flags a product that is publishing normally."""
+    assert is_prerelease("v4.0.0a6")
+    assert lag_verdict("3.4.5", "v4.0.0a6") == ("prerelease", 1)
+
+
+def test_a_prerelease_on_a_line_the_registry_already_has_is_simply_clear():
+    """`qwenpaw`, the case that decided #435. PyPI 2.2.0b5 was uploaded the same day as the
+    repo tag v2.2.0-beta.5: the registry is exactly current, and the only thing that looked
+    wrong about it was a downloads-to-stars ratio, which is the un-auditable half. It is
+    neither a finding nor an exclusion."""
+    assert lag_verdict("2.2.0b5", "v2.2.0-beta.5") == ("clear", 0)
+
+
+def test_an_unparseable_repo_tag_is_undecidable_not_clear():
+    """`chroma` tags `latest` and `mlflow` tags `model-catalog/latest`. The comparison could
+    not be made, which is a different statement from there being no lag - folding it into
+    `clear` would report a silent pass over a product nobody checked."""
+    assert parse_version("latest") is None
+    assert lag_verdict("1.5.9", "latest") == ("undecidable", 0)
+    assert lag_verdict("3.15.2", "model-catalog/latest") == ("undecidable", 0)
+
+
+def test_a_version_embedded_in_a_monorepo_tag_still_parses():
+    """`openlit` tags `openlit-2.0.0`. A per-package monorepo tag carries a real version."""
+    assert parse_version("openlit-2.0.0") == (2, 0, 0)
+
+
+def test_a_two_part_version_parses_with_a_zero_patch():
+    assert parse_version("v4.0") == (4, 0, 0)
+
+
+def test_only_a_record_still_banding_on_the_registry_count_is_flagged():
+    """A fire is a fact about the release line; whether it is a FINDING depends on whether the
+    band rests on that line. `swe-agent` publishes sweagent==0.0.1 against v1.1.0 and is not a
+    finding, because it records `stars_fallback` - its level never followed from the package."""
+    fires = [
+        {"slug": "sageattention", "instrument": "usage_volume", "banded_quantity": ""},
+        {"slug": "swe-agent", "instrument": "stars_fallback", "banded_quantity": ""},
+        {"slug": "helm", "instrument": "reported_traction", "banded_quantity": ""},
+    ]
+    assert [row["slug"] for row in unremedied(fires)] == ["sageattention"]
+
+
+def test_naming_the_quantity_is_the_other_remedy_and_clears_the_flag():
+    """The ladder offers two remedies and the report advertises both, so both must clear.
+
+    `langflow` and `semantic-kernel` are the shape: the band stands on the registry count, and
+    a `banded_quantity` says what that count actually covers so nobody reads a precise number
+    as a measurement of the whole product. A gate that accepted only the relabel would flag a
+    correctly remedied product forever, which is how a report stops being read.
+    """
+    fires = [
+        {"slug": "named", "instrument": "usage_volume",
+         "banded_quantity": "npm downloads only; the Docker channel is larger and uncounted"},
+        {"slug": "silent", "instrument": "usage_volume", "banded_quantity": ""},
+    ]
+    assert [row["slug"] for row in unremedied(fires)] == ["silent"]
+
+
+def test_a_missing_banded_quantity_key_is_treated_as_absent():
+    """Rows come from the corpus, where the key is optional, so absence must not raise."""
+    assert unremedied([{"slug": "p", "instrument": "usage_volume"}]) == [
+        {"slug": "p", "instrument": "usage_volume"}
+    ]
+
+
+# --- the release flag, and the boundary the version-string comparison sits on ---------------
+
+
+def test_a_release_flagged_prerelease_with_a_stable_tag_still_fires(monkeypatch):
+    """The xtuner shape, and the one refactor that would silently reverse this module.
+
+    GitHub flags `v1.0.1` as a pre-release while its version string reads stable and the
+    project's README documents V1 as current. `newest_repo_tag` returns the tag STRING and
+    discards the flag on purpose: honoring the flag would report the 416-day-old `0.2.0`
+    registry line as current, the opposite of what the project says about itself. `qwenpaw` is
+    kept clear by the string test instead (`v2.2.0-beta.5` reads as a pre-release), which is
+    where that protection belongs.
+    """
+    monkeypatch.setattr(
+        gate, "_get_json",
+        lambda url, token=None: [{"tag_name": "v1.0.1", "prerelease": True, "draft": False}],
+    )
+    assert newest_repo_tag("InternLM/xtuner") == "v1.0.1"
+    assert lag_verdict("0.2.0", newest_repo_tag("InternLM/xtuner")) == ("fires", 1)
+
+
+# --- the denominator, so a degraded run does not read as a healthy one -----------------------
+
+
+def _fixture_corpus(monkeypatch, routed, repos, packages, tags):
+    monkeypatch.setattr(gate, "pypi_routed", lambda root=None: routed)
+    monkeypatch.setattr(gate, "declared_repo_id", lambda slug, root=None: repos.get(slug))
+    monkeypatch.setattr(gate, "newest_pypi_release", lambda pkg: packages.get(pkg))
+    monkeypatch.setattr(gate, "newest_repo_tag", lambda repo, token=None: tags.get(repo))
+    monkeypatch.setattr(gate.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(gate, "_load", lambda path: {})
+
+
+def test_the_report_counts_what_it_could_not_read(monkeypatch, tmp_path):
+    """A 503-degraded run must not look healthier than a clean one.
+
+    Four products, one verdict. Dropping the other three silently would print "1 fire" and read
+    as a near-clean corpus; counted, it prints one of four readable and the reviewer knows the
+    run is not evidence about the other three.
+    """
+    _fixture_corpus(
+        monkeypatch,
+        routed={"fires": "f", "norepo": "n", "deadpkg": "d", "deadrepo": "r"},
+        repos={"fires": "o/fires", "deadpkg": "o/deadpkg", "deadrepo": "o/deadrepo"},
+        packages={"f": ("1.0.0", "2025-01-01T00:00:00Z"), "d": None,
+                  "r": ("1.0.0", "2025-01-01T00:00:00Z")},
+        tags={"o/fires": "v2.0.0", "o/deadrepo": None},
+    )
+    legs = release_lines(tmp_path)
+    assert legs["considered"] == 4
+    assert [row["slug"] for row in legs["fires"]] == ["fires"]
+    assert legs["skipped"] == {
+        "declare no repository": 1, "package unreadable": 1, "repository unreadable": 1,
+    }
+    assert skipped_total(legs) == 3
+
+
+def test_a_clean_run_skips_nothing(monkeypatch, tmp_path):
+    """The other half of the invariant: with everything readable the denominator is the whole
+    population and the skipped breakdown is empty, so a nonzero skip count always means
+    something really was unreadable."""
+    _fixture_corpus(
+        monkeypatch,
+        routed={"lagging": "l", "current": "c"},
+        repos={"lagging": "o/lagging", "current": "o/current"},
+        packages={"l": ("1.0.0", "2025-01-01T00:00:00Z"),
+                  "c": ("2.1.0", "2026-01-01T00:00:00Z")},
+        tags={"o/lagging": "v2.0.0", "o/current": "v2.1.0"},
+    )
+    legs = release_lines(tmp_path)
+    assert legs["considered"] == 2
+    assert skipped_total(legs) == 0
+    assert [row["slug"] for row in legs["fires"]] == ["lagging"]
+
+
+def test_the_prose_leg_holds_at_its_known_count():
+    """Report-only today, so this pins the remaining set rather than asserting it is empty.
+
+    Every entry is a band whose own note says the signal does not measure the product. The
+    number moves DOWN when one is remedied — a `banded_quantity` naming what the figure counts,
+    or a relabel to `reported_traction` — and moves UP when a re-read writes a new such note.
+    It went 17 -> 15 when `areal` and `xtuner` were relabeled in the change that added this
+    gate. Lower it as they are resolved; at zero the check can gate strict.
+    """
+    findings = under_coverage()
+    assert len(findings) == 15, [f[0] for f in findings]
+    assert {f[0] for f in findings} == {
+        "aider", "faiss", "gvisor", "langflow", "llm-guard", "mistral-large", "mistral-rs",
+        "n8n", "nemo-data-designer", "nemo-guardrails", "ollama", "perplexica", "promptfoo",
+        "searxng", "uzu",
+    }

--- a/tests/test_schedule_doc.py
+++ b/tests/test_schedule_doc.py
@@ -21,7 +21,7 @@ ROOT = Path(__file__).resolve().parent.parent
 DOC = ROOT / "docs/operations/deploy-models.md"
 # The gates whose times the doc's table quotes. Dataset crons live on the platform and
 # cannot be read from the repo, so they are out of scope here by construction.
-GATES = ("parity", "artifacts", "freshness")
+GATES = ("parity", "artifacts", "freshness", "channel-authority")
 
 _DAYS = {"1": "Monday", "2": "Tuesday", "3": "Wednesday", "4": "Thursday",
          "5": "Friday", "6": "Saturday", "0": "Sunday"}

--- a/tests/test_score_notes.py
+++ b/tests/test_score_notes.py
@@ -167,6 +167,11 @@ ISO_DATE = re.compile(r"\b20\d\d-\d\d-\d\d\b")
 DATES_THAT_ARE_PRODUCT_FACTS = {
     ("amazon-bedrock-evaluations", "adoption"),
     ("apertus", "adoption"),
+    # A release date on each side of a trailing registry line. The whole reason the band does
+    # not rest on the download figure is that the registry stopped at 1.0.4 in June while the
+    # repository is on 2.1.0 from August; drop the dates and the note asserts a lag it can no
+    # longer show. Both are publication facts, true whether or not anybody re-reads them.
+    ("areal", "adoption"),
     ("apertus", "openness"),
     ("atropos", "adoption"),
     ("claude-haiku", "capability"),
@@ -187,6 +192,9 @@ DATES_THAT_ARE_PRODUCT_FACTS = {
     ("ragflow", "adoption"),
     ("sandbox-runtime", "adoption"),
     ("vercel-sandbox", "adoption"),
+    # Same shape as areal: the PyPI upload of 2025-07-11 and the v1.0.1 release of 2026-05-15
+    # are the two publication dates the 416-day gap is measured between.
+    ("xtuner", "adoption"),
 }
 
 


### PR DESCRIPTION
## The question #435 asked

When a verified authoritative channel exists but is demonstrably non-primary, should it keep
dominating the route (A), abstain (B), or route on the larger signal (C)?

**A, with the gap that made the question feel necessary closed by a gate.** C was already dead on
the overstatement history. B does not survive the simulation.

## The three findings that decided it

A whole-corpus simulation ran every B variant through the real pipeline functions —
`build.serialize.build_payload`, `_stage_and_gaps`, `_maturity_score`, `select_route`,
`adoption_bands` — rather than re-implementing any formula.

1. **The premise B rests on is false, and abstention moves nothing.** The issue says a level-1
   band "pulls the category's `B` down". `B` is `max(...)` over fully-open scores
   (`build/serialize.py:145`), so a low band cannot pull it down. Across seven trigger sets — the
   three named products, the `atropos` precedent, three downloads-to-stars thresholds, the
   version-lag test, the prose detector intersected with authoritative routes — **no category
   changes stage, L, B, M or gaps.** A leave-one-out over all 266 in-scope products found 39
   whose abstention would move their category, and every one is level 3 or above, where the
   trigger cannot fire. Stage responds to the top of the distribution; the trigger targets the
   bottom.

2. **The only auditable trigger clears one of the three motivating products.** A stable-major
   version-lag test is fully mechanical and fires on `areal` and `xtuner`. It does not fire on
   `qwenpaw`, whose PyPI release `2.2.0b5` was uploaded the same day as the repo tag
   `v2.2.0-beta.5`. Its registry is exactly current; the only thing that ever looked wrong was
   its downloads-to-stars ratio, and a ratio test hands stars a veto over a usage measurement,
   which is the overstatement failure re-entering one level up.

3. **B carries downside risk with no upside.** Applied to the prose tell as written it erases
   `gvisor` — level 5 on container distribution its own note describes honestly — and demotes
   `deployment` from stage 5 to 4. It would also need a new `signal_type`, an inverted
   `validate` rule (an abstention is a claim and would need evidence), and a reconciliation
   story for a permanent recorded-against-computed mismatch, all for a result that moves no
   published number.

## What ships instead

**`build/check_channel_authority.py`** — report-only, two legs, re-bands nothing.

- **Leg 1, the release line** (`--live`): for every pypi-routed product, the newest registry
  release against the repository's newest release or tag. Stable against stable, on the major
  line only. Current run: **7 fires**, of which **4 still band on that registry count** after the
  two relabels below, plus **4 pre-release exclusions** and **2 undecidable tags**, over
  **141 of 146** readable products. That split differs from the simulation's (3 and 14) because
  this gate falls back to `/tags` and parses decorated tags; the seven fires are identical, and
  the docstring says so.
- **Leg 2, the note**: the under-coverage tell `docs/reference/adoption.md` names, imported from
  `build/sweep_status.py` rather than restated so the two cannot drift. **15 findings**, down
  from 17.

Every flag names its remedy, and **both remedies clear it**: a `banded_quantity` saying what the
figure actually counts (the `langflow` / `semantic-kernel` shape), or a relabel to
`reported_traction` with `reach` null and a digested source. Never the star count.

Unreadable products are counted and printed against a denominator, so a rate-limited or
503-degraded run cannot report fewer findings and read as healthier than a clean one. The GitHub
token is checked before the run and the request pace matches `propose_artifacts`.

Non-strict by default, per `check_adoption` / `check_instrument` / `check_artifacts`. Weekly on
the Monday chain at 09:00 UTC, behind the signal refresh and the age gate, because it reads a
live release line and a gate's cadence has to match the thing it polices.

**Two corpus edits**, the ones the gate immediately demands.

| product | before | after |
|---|---|---|
| `areal` | 1 `usage_volume`, `reach: <10K` | **1** `reported_traction`, no `reach` |
| `xtuner` | 1 `usage_volume`, `reach: <10K` | **1** `reported_traction`, no `reach` |

**The level does not move.** What was wrong is the claim to have counted the product's
downloads, not the reading of its standing, and the ladder is explicit that a relabel corrects
the instrument and leaves the level to its own evidence. Raising it would be a separate
judgment, and the only other signal either product has is its star count — which is exactly
what the gate's own remedy text forbids substituting.

`areal` publishes `1.0.4` (2026-06-10, its only release) against repo `v2.1.0` (2026-08-25).
`xtuner` publishes `0.2.0` (2025-07-11, 416 days old) against `v1.0.1` (2026-05-15) while the
README documents XTuner V1. Both take remedy 3 from the under-coverage ladder in the shape
`helm`, `laminar` and `swe-bench` already use: a `banded_quantity` naming the trailing release
line, `reach` omitted, and two new digested sources each behind the level. `qwenpaw` and
`atropos` are deliberately untouched — the first is correctly banded, the second is a dormant
project accurately measured.

**The shape is borrowed; the level is not.** `laminar` records level 3 `reported_traction` with
GitHub stars as the proxy behind it, which reaches a star-derived level through an instrument
defined as carrying no count. Whether that precedent is good is a live question and this PR
does not answer it — but it deliberately does not multiply it either. Neither of these two
records cites a star count as the basis for anything, and the sources added here establish the
release-line mismatch, which is the only claim the notes make. Re-reading `laminar` against the
same standard belongs in its own change.

## Stage impact: none, in any category

Recomputed through `_stage_and_gaps` on the real payload before and after the two edits.

| category | stage | L | B | M | gaps |
|---|---|---|---|---|---|
| agent_tools_protocols | 5 → 5 | 8 → 8 | 5.00 → 5.00 | 1 → 1 | unchanged |
| base_pretrained | 3 → 3 | 0 → 0 | 3.70 → 3.70 | 1 → 1 | unchanged |
| benchmark_eval_data | 3 → 3 | 0 → 0 | 4.00 → 4.00 | 0 → 0 | unchanged |
| compilers | 3 → 3 | 0 → 0 | 4.00 → 4.00 | 0 → 0 | unchanged |
| dataset_processing_tools | 2 → 2 | 0 → 0 | 3.40 → 3.40 | 0 → 0 | unchanged |
| deployment | 5 → 5 | 4 → 4 | 5.00 → 5.00 | 1 → 1 | unchanged |
| edge_hardware | 3 → 3 | 0 → 0 | 3.50 → 3.50 | 1 → 1 | unchanged |
| evaluation_code | 4 → 4 | 3 → 3 | 4.50 → 4.50 | 1 → 1 | unchanged |
| finetuned_chat | 3 → 3 | 0 → 0 | 3.70 → 3.70 | 1 → 1 | unchanged |
| finetuning_code | 4 → 4 | 1 → 1 | 4.50 → 4.50 | 1 → 1 | unchanged |
| inference_code | 5 → 5 | 4 → 4 | 4.50 → 4.50 | 1 → 1 | unchanged |
| ml_frameworks | 5 → 5 | 15 → 15 | 5.00 → 5.00 | 1 → 1 | unchanged |
| orchestration_agents | 5 → 5 | 5 → 5 | 5.00 → 5.00 | 1 → 1 | unchanged |
| safeguards | 3 → 3 | 0 → 0 | 3.50 → 3.50 | 0 → 0 | unchanged |
| storage | 4 → 4 | 2 → 2 | 4.60 → 4.60 | 1 → 1 | unchanged |
| telemetry_observability | 4 → 4 | 2 → 2 | 4.50 → 4.50 | 1 → 1 | unchanged |
| training_synthetic_datasets | 4 → 4 | 2 → 2 | 4.50 → 4.50 | 1 → 1 | unchanged |
| ui_api | 4 → 4 | 2 → 2 | 5.00 → 5.00 | 1 → 1 | unchanged |

**Adoption signal mix**: `finetuning_code` `usage_volume` 14 → 12, `reported_traction` 3 → 5. No
other category moves, `open_scored` is unchanged everywhere, and adoption coverage stays at
533/553. Both products keep their maturity score, so no published number moves at all.

## Deferred

- **Two warehouse signal columns**, so leg 1 becomes machine-checkable offline instead of a live
  fetch: `latest_version` / `latest_upload_at` on
  `currentai.signal_pypi.package_downloads`, and `latest_release_tag` /
  `latest_release_published_at` / `is_prerelease` on `currentai.signal_github.artifact_state`.
  Both are single fields on endpoints the collectors already call. Platform-side; follow-up
  issue.
- **The missing instruments** #435 raises in passing — no Homebrew formula, app-store listing,
  container pull count or release-asset download count is bridged, and 153 products route to
  stars partly because of it. That is a bridge-building problem rather than a routing-policy
  one, larger than this issue, and it should not be folded in.
- **`--strict`**, once the two legs hold at zero.

Closes #435
