### PR TITLE
Round 2 discovery: compilers, storage, telemetry_observability — 41 candidates

### DIFF
--- a/sources/registry/compilers.yaml
+++ b/sources/registry/compilers.yaml
@@ -10,7 +10,7 @@
 # #434 names) has been renamed to uxlfoundation/oneMath on GitHub - the old slug 302-redirects to the
 # new one - so the row below uses the canonical repository.
 #
-# Predeclared retrieval cutoff: GitHub search across six population-representative queries ("gpu
+# Predeclared retrieval cutoff: GitHub search across ten population-representative queries ("gpu
 # kernel library primitives", "tensor compiler", "quantization inference toolkit", "collective
 # communication gpu", "attention kernel", "gemm kernel library", "model quantization gptq awq",
 # "graph compiler neural network mlir", "cuda sparse library", "onnx converter optimizer"), sorted by
@@ -175,3 +175,8 @@ products:
     type: software
     org: rise-ai
     github: RiseAI-Sys/attention-gym
+  - slug: torch-tensorrt
+    display_name: Torch-TensorRT
+    type: software
+    org: pytorch
+    github: pytorch/TensorRT

--- a/sources/registry/compilers.yaml
+++ b/sources/registry/compilers.yaml
@@ -1,8 +1,66 @@
-# Seeded from currentai.signal_goodailist.repo_catalog (upstream 2026-08-18) and triaged in
-# full on 2026-08-18: every row was either promoted to a head product in
-# sources/categories/compilers.yaml or rejected on the category boundary. Rejected rows are
-# not parked here, because a row that fails the boundary does not belong to this category at
-# any tier; the reasons are in the promotion PR. The file stays so the category keeps a place
-# to accumulate the next discovery batch.
+# Swept 2026-09-01, targeted at issue #434: compilers holds three populations (compiler/converter,
+# quantization/optimizer, kernel library) and no kernel library in the current roster scores above
+# capability 3. #434's read is that the roster is the wrong fix for that, but the corpus is also
+# missing major kernel and runtime incumbents on significance alone, independent of openness. This
+# batch completes that incumbent set rather than filtering on openness in either direction.
+#
+# GitHub reports NOASSERTION for nccl and miopen because each carries a composite or vendor-header
+# LICENSE file; both were verified open by reading the license body directly, per #434's own finding
+# and the abstain rule in sources/signal_routing.yaml. oneapi-src/oneMKL (the Interfaces project
+# #434 names) has been renamed to uxlfoundation/oneMath on GitHub - the old slug 302-redirects to the
+# new one - so the row below uses the canonical repository.
+#
+# Predeclared retrieval cutoff: GitHub search across six population-representative queries ("gpu
+# kernel library primitives", "tensor compiler", "quantization inference toolkit", "collective
+# communication gpu", "attention kernel", "gemm kernel library", "model quantization gptq awq",
+# "graph compiler neural network mlir", "cuda sparse library", "onnx converter optimizer"), sorted by
+# stars, top 15 per query, plus direct lookups for the three incumbents #434 names by hand
+# (nccl, miopen, oneMath) and the four closed vendor primitives it names for completeness
+# (cudnn, cublas, cufft, cutensor). No additional star floor beyond what each query's top-15 window
+# returned - volume at this window was small enough to triage by hand.
+#
+# cuDNN, cuBLAS, cuFFT and cuTENSOR resolve to no public repository - NVIDIA distributes them as
+# binaries - so per docs/workflows/discover-candidates.md they are parked against #365 (GitHub-backed
+# storage not yet available), not emitted. NVIDIA/cudnn-frontend is explicitly NOT used as cuDNN's
+# artifact: #434 names it as the exact hazard from the tinker-cookbook/tinker case in #431 - an
+# open wrapper repo would let an externally-open project lift a closed binary's openness score.
+#
+# rapidsai/raft stays unresolved per the #428 ledger hold and is not re-proposed. NVIDIA/cuvs, raft's
+# ANN successor per #428's own note, is parked against the same open category-fit question rather
+# than resolved unilaterally here.
 category: compilers
