### PR TITLE
fix(storage): make declared package artifacts match the adoption they measure

### DIFF
--- a/sources/categories/storage.yaml
+++ b/sources/categories/storage.yaml
@@ -134,8 +134,17 @@ comments: >-
   dataset_processing_tools boundary rather than this category's, and its last real commit is
   2025-06-06 - the GitHub API's `pushed_at` read over a year newer on bot-triggered pushes with no
   accompanying commits, which is worth checking on any repository whose activity looks livelier than its
-  commit log. Its row was removed from the registry rather than parked. diskann's PyPI package
-  (`diskannpy`) binds the legacy C++ implementation the repository itself says is no longer actively
-  developed - the maintained code is a Rust-based composable DiskANN3 library - so its downloads were not
-  used for adoption, which is the same client-package caution the category's PyPI-name trap describes,
-  one layer down.
+  commit log. Its row was removed from the registry rather than parked.
+
+  Artifact identity in the round-2 roster, settled on review: a declared PyPI or npm artifact is a
+  measurement identity, so a package whose count is not the product's usage is left undeclared rather than
+  declared and discounted in the adoption note - otherwise the next warehouse refresh routes to it and
+  overwrites the star-based judgment with the wrong count. Three packages were removed on that rule:
+  `weaviate-client` (client for the server, published from a separate repository), `openmldb` (client SDK
+  for a running cluster) and `diskannpy` (binds the legacy C++ implementation the repository itself says is
+  no longer actively developed; the maintained code is a Rust-based composable DiskANN3 library). All three
+  products band from stars. Four packages stay declared and their bands were made to follow them: `quilt3`
+  (the SDK and CLI that create and install Quilt packages against S3 on their own, so a Quilt user rather than
+  a client of a server), `oxenai` (compiles liboxen into the wheel), `sptag` (first-party bindings built from
+  the repository root) and `lamindb` (the library itself). `@orama/orama` and `pixeltable` are the product
+  itself and were never in question. The reasoning for each sits in the product's comments.

--- a/sources/products/diskann.yaml
+++ b/sources/products/diskann.yaml
@@ -6,9 +6,9 @@ description: DiskANN is a Microsoft Research vector indexing library built aroun
   composable library exposing build and query APIs rather than a standalone server.
 github:
 - url: https://github.com/microsoft/DiskANN
-pypi:
-- url: https://pypi.org/project/diskannpy/
-comments: The repository has moved to a Rust-based composable DiskANN3 architecture (a `DataProvider` trait
-  implemented per host system); the diskannpy PyPI package binds the legacy C++ implementation on the `cpp_main`
-  branch, which the repository itself states is no longer actively developed, so its downloads are not attributed
-  to this product's current adoption. Verified 2026-09-02 via the GitHub API and the LICENSE body.
+comments: No PyPI artifact is declared on purpose. The repository has moved to a Rust-based composable DiskANN3
+  architecture (a `DataProvider` trait implemented per host system); the diskannpy PyPI package (0.7.0, no
+  project URL in its metadata) binds the legacy C++ implementation on the `cpp_main` branch, which the repository
+  itself states is no longer actively developed. Its downloads measure the frozen artifact, not the product being
+  scored, and declaring it would make that count the product's adoption on the next warehouse refresh, so it
+  stays undeclared and adoption reads from stars. Verified 2026-09-02 via the GitHub API and the LICENSE body.

--- a/sources/products/lamindb.yaml
+++ b/sources/products/lamindb.yaml
@@ -8,4 +8,6 @@ github:
 - url: https://github.com/laminlabs/lamindb
 pypi:
 - url: https://pypi.org/project/lamindb/
-comments: Verified 2026-09-02 via the GitHub API and the LICENSE body.
+comments: lamindb on PyPI is the library itself - there is no separate server - and its metadata points back at
+  laminlabs/lamindb, so it is the measurement identity and adoption bands on its downloads. Verified 2026-09-02
+  via the GitHub API, the PyPI metadata and the LICENSE body.

