### PR TITLE
Reword the MinerU license note to unblock the data sync

### DIFF
--- a/sources/scores/mineru.yaml
+++ b/sources/scores/mineru.yaml
@@ -17,11 +17,12 @@ openness:
     is Apache-2.0 'subject to the additional terms below', and those terms require a separate commercial license
     once an organization and its affiliates exceed 100 million monthly active users or USD 20 million in monthly
     revenue, oblige anyone offering an online service built on it to say so prominently, and terminate the grant
-    automatically on breach. That is a license charging for a class of use above a threshold, which is the competition_restricted
-    tier stated directly, and the ladder scores a public source under that tier at 2/source_available. Nothing is
-    withheld from the published tree - the whole pipeline is there and builds - so core-gated is ungated and the
-    cap comes from the license alone. GitHub reports NOASSERTION because the file is a modified Apache text, which
-    is substantive here rather than the usual custom-copyright-line false alarm.
+    automatically if those terms are violated. That is a license charging for a class of use above a threshold,
+    which is the competition_restricted tier stated directly, and the ladder scores a public source under that
+    tier at 2/source_available. Nothing is withheld from the published tree - the whole pipeline is there and
+    builds - so core-gated is ungated and the cap comes from the license alone. GitHub reports NOASSERTION
+    because the file is a modified Apache text, which is substantive here rather than the usual
+    custom-copyright-line false alarm.
   raw: license:MinerU-Open-Source-License(Apache-2.0 plus commercial thresholds; not OSI);source:public(the repository
     builds the extraction pipeline the package installs);core-gated:ungated(nothing is withheld from the published
     tree; the constraint is in the license, not in the build)


### PR DESCRIPTION
## Summary

Reword the MinerU openness note from "terminate the grant automatically on breach" to "...if those terms are violated", and re-flow the note to the file's existing line width. `sources/` only — the payload is regenerated by the bot on merge.

## Why

aipotluck.org runs a `check:vocabulary` gate that treats "breach" as security-only vocabulary. The gate scans `web/static/data/notebook_data.json`, so a word written here in its ordinary contract sense fails a check in a repo it was never written for:

```
vocabulary check: 1 disallowed use(s).

  web/static/data/notebook_data.json:43478
    "breach" is for security contexts only — a threshold crossing is OVER,
    a failed test case DID NOT HOLD
```

Every daily sync PR since 2026-08-31 has failed on this one use, so the site's data has been frozen for two days while the cron kept reporting success. Nothing alerted, because from Actions' point of view the sync worked.

The wording change is not a concession that the original was wrong, it was correct. It is the cheapest way to get the data moving again. The durable fix is to stop a prose style gate from policing a generated data file, which is an aipotluck.org change and belongs in its own PR.

## Test plan

- `uv run python -m build.validate` — 0 errors
- `uv run python -m build.check_rubric` — passes
- `uv run python -m build.check_payload` — 576 products, 321 organizations, ok
- `grep -rni breach sources/` — no matches
- Regenerated the payload locally to confirm the string clears; that file is not part of this PR

## Note

The payload is at 576 products while the live map still shows 522. Merging this unblocks the sync, so the next run will publish that difference.