-products: []
+products:
+  - slug: nccl
+    display_name: NCCL
+    type: software
+    org: nvidia
+    github: NVIDIA/nccl
+    homepage: https://developer.nvidia.com/nccl
+  - slug: miopen
+    display_name: MIOpen
+    type: software
+    org: amd
+    github: ROCm/MIOpen
+    homepage: https://rocm.docs.amd.com/projects/MIOpen/
+  - slug: onemath
+    display_name: oneMath
+    type: software
+    org: uxl-foundation
+    github: uxlfoundation/oneMath
+    homepage: https://oneapi-src.github.io/oneMath/
+  - slug: flashmla
+    display_name: FlashMLA
+    type: software
+    org: deepseek-ai
+    github: deepseek-ai/FlashMLA
+  - slug: uccl
+    display_name: UCCL
+    type: software
+    org: uccl-project
+    github: uccl-project/uccl
+  - slug: auto-round
+    display_name: AutoRound
+    type: software
+    org: intel
+    github: intel/auto-round
+    pypi: auto-round

--- a/sources/registry/compilers.yaml
+++ b/sources/registry/compilers.yaml
@@ -28,6 +28,41 @@
 # rapidsai/raft stays unresolved per the #428 ledger hold and is not re-proposed. NVIDIA/cuvs, raft's
 # ANN successor per #428's own note, is parked against the same open category-fit question rather
 # than resolved unilaterally here.
+#
+# Second pass, swept 2026-09-01, same PR window as the first. Carl's instruction after the first
+# pass's 16-candidate total (6 accepted + ~10 individually parked, ignoring the bucket-parked ~85)
+# came in short of his 50-75 target: re-sweep at a lower floor and triage every result
+# individually rather than bucket-parking. Effective star floor lowered from ~100 to 30, each of
+# the original 10 queries widened from top-15 to top-30, plus five new queries covering angles the
+# first pass's ten queries missed ("sparse attention kernel", "int4 int8 quantization library",
+# "triton kernel library", "cuda graph compiler", "onnx runtime optimization"). Predeclared
+# retrieval cutoff: GitHub repository search, sort by stars, star floor 30, top 30 per query
+# across all fifteen queries, executed 2026-09-01.
+#
+# Every accepted row's license was read from the LICENSE body, not GitHub's classifier: taco,
+# NVIDIA/cuda-tile and NX-AI/mlstm_kernels all report NOASSERTION or a nonstandard SPDX id from
+# GitHub. taco's body is plain MIT; NVIDIA/cuda-tile's is Apache-2.0-with-LLVM-exceptions (real
+# open source, not a closed-binary wrapper - see the note on cudnn-frontend above for the case
+# this is NOT). NX-AI/mlstm_kernels ships the NXAI Community License Agreement, a Llama-3-style
+# custom license with commercial-scale restrictions - not an open license, but the row is still
+# emitted per this workflow's rule that a repository is only excluded for having no public
+# artifact, not for the license it carries; its restrictive terms are a scoring-stage fact, not a
+# discovery-stage rejection.
+#
+# NVIDIA/tensor-ir and NVIDIA/cuda-tile are two layers of the same NVIDIA MLIR toolchain
+# (tensor-ir is the frontend, cuda-tile is the IR it lowers to) but are distinct repositories with
+# distinct real functionality, unlike NVIDIA/cudnn-frontend, which stays parked (restated above).
+# NVIDIA/cuvs surfaced again in this pass's widened cuda-sparse-library window and also stays
+# parked, restated: the #428 ledger hold on rapidsai/raft is a category-fit question, not a score,
+# and this pass does not resolve it unilaterally either.
+#
+# intel/neural-speed surfaced again (int4/int8 quantization library query) but is archived - GitHub
+# reports archived: true, last push 2024-08-30 - so it is parked as superseded, not accepted.
+# uwsampl/SparseTIR (tensor compiler query) last pushed 2023-03-31 and Santosh-Gupta/SpeedTorch
+# (cuda sparse library query) last pushed 2020-02-21; both parked as unmaintained rather than
+# accepted, despite clearing the star floor. NVIDIA/MinkowskiEngine last pushed 2024-03-05 - over
+# two years stale - is parked unmaintained too, despite 2956 stars from its 3D deep learning
+# heyday.
 category: compilers
 products:
   - slug: nccl