--- a/sources/products/openmldb.yaml
+++ b/sources/products/openmldb.yaml
@@ -6,8 +6,8 @@ description: OpenMLDB is a machine learning database that computes SQL-defined f
   online and offline execution engine sharing the same feature definitions.
 github:
 - url: https://github.com/4paradigm/OpenMLDB
-pypi:
-- url: https://pypi.org/project/openmldb/
-comments: openmldb on PyPI is the client SDK for connecting to a running OpenMLDB cluster, not the distributed
-  database engine, so its downloads are not attributed to this product. Verified 2026-09-02 via the GitHub API
-  and the LICENSE body.
+comments: No PyPI artifact is declared on purpose. openmldb on PyPI is the Python SDK for connecting to a running
+  OpenMLDB cluster, built from the `python/` directory of this repository, not the distributed database engine;
+  installing it gives you a way to reach a cluster, not a cluster. Declaring it would make the SDK's count the
+  product's adoption on the next warehouse refresh, so it stays undeclared and adoption reads from stars.
+  Verified 2026-09-02 via the GitHub API and the LICENSE body.

--- a/sources/products/oxen.yaml
+++ b/sources/products/oxen.yaml
@@ -9,4 +9,8 @@ github:
 - url: https://github.com/Oxen-AI/Oxen
 pypi:
 - url: https://pypi.org/project/oxenai/
-comments: Verified 2026-09-02 via the GitHub API and the LICENSE body.
+comments: oxenai on PyPI is declared as the measurement identity. It is built from this repository's `oxen-python`
+  directory and compiles liboxen into the wheel, so installing it gives you Oxen (init, add, commit, push, pull run
+  locally) rather than a client to an Oxen Server, and its metadata points back at Oxen-AI/Oxen. It is a minority
+  channel next to the CLI, so the adoption note treats the count as a lower bound. Verified 2026-09-02 via the
+  GitHub API, the PyPI metadata and the LICENSE body.

--- a/sources/products/quilt.yaml
+++ b/sources/products/quilt.yaml
@@ -9,7 +9,12 @@ github:
 - url: https://github.com/quiltdata/quilt
 pypi:
 - url: https://pypi.org/project/quilt3/
-comments: quilt3 on PyPI is one of two components in this repository (the SDK and CLI); the catalog and Lambda
-  stack that make up the rest of the product are the `catalog` and `lambdas` directories in the same repository
-  and deploy from the same Apache-2.0 source, so unlike most same-named PyPI packages in this category, quilt3 is
-  not a client talking to a closed server. Verified 2026-09-02 via the GitHub API and the LICENSE body.
+comments: quilt3 on PyPI is declared as the measurement identity, and the reasoning is recorded because the
+  package is one of two components in this repository. Installing quilt3 gives you Quilt - the SDK and CLI in
+  `api/python` create, version and install data packages against S3 on their own, with the catalog and Lambda
+  stack in `catalog` and `lambdas` as an optional browsing layer over the same packages, all from the same
+  Apache-2.0 source. Every programmatic use of Quilt goes through quilt3, so its downloads count Quilt users
+  rather than clients of a separately shipped server, which is what separates it from weaviate-client or the
+  openmldb SDK. The count is a lower bound (catalog-only users never install it) and the note says so. Verified
+  2026-09-02 via the GitHub API, the PyPI metadata (Repository points back at quiltdata/quilt) and the LICENSE
+  body.

--- a/sources/products/sptag.yaml
+++ b/sources/products/sptag.yaml
@@ -9,4 +9,8 @@ github:
 pypi:
 - url: https://pypi.org/project/sptag/
 comments: Distinct from diskann - a different Microsoft Research ANN algorithm family (tree-plus-graph rather
-  than Vamana), maintained independently. Verified 2026-09-02 via the GitHub API and the LICENSE body.
+  than Vamana), maintained independently. sptag on PyPI is declared as the measurement identity because, unlike
+  diskannpy, it is built from this repository's root `setup.py` against the current code by the Microsoft SPTAG
+  team, and the library has no server for it to be a client of; installing it gives you SPTAG. Its count is small
+  because most users build the C++ library directly, which the adoption note records. Verified 2026-09-02 via the
+  GitHub API, the PyPI metadata (Homepage points back at Microsoft/SPTAG) and the LICENSE body.