@@ -64,3 +99,79 @@ products:
     org: intel
     github: intel/auto-round
     pypi: auto-round
+  - slug: taco
+    display_name: TACO
+    type: software
+    org: tensor-compiler
+    github: tensor-compiler/taco
+    homepage: http://tensor-compiler.org
+  - slug: finch-jl
+    display_name: Finch.jl
+    type: software
+    org: finch-tensor
+    github: finch-tensor/Finch.jl
+    pypi: finch-tensor
+    homepage: https://finch-tensor.github.io/Finch.jl
+  - slug: freetensor
+    display_name: FreeTensor
+    type: software
+    org: roastduck
+    github: roastduck/FreeTensor
+    homepage: https://roastduck.github.io/FreeTensor/
+  - slug: cuda-tile
+    display_name: CUDA Tile IR
+    type: software
+    org: nvidia
+    github: NVIDIA/cuda-tile
+  - slug: nvidia-tensor-ir
+    display_name: TensorIR
+    type: software
+    org: nvidia
+    github: NVIDIA/tensor-ir
+  - slug: flashkda
+    display_name: FlashKDA
+    type: software
+    org: moonshot-ai
+    github: MoonshotAI/FlashKDA
+  - slug: flash-sparse-attention
+    display_name: Flash Sparse Attention
+    type: software
+    org: hkust-dial
+    github: HKUSTDial/flash-sparse-attention
+    homepage: https://hkustdial.github.io/flash-sparse-attention/
+  - slug: flashqla
+    display_name: FlashQLA
+    type: software
+    org: qwen
+    github: QwenLM/FlashQLA
+  - slug: block-sparse-attention
+    display_name: Block Sparse Attention
+    type: software
+    org: mit-han-lab
+    github: mit-han-lab/Block-Sparse-Attention
+  - slug: cula
+    display_name: cuLA
+    type: software
+    org: inclusion-ai
+    github: inclusionAI/cuLA
+  - slug: humming
+    display_name: Humming
+    type: software
+    org: inclusion-ai
+    github: inclusionAI/humming
+  - slug: mlstm-kernels
+    display_name: mLSTM Kernels
+    type: software
+    org: nx-ai
+    github: NX-AI/mlstm_kernels
+  - slug: rocalution
+    display_name: rocALUTION
+    type: software
+    org: amd
+    github: ROCm/rocALUTION
+    homepage: https://rocm.docs.amd.com/projects/rocALUTION/en/latest/
+  - slug: attention-gym
+    display_name: Attention Gym
+    type: software
+    org: rise-ai
+    github: RiseAI-Sys/attention-gym

--- a/sources/registry/storage.yaml
+++ b/sources/registry/storage.yaml
@@ -1,8 +1,63 @@
-# Seeded from currentai.signal_goodailist.repo_catalog (upstream 2026-08-18) and triaged in
-# full on 2026-08-18: every row was either promoted to a head product in
-# sources/categories/storage.yaml or rejected on the category boundary. Rejected rows are
-# not parked here, because a row that fails the boundary does not belong to this category at
-# any tier; the reasons are in the promotion PR. The file stays so the category keeps a place
-# to accumulate the next discovery batch.
+# Swept 2026-09-01 over the storage category (vector databases, indexes, feature stores and
+# versioned data layers for training, inference and retrieval-augmented-generation data).
+# Sources: GitHub topic search (vector-database, vector-search, feature-store,
+# data-version-control), sorted by stars, cross-checked against PyPI and npm. Predeclared
+# retrieval cutoff: top 25 repositories per topic by all-time stars, star floor 800, executed
+# 2026-09-01. Every accepted row was verified against the GitHub API and its declared package
+# registry on the same date. Counts, parked candidates and their reasons are in the sweep
+# summary on the PR.
 category: storage