--- a/sources/products/weaviate.yaml
+++ b/sources/products/weaviate.yaml
@@ -7,8 +7,8 @@ description: Weaviate is an open-source vector database that stores objects and 
   modules that call out to embedding and reranking models.
 github:
 - url: https://github.com/weaviate/weaviate
-pypi:
-- url: https://pypi.org/project/weaviate-client/
-comments: weaviate-client on PyPI is the Python client for a self-hosted or hosted Weaviate instance, not the
-  server, so its downloads are not attributed to this product. Verified 2026-09-02 via the GitHub API and the
-  LICENSE body.
+comments: No PyPI artifact is declared on purpose. weaviate-client (80M downloads a month, published from
+  weaviate/weaviate-python-client) is the Python client for a self-hosted or hosted Weaviate instance, not the
+  server; installing it gives you a way to reach a Weaviate, not a Weaviate. Declaring it would make the client's
+  count the product's adoption on the next warehouse refresh, so the package is recorded in the resolution ledger
+  instead and adoption reads from stars. Verified 2026-09-02 via the GitHub API and the LICENSE body.

--- a/sources/resolution_ledger.yaml
+++ b/sources/resolution_ledger.yaml
@@ -2098,3 +2098,13 @@ resolutions:
     feature, which also argues for a different category. Growth curve is fast for its age
     (1,671 stars and 415 forks in about five months), flagged rather than trusted at face value.
     Left unresolved on both the license and the category question.'
+- repo: weaviate/weaviate-python-client
+  verdict: existing_product
+  product: weaviate
+  decided_in: 'Round 2 storage promotion, identity fix'
+  decided_on: '2026-09-02'
+  note: 'Publishes the PyPI package weaviate-client, the Python client for a running Weaviate instance.
+    Recorded so no sweep proposes it as a product, and deliberately NOT declared as one of weaviate''s
+    artifacts: at 80M downloads a month it would band the server at level 5 on the strength of its
+    client, the shape docs/reference/identity.md calls a real binding whose usage is not the head
+    product''s usage. weaviate bands from stars instead.'

--- a/sources/scores/diskann.yaml
+++ b/sources/scores/diskann.yaml
@@ -46,9 +46,11 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: 1,915 GitHub stars, which lands in the 1K-10K stars band of the stars scale, level 2. The diskannpy package
-    on PyPI binds the legacy C++ implementation the repository itself says is no longer actively developed, so its
-    downloads measure the frozen artifact rather than the current DiskANN3 library, and are not used here.
+  note: 1,915 GitHub stars, which lands in the 1K-10K stars band of the stars scale, level 2. No package artifact is
+    declared - the PyPI diskannpy package binds the legacy C++ implementation the repository itself says is no
+    longer actively developed, so its downloads would measure the frozen artifact rather than the current DiskANN3
+    library, and it is left undeclared rather than declared and ignored (see the product comments). The stars scale
+    applies with its cap of 3.
   last_verified: '2026-09-02'
   sources:
   - url: https://api.github.com/repos/microsoft/DiskANN

--- a/sources/scores/lamindb.yaml
+++ b/sources/scores/lamindb.yaml
@@ -43,14 +43,21 @@ openness:
     - source
     - core-gated
 adoption:
-  level: 1
-  reach: <1K stars
-  signal_type: stars_fallback
-  confidence: low
-  note: 365 GitHub stars, which lands in the <1K stars band of the stars scale, level 1. No countable download
-    figure was confirmed for `lamindb` on PyPI at verification time, which leaves the stars scale.
+  level: 2
+  reach: 10K-100K
+  signal_type: usage_volume
+  confidence: high
+  note: 75,817 PyPI downloads of `lamindb` in the trailing 30 days, which lands in the 10K-100K band of the software
+    usage scale, level 2. LaminDB is a Python library with no separate server, so the package is the product itself
+    rather than a client to one. The first verification pass could not read pypistats (rate-limited) and fell back
+    to stars; the figure was confirmed on a retry the same day.
   last_verified: '2026-09-02'
   sources:
+  - url: https://pypistats.org/api/packages/lamindb/recent
+    shows: last_month downloads = 75,817 for lamindb.
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: 1553f75a5780b51af5bb8678878bab9ce5385554660636f0592acd928d33aafb
   - url: https://api.github.com/repos/laminlabs/lamindb
     shows: Repo metadata - stargazers_count = 365 - for laminlabs/lamindb.
     accessed: '2026-09-02'

--- a/sources/scores/openmldb.yaml
+++ b/sources/scores/openmldb.yaml
@@ -46,10 +46,10 @@ adoption:
   reach: 1K-10K stars
   signal_type: stars_fallback
   confidence: low
-  note: 1,711 GitHub stars, which lands in the 1K-10K stars band of the stars scale, level 2. The openmldb package
-    on PyPI is the client SDK for a running OpenMLDB cluster rather than the cluster engine itself, so its
-    downloads are not attributed here. No deployment count is published, which leaves the stars scale and its cap
-    of 3.
+  note: 1,711 GitHub stars, which lands in the 1K-10K stars band of the stars scale, level 2. No package artifact is
+    declared - the PyPI openmldb package is the client SDK for a running OpenMLDB cluster rather than the cluster
+    engine, so it is left undeclared rather than declared and ignored (see the product comments). No deployment
+    count is published, which leaves the stars scale and its cap of 3.
   last_verified: '2026-09-02'
   sources:
   - url: https://api.github.com/repos/4paradigm/OpenMLDB

--- a/sources/scores/oxen.yaml
+++ b/sources/scores/oxen.yaml
@@ -44,15 +44,24 @@ openness:
     - source
     - core-gated
 adoption:
-  level: 2
-  reach: 1K-10K stars
-  signal_type: stars_fallback
-  confidence: low
-  note: 1,183 GitHub stars, which lands in the 1K-10K stars band of the stars scale, level 2. No deployment or
-    download count for the CLI, liboxen crate or oxenai PyPI bindings is published in a form that isolates real
-    usage, which leaves the stars scale and its cap of 3.
+  level: 1
+  reach: <10K
+  signal_type: usage_volume
+  confidence: medium
+  note: 4,302 PyPI downloads of `oxenai` in the trailing 30 days, which lands in the <10K band of the software
+    usage scale, level 1. oxenai is built from this repository's `oxen-python` directory and compiles liboxen into
+    the wheel, so installing it gives you Oxen itself rather than a client to an Oxen Server, and it is the one
+    declared artifact with a countable channel. It undercounts - the CLI is installed through Homebrew, cargo and
+    a shell script that publish no figures - which is why confidence is medium rather than high. The stars scale
+    would read one level higher (1,183 stars, 1K-10K), but a declared package artifact is the measurement identity
+    and its count is what the warehouse routes to.
   last_verified: '2026-09-02'
   sources:
+  - url: https://pypistats.org/api/packages/oxenai/recent
+    shows: last_month downloads = 4,302 for oxenai.
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: dabe109693d849a2c18977af5907159095b16076a0edadee8e436aafa8bce800
   - url: https://api.github.com/repos/Oxen-AI/Oxen
     shows: Repo metadata - stargazers_count = 1,183 - for Oxen-AI/Oxen.
     accessed: '2026-09-02'

--- a/sources/scores/quilt.yaml
+++ b/sources/scores/quilt.yaml
@@ -50,14 +50,22 @@ openness:
     - core-gated
 adoption:
   level: 2
-  reach: 1K-10K stars
-  signal_type: stars_fallback
-  confidence: low
-  note: 1,370 GitHub stars, which lands in the 1K-10K stars band of the stars scale, level 2. quilt3's PyPI
-    downloads measure local client and CLI installs rather than deployed catalog stacks, which is the countable
-    channel for this kind of self-hosted platform, so the stars scale applies with its cap of 3.
+  reach: 10K-100K
+  signal_type: usage_volume
+  confidence: medium
+  note: 32,910 PyPI downloads of `quilt3` in the trailing 30 days, which lands in the 10K-100K band of the software
+    usage scale, level 2. quilt3 is the SDK and CLI built from this repository's `api/python`, and it creates,
+    versions and installs Quilt packages against S3 without a catalog, so the count measures Quilt users rather
+    than clients of a separate server. It is a lower bound - people who only browse a deployed catalog never
+    install it - which is why confidence is medium. The stars scale would give the same level (1,370 stars,
+    1K-10K).
   last_verified: '2026-09-02'
   sources:
+  - url: https://pypistats.org/api/packages/quilt3/recent
+    shows: last_month downloads = 32,910 for quilt3.
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: 41ba6e90d37013ce5567c861f0d91d871f8d4285936c2f9d6b34d320c64b397e
   - url: https://api.github.com/repos/quiltdata/quilt
     shows: Repo metadata - stargazers_count = 1,370 - for quiltdata/quilt.
     accessed: '2026-09-02'

--- a/sources/scores/weaviate.yaml
+++ b/sources/scores/weaviate.yaml
@@ -49,10 +49,10 @@ adoption:
   reach: '>10K stars'
   signal_type: stars_fallback
   confidence: low
-  note: 16,776 GitHub stars, which lands in the >10K stars band of the stars scale, level 3. The weaviate-client
-    package on PyPI is a client for a running Weaviate instance rather than the server, so its downloads are not
-    attributed here. Weaviate is deployed as a Docker or Kubernetes cluster with no published deployment count,
-    which leaves the stars scale and its cap of 3.
+  note: 16,776 GitHub stars, which lands in the >10K stars band of the stars scale, level 3. No package artifact is
+    declared - the PyPI weaviate-client package is a client for a running Weaviate instance rather than the server,
+    so it is left undeclared rather than declared and ignored (see the product comments). Weaviate is deployed as a
+    Docker or Kubernetes cluster with no published deployment count, which leaves the stars scale and its cap of 3.
   last_verified: '2026-09-02'
   sources:
   - url: https://api.github.com/repos/weaviate/weaviate


### PR DESCRIPTION
Review fix for the storage leg of #453 (measurement-artifact identity, per the branch review).

The test applied to every declared usage artifact: does installing it give you the scored head
product, or a way to reach a component/server that varies independently?

| Product | Artifact | Decision |
|---|---|---|
| weaviate | pypi `weaviate-client` | **Removed** — client for a running server, separate repo, 80M dl/mo would have banded the server at 5. Ledgered as `existing_product` so no sweep re-proposes it. Stays stars 3. |
| openmldb | pypi `openmldb` | **Removed** — Python SDK for a cluster, not the engine. Stays stars 2. |
| diskann | pypi `diskannpy` | **Removed** — binds the legacy `cpp_main` C++ tree, not DiskANN3. Stays stars 2. |
| quilt | pypi `quilt3` | Kept — built in-tree, works against S3 with no catalog, so it counts Quilt users. Re-banded on it: 32,910/mo → level 2 (unchanged from stars 2). |
| oxen | pypi `oxenai` | Kept — in-tree, compiles liboxen into the wheel, not a client of Oxen Server. Re-banded: 4,302/mo → **level 1** (was stars 2). Stage-neutral. |
| lamindb | pypi `lamindb` | Kept — the library itself. First pass hit a pypistats 429; retry: 75,817/mo → **level 2** (was stars 1). Stage-neutral. |
| sptag | pypi `sptag` | Kept — first-party, built from root `setup.py`. Already usage_volume 1. |
| orama, pixeltable | npm / pypi | Kept — the engine / library itself. |

Adoption notes on the three undeclared products now say the package is undeclared rather than
"declared but not attributed". The category comments record the rule and all seven decisions.

Refetch (`check_refetch --strict`) over all 12: no fabricated digests. Every drift is an
`api.github.com/repos/*` body (star counts move), plus one 403 on pixeltable's final run from an
exhausted unauthenticated GitHub quota that had passed on the run before.

Validation: validate 0 errors; check_recipe 0 failures; check_rubric storage 39/39;
check_verification / check_capability / check_adoption / check_instrument OK. pytest excluding the
five corpus goldens: 1136 passed — the goldens are re-pinned once, centrally, in #453 after all three
fix legs merge. `check_artifacts` could not run: pyoso reports `InsufficientCreditError` on the
warehouse account (see note on #453).