-products: []
+products:
+  - slug: weaviate
+    display_name: Weaviate
+    type: software
+    org: weaviate
+    github: weaviate/weaviate
+    pypi: weaviate-client
+    homepage: https://weaviate.io
+  - slug: orama
+    display_name: Orama
+    type: software
+    org: oramasearch
+    github: oramasearch/orama
+    npm: "@orama/orama"
+    homepage: https://orama.com
+  - slug: paradedb
+    display_name: ParadeDB
+    type: software
+    org: paradedb
+    github: paradedb/paradedb
+    homepage: https://paradedb.com
+  - slug: diskann
+    display_name: DiskANN
+    type: software
+    org: microsoft
+    github: microsoft/DiskANN
+    pypi: diskannpy
+  - slug: sptag
+    display_name: SPTAG
+    type: software
+    org: microsoft
+    github: microsoft/SPTAG
+    pypi: sptag
+  - slug: openmldb
+    display_name: OpenMLDB
+    type: software
+    org: 4paradigm
+    github: 4paradigm/OpenMLDB
+    pypi: openmldb
+    homepage: https://openmldb.ai
+  - slug: quilt
+    display_name: Quilt
+    type: software
+    org: quiltdata
+    github: quiltdata/quilt
+    pypi: quilt3
+    homepage: https://quiltdata.com
+  - slug: oxen
+    display_name: Oxen
+    type: software
+    org: oxen-ai
+    github: Oxen-AI/Oxen
+    pypi: oxenai
+    homepage: https://oxen.ai

--- a/sources/registry/storage.yaml
+++ b/sources/registry/storage.yaml
@@ -6,6 +6,14 @@
 # 2026-09-01. Every accepted row was verified against the GitHub API and its declared package
 # registry on the same date. Counts, parked candidates and their reasons are in the sweep
 # summary on the PR.
+#
+# Second pass, same day (2026-09-01), lower floor per Carl's instruction after the first pass's
+# 16-candidate total across 3 categories fell short of the 50-75 target. Re-ran the original four
+# topic searches plus six adjacent angles (embedding store, document store ai, graph database rag,
+# time series database ml, object storage ml, metadata store mlops), top-30 per query, predeclared
+# retrieval cutoff star floor 250. Every new result at or above the floor was triaged individually,
+# not bucket-parked. Four accepted: lakesoul, pixeltable, lamindb, butterfree. Counts and the full
+# parked list, with reasons, source URLs and fetch dates, are in the sweep summary on the PR.
 category: storage
 products:
   - slug: weaviate
@@ -61,3 +69,34 @@ products:
     github: Oxen-AI/Oxen
     pypi: oxenai
     homepage: https://oxen.ai
+  - slug: lakesoul
+    display_name: LakeSoul
+    type: software
+    org: lakesoul-io
+    github: lakesoul-io/LakeSoul
+    homepage: https://lakesoul-io.github.io/
+  - slug: pixeltable
+    display_name: Pixeltable
+    type: software
+    org: pixeltable
+    github: pixeltable/pixeltable
+    pypi: pixeltable
+    homepage: https://docs.pixeltable.com
+  - slug: lamindb
+    display_name: LaminDB
+    type: software
+    org: laminlabs
+    github: laminlabs/lamindb
+    pypi: lamindb
+    homepage: https://docs.lamin.ai
+  - slug: redisearch
+    display_name: RediSearch
+    type: software
+    org: redis
+    github: RediSearch/RediSearch
+  - slug: butterfree
+    display_name: Butterfree
+    type: software
+    org: quintoandar
+    github: quintoandar/butterfree
+    pypi: butterfree

--- a/sources/registry/telemetry_observability.yaml
+++ b/sources/registry/telemetry_observability.yaml
@@ -1,0 +1,12 @@
+category: telemetry_observability
+products:
+  - slug: ragaai-catalyst
+    display_name: RagaAI Catalyst
+    type: software
+    org: raga-ai
+    github: raga-ai-hub/RagaAI-Catalyst
+  - slug: logfire
+    display_name: Pydantic Logfire
+    type: software
+    org: pydantic
+    github: pydantic/logfire

--- a/sources/registry/telemetry_observability.yaml
+++ b/sources/registry/telemetry_observability.yaml
@@ -30,3 +30,8 @@ products:
     type: software
     org: latitude
     github: latitude-dev/latitude-llm
+  - slug: evidently
+    display_name: Evidently
+    type: software
+    org: evidently-ai
+    github: evidentlyai/evidently

--- a/sources/registry/telemetry_observability.yaml
+++ b/sources/registry/telemetry_observability.yaml
@@ -10,3 +10,23 @@ products:
     type: software
     org: pydantic
     github: pydantic/logfire
+  - slug: monocle
+    display_name: Monocle
+    type: software
+    org: monocle2ai
+    github: monocle2ai/monocle
+  - slug: traccia
+    display_name: Traccia
+    type: software
+    org: traccia-ai
+    github: traccia-ai/traccia-py
+  - slug: axon
+    display_name: Axon
+    type: software
+    org: langchain-tracer
+    github: langchain-tracer/Axon
+  - slug: latitude-llm
+    display_name: Latitude
+    type: software
+    org: latitude
+    github: latitude-dev/latitude-llm

--- a/sources/resolution_ledger.yaml
+++ b/sources/resolution_ledger.yaml
@@ -2016,3 +2016,90 @@ resolutions:
     is fully resolved (Apache-2.0 LICENSE body read 2026-09-01, 870 stars, arXiv:2405.14573, no
     first-party HF dataset), only the category filing waits. Do not re-propose for
     benchmark_eval_data.'
+- repo: NVIDIA/cudnn-frontend
+  verdict: excluded_boundary
+  decided_in: 'Round 2 discovery, compilers'
+  decided_on: '2026-09-01'
+  note: 'the open C++/Python wrapper around the closed cuDNN binary, named explicitly in #434 as
+    the hazard: declaring it as its own product or as cuDNN''s substitute artifact would let an
+    externally-open shim launder a closed core''s openness score, the tinker-cookbook shape.
+    cuDNN itself resolves to no public repository (checked NVIDIA/cudnn, 404), so it is excluded
+    from the discovery workflow on artifact grounds and cannot be declared under any identifier.
+    Apache-2.0-with-LLVM-exceptions, 921 stars, active - a real, well-maintained repository, just
+    not a product of its own.'
+- repo: pytorch/TensorRT
+  verdict: excluded_boundary
+  decided_in: 'Round 2 discovery, compilers'
+  decided_on: '2026-09-01'
+  note: 'Torch-TensorRT, an open compiler wrapper around the corpus''s existing `tensorrt`
+    product, whose optimizing builder ships as a binary. Same shape as cudnn-frontend: an open
+    integration layer over a partly-closed core, which should not be declared as its own product
+    or used to lift tensorrt''s openness reading. BSD-3-Clause, 2,989 stars, active.'
+- repo: NVIDIA/cuvs
+  verdict: unresolved
+  decided_in: 'Round 2 discovery, compilers'
+  decided_on: '2026-09-01'
+  note: 'cuVS, the ANN-search successor to rapidsai/raft per #428''s own note. Sits on the exact
+    same open question as the existing raft hold (#428): does it transform model computation
+    toward hardware, which is what the compilers ladder measures, or supply primitives to
+    systems that do? Parked against the same question rather than resolved unilaterally in a
+    discovery pass. Apache-2.0, 844 stars, active.'
+- repo: superduper-io/superduper
+  verdict: unresolved
+  decided_in: 'Round 2 discovery, storage'
+  decided_on: '2026-09-01'
+  note: 'An AI data framework layered over existing databases (Postgres, MongoDB, and others)
+    rather than a storage system in its own right. Genuinely borderline between storage and
+    general-agent-frameworks - it does not fit either cleanly, and the discovering agent flagged
+    it explicitly rather than forcing a call. 5,317 stars, active.'
+- repo: RyanCodrai/turbovec
+  verdict: unresolved
+  decided_in: 'Round 2 discovery, storage'
+  decided_on: '2026-09-01'
+  note: '16,623 stars on a repository created 2026-03-26 (about five months old at read time)
+    with only 1,441 forks and 73 subscribers - a star-to-watcher ratio well outside the pattern
+    of a genuinely adopted project of that size. Flagged per the workflow''s rule to record an
+    implausible signal rather than adjudicate it. Needs a legitimacy check before any future
+    consideration, not a rejection on the merits of the product itself.'
+- repo: jeffhajewski/latticedb
+  verdict: unresolved
+  decided_in: 'Round 2 discovery, storage'
+  decided_on: '2026-09-01'
+  note: 'The same shape as turbovec, less extreme: 630 stars on a solo repository created
+    2025-12-20 with only 29 forks and 2 subscribers. On-topic if legitimate (an embedded
+    vector-plus-graph store), but the ratio warrants the same legitimacy check before promotion.'
+- repo: postgresml/postgresml
+  verdict: unresolved
+  decided_in: 'Round 2 discovery, storage'
+  decided_on: '2026-09-01'
+  note: 'Two open questions, not one. Stale at read time (last push 2025-07, over a year quiet),
+    which alone would be excluded_maintenance - but the discovering agent also flagged that even
+    setting staleness aside, this is arguably inference_code (ML/GPU compute embedded in
+    Postgres) rather than storage. Left unresolved rather than filed under either reason alone,
+    so a future read settles both questions together if the project becomes active again.'
+- repo: evidentlyai/evidently
+  verdict: unresolved
+  decided_in: 'Round 2 discovery, telemetry_observability (superseding a Round 1 census flag and
+    a same-round parked call)'
+  decided_on: '2026-09-01'
+  note: 'Contested three times now and never settled: the Round 1 whole-corpus census
+    (2026-08-31) flagged it as an evaluation_code/telemetry_observability boundary case; this
+    round''s first telemetry_observability sweep read it as evaluation_code ("evaluation and
+    drift-testing framing... do not add here"); this round''s second sweep, run independently at
+    a lower retrieval floor, read it the opposite way and accepted it into
+    telemetry_observability ("production ML/LLM monitoring... distinct from the evaluation_code
+    harnesses that grade models"). Both readings are defensible - it genuinely does both drift
+    monitoring on deployed models and pre-deployment quality checks - which is exactly why one
+    ruling belongs here rather than being re-derived, and re-flipped, by the next sweep that
+    encounters it. Held out of both categories'' Round 2 promotion pools pending a person''s
+    call. Apache-2.0, 7,874 stars, active.'
+- repo: FailproofAI/failproofai
+  verdict: unresolved
+  decided_in: 'Round 2 discovery, telemetry_observability'
+  decided_on: '2026-09-01'
+  note: 'LICENSE body read directly (not the GitHub classifier): MIT with a Commons Clause
+    no-sell restriction appended, which needs a real openness read rather than a discovery-stage
+    guess. Core product is agent-harness guardrail enforcement with observability as a secondary
+    feature, which also argues for a different category. Growth curve is fast for its age
+    (1,671 stars and 415 forks in about five months), flagged rather than trusted at face value.
+    Left unresolved on both the license and the category question.'

--- a/sources/resolution_ledger.yaml
+++ b/sources/resolution_ledger.yaml
@@ -2027,14 +2027,6 @@ resolutions:
     from the discovery workflow on artifact grounds and cannot be declared under any identifier.
     Apache-2.0-with-LLVM-exceptions, 921 stars, active - a real, well-maintained repository, just
     not a product of its own.'
-- repo: pytorch/TensorRT
-  verdict: excluded_boundary
-  decided_in: 'Round 2 discovery, compilers'
-  decided_on: '2026-09-01'
-  note: 'Torch-TensorRT, an open compiler wrapper around the corpus''s existing `tensorrt`
-    product, whose optimizing builder ships as a binary. Same shape as cudnn-frontend: an open
-    integration layer over a partly-closed core, which should not be declared as its own product
-    or used to lift tensorrt''s openness reading. BSD-3-Clause, 2,989 stars, active.'
 - repo: NVIDIA/cuvs
   verdict: unresolved
   decided_in: 'Round 2 discovery, compilers'
@@ -2079,20 +2071,23 @@ resolutions:
     so a future read settles both questions together if the project becomes active again.'
 - repo: evidentlyai/evidently
   verdict: unresolved
-  decided_in: 'Round 2 discovery, telemetry_observability (superseding a Round 1 census flag and
-    a same-round parked call)'
+  decided_in: 'Round 2 discovery, telemetry_observability; ruled 2026-09-01 in PR #451 review'
   decided_on: '2026-09-01'
-  note: 'Contested three times now and never settled: the Round 1 whole-corpus census
-    (2026-08-31) flagged it as an evaluation_code/telemetry_observability boundary case; this
-    round''s first telemetry_observability sweep read it as evaluation_code ("evaluation and
-    drift-testing framing... do not add here"); this round''s second sweep, run independently at
-    a lower retrieval floor, read it the opposite way and accepted it into
-    telemetry_observability ("production ML/LLM monitoring... distinct from the evaluation_code
-    harnesses that grade models"). Both readings are defensible - it genuinely does both drift
-    monitoring on deployed models and pre-deployment quality checks - which is exactly why one
-    ruling belongs here rather than being re-derived, and re-flipped, by the next sweep that
-    encounters it. Held out of both categories'' Round 2 promotion pools pending a person''s
-    call. Apache-2.0, 7,874 stars, active.'
+  note: 'Contested three times: the Round 1 whole-corpus census (2026-08-31) flagged it as an
+    evaluation_code/telemetry_observability boundary case; this round''s first
+    telemetry_observability sweep read it as evaluation_code; this round''s second sweep, run
+    independently at a lower retrieval floor, read it the opposite way. RULED in PR #451 review:
+    telemetry_observability. The deciding test is product shape, not feature overlap - evaluation
+    is one workflow inside Evidently, while continuous monitoring (a persistent UI/service
+    tracking metrics and tests over time) is its first-class surface, unlike a benchmark-runner
+    or model-ranking harness such as lm-evaluation-harness, HELM or OpenCompass. Verdict stays
+    `unresolved` rather than moving to a settled-product verdict, because the underlying question
+    a person had to look at has now been looked at and the correct next action is exactly what
+    `unresolved` already permits: propose it. It is accepted as a telemetry_observability
+    candidate in `sources/registry/telemetry_observability.yaml`. The same product-shape test
+    applies to `langwatch` and `judgeval`, held out of Round 1''s evaluation_code pass on the same
+    unresolved boundary - worth reading against this ruling before a future sweep re-derives it
+    from nothing. Apache-2.0, 7,874 stars, active.'
 - repo: FailproofAI/failproofai
   verdict: unresolved
   decided_in: 'Round 2 discovery, telemetry_observability'


### PR DESCRIPTION
## What this is

Discovery for Round 2, scoped to `compilers`, `storage` and `telemetry_observability` per
`docs/workflows/discover-candidates.md` — registry rows only, nothing scored, nothing promoted.
`deployment` and its ML-orchestration boundary question (#429) are deliberately out of scope this
round; that stays frozen until #429 resolves.

Two passes per category: an initial sweep at a conservative star floor, then a second pass at a
lower floor (per direction after the first pass landed short of target), individually triaging what
the first pass had bucket-parked rather than starting over. Reconciled counts, combined — every row
below satisfies `accepted + parked = unique` and `duplicate_signals + unique = raw_signals`:

| Category | Raw signals | Duplicates | Unique | Accepted | Parked |
|---|---|---|---|---|---|
| compilers | 211 | 27 | 184 | 21 | 163 |
| storage | 184 | 75 | 109 | 13 | 96 |
| telemetry_observability | 245 | 95 | 150 | 7 | 143 |
| **Total** | **640** | **197** | **443** | **41** | **402** |

## compilers (21 accepted)

Targeted at #434's own finding: the roster's kernel-library population caps at capability ≤3 on the
current rubric, and #434's proposed fix is completing the missing incumbent set *before* any rubric
redesign, not filtering on openness in either direction. This sweep is exactly that step.

Confirmed open (license bodies read directly, not GitHub's classifier): `nccl`, `miopen`, `onemath`
— all three named in #434. Confirmed closed with no public repository: `cudnn`, `cublas`, `cufft`,
`cutensor` — parked against #365, not emitted, per the workflow's rule that a candidate with no
identifier cannot be declared.

One identity hazard held to the ledger: `cudnn-frontend`, an open wrapper repo around the closed
cuDNN binary that would launder its openness score if used as a substitute artifact. `Torch-TensorRT`
was flagged the same way in an earlier draft of this PR and corrected on review — unlike
`cudnn-frontend`, it has its own installable package and its own compiler API
(`torch_tensorrt.compile(...)`) that performs real graph transformation rather than exposing
someone else's API surface; a dependency on a partly-closed backend doesn't make the frontend
merely an artifact of it. Accepted as its own compilers candidate.

The rest of the accepted set is a real kernel-library land-rush the roster was missing: `flashmla`,
`uccl`, `auto-round`, plus a second pass surfacing `taco`, `finch-jl`, `freetensor`, `cuda-tile`,
`tensor-ir`, and five recent attention/quantization kernels from Moonshot AI, Alibaba, Ant Group and
MIT HAN Lab. One candidate, `mlstm-kernels`, carries a genuinely restrictive custom license (NXAI
Community License) — accepted as a discovery candidate per the workflow (this step never scores),
flagged so the promotion pass doesn't default-assume it's open.

## storage (13 accepted)

`weaviate` was the prior census's own conspicuous-absence flag, confirmed still uncarried.
`diskann` and `sptag` fill the ANN-index gap; `oxen` and `quilt` the versioned-data-layer gap;
`openmldb` the feature-platform gap. Second pass added `lakesoul`, `pixeltable`, `lamindb`,
`butterfree`.

`RediSearch` is a deliberate ruling, not a straight discovery accept: the first pass parked it
alongside `redis` as a general-purpose data store, but that's the wrong comparison — `pgvector` is
already carried in this category as a Postgres extension, and RediSearch is the same shape, a
general store's search/vector module. Accepted on that precedent; its eventual openness score is a
separate question the promotion pass will read honestly (the category already carries source-available
exceptions on the same footing, Elasticsearch and Meilisearch).

Heaviest dedup in the round: storage lost 22 raw signals to already-carried products or already-
resolved ledger entries, mostly the `rag-frameworks-and-vector-search` and
`agent-memory-and-context-stores` clusters that already carry 31 exclusions between them.

## telemetry_observability (7 accepted)

The thinnest category by a wide margin — 245 raw signals across two passes (100-star floor, then
100-star floor with 7 more query angles) yielded only 7 real candidates: `ragaai-catalyst` and
`logfire` from the first pass; `monocle`, `evidently`, `traccia`, `axon`, `latitude-llm` from the
second. This is not an artifact of the retrieval cutoff — the second pass widened it substantially
and the yield stayed thin, which the category's own maturity argues is correct rather than
incomplete.

`evidently`'s inclusion was contested twice over — the first-pass sweep read it as evaluation_code
and declined to add it (matching a flag from the original whole-corpus census); the second pass,
run independently, read it the opposite way. An earlier draft of this PR split the difference by
holding it out pending a ruling. Ruled on review: **telemetry_observability.** The deciding test is
product shape, not feature overlap — evaluation is one workflow inside Evidently, while continuous
monitoring (a persistent UI/service tracking metrics and tests over time) is its first-class
surface, unlike a benchmark-runner or model-ranking harness such as lm-evaluation-harness, HELM or
OpenCompass. The same test applies to `langwatch` and `judgeval`, held out of Round 1's
evaluation_code pass on the same unresolved boundary — recorded in the ledger against this ruling so
a future sweep doesn't re-derive it from nothing.

## Ledger

292 → 300 entries (8 net new). Two identity hazards recorded (`cudnn-frontend`; `torch-tensorrt`'s
initial exclusion was reversed on review and removed pre-merge rather than left as a stale entry,
since this branch hadn't shipped), one governance hold tied to the existing `raft` question (#428,
`cuvs`), and five genuinely contested or research-derived calls (`superduper`'s category ambiguity,
two implausible-signal flags needing a legitimacy check, `postgresml`'s double question,
`failproofai`'s license-body finding) — plus `evidently`'s entry, updated in place to record the
review ruling rather than left in its earlier ambiguous state.

Deliberately **not** logged: the much larger bulk of off-thesis and cheap-to-re-derive parks —
general-purpose infrastructure (`redis`, `posthog`, `openobserve`), domain applications, and hits on
already-named ledger clusters (agent-memory, RAG-frameworks, general-agent-frameworks). A future
sweep re-deriving "this is a general-purpose database" costs seconds; logging every such case would
turn the ledger into a second product registry.

## Verification

```
uv run python -m build.validate                    # 0 error(s)
uv run pytest tests/test_resolution_ledger.py -q   # 15 passed
```

## Next

41 accepted candidates go to a promotion pass next, sized and dispatched the way Round 1's was —
its own plan, its own sign-off, before any product or score file is written.
