### PR TITLE
fix(telemetry_observability): band adoption on the product measured, replace a fabricated digest

### DIFF
--- a/sources/products/axon.yaml
+++ b/sources/products/axon.yaml
@@ -10,4 +10,7 @@ github:
 npm:
 - url: https://www.npmjs.com/package/@axon-ai/cli
 comments: The CLI, backend and dashboard packages it bundles all ship in the same MIT-licensed repository
-  and run entirely on the developer's machine. Verified 2026-09-02 via the langchain-tracer/Axon repository.
+  and run entirely on the developer's machine. The @axon-ai/cli npm package is declared as a measurement
+  artifact because installing it installs and runs the product - the CLI launches the backend and serves the
+  dashboard - so its download count is Axon's own usage rather than a client's or a component's. Verified
+  2026-09-02 via the langchain-tracer/Axon repository.

--- a/sources/products/evidently.yaml
+++ b/sources/products/evidently.yaml
@@ -12,5 +12,9 @@ pypi:
 - url: https://pypi.org/project/evidently
 comments: Ruled into telemetry_observability rather than evaluation_code in the resolution ledger (2026-09-01,
   pull request 451 review) on product shape - continuous monitoring is Evidently's first-class surface and
-  evaluation one workflow inside it, unlike a benchmark-runner or model-ranking harness. Verified 2026-09-02
-  via the evidentlyai/evidently repository.
+  evaluation one workflow inside it, unlike a benchmark-runner or model-ranking harness. The evidently PyPI
+  package is declared as a measurement artifact because installing it gives you the product - the evaluation
+  library and the Monitoring UI service (`evidently ui`) both ship in that one package, its PyPI homepage
+  points back at evidentlyai/evidently, and it is published by the project's own maintainers. Evidently Cloud
+  is a separate hosted layer and is not what is scored here. Verified 2026-09-02 via the evidentlyai/evidently
+  repository.

--- a/sources/products/latitude-llm.yaml
+++ b/sources/products/latitude-llm.yaml
@@ -8,11 +8,12 @@ description: Self-healing AI agent platform providing telemetry-based tracing of
   hosted cloud with usage-based billing.
 github:
 - url: https://github.com/latitude-dev/latitude-llm
-pypi:
-- url: https://pypi.org/project/latitude-telemetry
-npm:
-- url: https://www.npmjs.com/package/@latitude-data/telemetry
 comments: The whole platform - web app, worker, CLI, SDKs and telemetry packages - ships MIT-licensed in
   one repository, with no enterprise-only directory found in the recursive tree; the hosted cloud's
-  credit-based billing is a separate commercial layer. Verified 2026-09-02 via the latitude-dev/latitude-llm
+  credit-based billing is a separate commercial layer. Only the repository is declared as an artifact. The
+  latitude-telemetry PyPI package and the @latitude-data/telemetry npm package are one component of the
+  platform - the instrumentation library an application imports - so their install counts measure how many
+  applications emit traces, not how many Latitude instances run, and a component's count must not stand in
+  for the whole platform's. The platform itself installs from Docker Hub images, a Helm chart or Railway,
+  none of which is a declarable artifact kind. Verified 2026-09-02 via the latitude-dev/latitude-llm
   repository.

--- a/sources/products/logfire.yaml
+++ b/sources/products/logfire.yaml
@@ -9,9 +9,13 @@ description: AI and application observability platform from the Pydantic team, b
   under a purchased enterprise license.
 github:
 - url: https://github.com/pydantic/logfire
-pypi:
-- url: https://pypi.org/project/logfire
 comments: The repository's own README states this directly - "This repo contains the Python SDK for logfire
   and documentation; the server application for recording and displaying data is closed source" - and its
   "Open-Source and Closed-Source Boundaries" section confirms the platform (UI and backend) is closed, self-hostable
-  only under a paid enterprise license. Verified 2026-09-02 via the pydantic/logfire repository.
+  only under a paid enterprise license. The scored product is that platform. The logfire PyPI package is
+  deliberately not declared as an artifact, because installing the SDK does not measure use of the platform -
+  it exports to any OpenTelemetry backend and is pulled in as an instrumentation dependency by Pydantic AI
+  and other libraries, so its install count can move independently of how many people send data to Logfire.
+  The repository stays declared because it is the vendor's own canonical repository for the product (the SDK
+  and the documentation), the openness read rests on it, and it is not a third-party binding. Verified 2026-09-02
+  via the pydantic/logfire repository.

--- a/sources/products/monocle.yaml
+++ b/sources/products/monocle.yaml
@@ -11,5 +11,9 @@ github:
 pypi:
 - url: https://pypi.org/project/monocle_apptrace
 comments: A Linux Foundation AI & Data project with no commercial tier or hosted platform; everything the
-  SDK does ships in the published, Apache-2.0 repository. Verified 2026-09-02 via the monocle2ai/monocle
-  repository.
+  SDK does ships in the published, Apache-2.0 repository. The monocle_apptrace PyPI package is declared as a
+  measurement artifact because the SDK is the product - installing the package is installing Monocle, and
+  there is no server or platform behind it whose use the package could stand in for. Its PyPI homepage points
+  back at monocle2ai/monocle; the publisher of record is Okahu, the company that contributed Monocle to the
+  Linux Foundation and maintains it, so a different publisher name is not a different project here. Verified
+  2026-09-02 via the monocle2ai/monocle repository.

--- a/sources/products/ragaai-catalyst.yaml
+++ b/sources/products/ragaai-catalyst.yaml
@@ -5,11 +5,12 @@ description: Python client for RagaAI's hosted LLM observability and evaluation 
   dataset and prompt management, agentic trace recording, metric-based evaluation, synthetic data generation
   and guardrail management. Every operation authenticates against the hosted catalyst.raga.ai service; the
   repository ships no server, dashboard or self-host path of its own.
-github:
-- url: https://github.com/raga-ai-hub/RagaAI-Catalyst
-pypi:
-- url: https://pypi.org/project/ragaai-catalyst
 comments: The Apache-2.0 license covers only this client library. The repository's own README requires an
   access key and secret key issued by the hosted catalyst.raga.ai platform for every operation and contains
-  no docker-compose, server or dashboard code, so the product it talks to is a closed SaaS. Verified 2026-09-02
+  no docker-compose, server or dashboard code, so the product it talks to is a closed SaaS. No artifact is
+  declared, on purpose. The scored product is the hosted platform, and both the raga-ai-hub/RagaAI-Catalyst
+  repository and the ragaai-catalyst PyPI package are its client, so installing or starring them measures
+  the client, not the platform - the open-satellite-around-a-closed-core shape in docs/reference/identity.md,
+  which is why the repository is recorded in the resolution ledger against this product rather than declared.
+  Both stay cited as openness evidence, because that is what they are evidence of. Verified 2026-09-02
   via the raga-ai-hub/RagaAI-Catalyst repository.

--- a/sources/products/traccia.yaml
+++ b/sources/products/traccia.yaml
@@ -1,15 +1,21 @@
 name: traccia
 display_name: Traccia
 type: software
-description: OpenTelemetry-based Python SDK for tracing, evaluation, governance and compliance across AI
-  agents and LLM applications, with automatic instrumentation for OpenAI, Anthropic and Gemini, guardrail
-  and safety-control detection, and EU AI Act and HIPAA-oriented evidence records. Core tracing exports as
-  OTLP to any collector - Grafana Tempo, Jaeger, Zipkin, SigNoz, console or file - with no account required.
-  Prompt registry access and persisted evaluation experiments call out to the hosted Traccia platform.
+description: The open-source Traccia Python SDK - the traccia package built from traccia-ai/traccia-py - for
+  OpenTelemetry-based tracing, evaluation, governance and compliance across AI agents and LLM applications,
+  with automatic instrumentation for OpenAI, Anthropic and Gemini, guardrail and safety-control detection,
+  and EU AI Act and HIPAA-oriented evidence records. Core tracing exports as OTLP to any collector - Grafana
+  Tempo, Jaeger, Zipkin, SigNoz, console or file - with no account required. The hosted Traccia platform at
+  app.traccia.ai, which the SDK's prompt registry and persisted evaluation experiments call out to, is a
+  separate commercial product and is not the product scored here.
 github:
 - url: https://github.com/traccia-ai/traccia-py
 pypi:
 - url: https://pypi.org/project/traccia
-comments: The published Apache-2.0 repository is the whole of what ships; the hosted app.traccia.ai platform
-  is a separate product for the prompt registry and experiment persistence, not a withheld part of the SDK
-  itself. Verified 2026-09-02 via the traccia-ai/traccia-py repository.
+comments: The scored product is the SDK, not the hosted platform, and all three axes describe the SDK. The
+  published Apache-2.0 repository is the whole of what ships; the hosted app.traccia.ai platform is a
+  separate product for the prompt registry and experiment persistence, not a withheld part of the SDK
+  itself. The traccia PyPI package is declared as a measurement artifact because it is the SDK - installing
+  it installs the scored product - and its PyPI project URLs point back at traccia-ai/traccia-py. Had the
+  hosted platform been the scored product, the same package would have been a client and could not have
+  been declared. Verified 2026-09-02 via the traccia-ai/traccia-py repository.

--- a/sources/resolution_ledger.yaml
+++ b/sources/resolution_ledger.yaml
@@ -2098,3 +2098,15 @@ resolutions:
     feature, which also argues for a different category. Growth curve is fast for its age
     (1,671 stars and 415 forks in about five months), flagged rather than trusted at face value.
     Left unresolved on both the license and the category question.'
+- repo: raga-ai-hub/RagaAI-Catalyst
+  verdict: existing_product
+  product: ragaai-catalyst
+  decided_in: 'Round 2 promotion review, telemetry_observability'
+  decided_on: '2026-09-02'
+  note: 'the Apache-2.0 client SDK for RagaAI Catalyst, which the map carries as the head product
+    `ragaai-catalyst` scored as the closed hosted platform it authenticates against. Recorded so no
+    sweep proposes the SDK as a product, and deliberately NOT declared as the head product''s artifact:
+    the tinker-cookbook shape. Declaring an open client against a closed platform would let the ladder
+    read the platform''s license off the client, and the repository''s 16,157 stars and the matching
+    PyPI package''s 2,711 monthly downloads measure the client''s users rather than the platform''s.
+    The repository stays cited as openness evidence, which is what it is evidence of.'

--- a/sources/scores/evidently.yaml
+++ b/sources/scores/evidently.yaml
@@ -52,23 +52,35 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  reach: null
-  signal_type: unknown
-  confidence: low
-  note: A pypi artifact (evidently) is declared for the warehouse to band from `currentai.signal_pypi`.
-    This session's own pypistats.org lookup was rate-limited (429) throughout, so no manual download
-    figure is recorded here rather than guessed. 7,877 GitHub stars on a project active since 2020
-    corroborate a mature, established user base without setting a level on their own (stars cap at
-    level 3 under this map's instrument rules).
+  level: 4
+  reach: 1M-10M
+  signal_type: usage_volume
+  confidence: medium
+  note: The evidently package draws 1,255,790 PyPI downloads a month, inside the 1M-10M band but close to
+    its floor, so a modest fall would put it at 3. The package is the product - the evaluation library and
+    the self-hostable Monitoring UI service both install from it - which is why its count is the band rather
+    than a proxy for one. 7,877 GitHub stars on a project active since 2020 corroborate without setting the
+    level.
   last_verified: '2026-09-02'
   sources:
+  - url: https://pypistats.org/api/packages/evidently/recent
+    shows: last_month = 1,255,790 downloads for evidently (last_week 179,235, last_day 29,221)
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: 9995fc455ad8ef765fddc5b0be325f510dd6a893a8c2accf597a31c5a73d3a49
+  - url: https://pypi.org/pypi/evidently/json
+    shows: 'info.name evidently, version 0.7.21, project_urls Homepage https://github.com/evidentlyai/evidently,
+      author Emeli Dral, license Apache License 2.0 - the package points back at the declared repository and
+      is published by the project''s own maintainer.'
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: 7539ccf6f8cc30943d06e41d38a43f5187e0c147dc763588512563aebfef0a05
   - url: https://api.github.com/repos/evidentlyai/evidently
     shows: stargazers_count = 7,877, forks_count = 906, created_at 2020-11-25, pushed_at 2026-08-31
       (actively maintained)
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: 77680666f7946c031a42865932b0302818bff4de1737db44f4432fb3b14288a8
+    content_sha256: 4edfcc9ccff5fe4f308f00bfe5b7b5d1cce50762ab95d00bfe7bbd8eeecd6571
 capability:
   score: 3
   basis: feature_matrix

--- a/sources/scores/latitude-llm.yaml
+++ b/sources/scores/latitude-llm.yaml
@@ -53,30 +53,44 @@ openness:
     - core-gated
 adoption:
   level: 2
-  reach: 10K-100K
-  signal_type: usage_volume
-  confidence: medium
-  note: The declared PyPI package latitude-telemetry draws 15,728 downloads a month, inside the 10K-100K
-    band. The npm package @latitude-data/telemetry, not a routed instrument but corroborating, draws
-    27,563 downloads a month over the same window - both channels land in the same band. 4,613 GitHub
-    stars corroborate without setting the level.
+  reach: 1K-10K stars
+  signal_type: stars_fallback
+  confidence: low
+  note: 4,613 GitHub stars on latitude-dev/latitude-llm, which lands in the 1K-10K stars band of the stars
+    scale, level 2. The platform is deployed as Docker Hub images, a Helm chart or a Railway template, and
+    none of those is a declarable artifact kind, so no download count of the platform itself exists to band
+    on. The telemetry packages (latitude-telemetry at 15,728 PyPI downloads a month, @latitude-data/telemetry
+    at 27,563 npm downloads a month) are one component of the platform - the instrumentation library an
+    application imports - and count instrumented applications rather than running Latitude instances, so they
+    are recorded as context and not banded. Docker Hub reports between 22,922 and 29,501 cumulative pulls per
+    image across the six platform images, a lifetime total that corroborates a small deployed base without
+    being a monthly figure.
   last_verified: '2026-09-02'
   sources:
-  - url: https://pypistats.org/api/packages/latitude-telemetry/recent
-    shows: last_month = 15,728 downloads for latitude-telemetry (last_week 3,331, last_day 632)
+  - url: https://api.github.com/repos/latitude-dev/latitude-llm
+    shows: stargazers_count = 4,613, forks_count = 387, pushed_at 2026-09-02, for latitude-dev/latitude-llm.
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: e8776da84e1555200596bf0877e26a53c75e0c9e8df8b1ad9de69f1bcf114df4
+    content_sha256: 6a56b5ab79ca871f9599d5b05fe4c99cadc9ff9fc859aaf73420e65d2afe8374
+  - url: https://hub.docker.com/v2/repositories/latitudedata/?page_size=25
+    shows: 'Six images under the latitudedata namespace with lifetime pull_count - web 22,922, api 24,418,
+      workers 23,845, ingest 24,982, workflows 29,501, migrations 27,349 - all last updated 2026-09-01.
+      Cumulative totals, not a monthly window; recorded as corroboration of the deployed base.'
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: 8baf2e639524555bf2ed482348a06ea5ac7b6f78a2a7ff2fba73388b90422b85
+  - url: https://pypistats.org/api/packages/latitude-telemetry/recent
+    shows: last_month = 15,728 downloads for latitude-telemetry (last_week 3,331, last_day 632). A measurement
+      of one component package's channel, recorded as context and explicitly not the basis of the band.
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: c9f5202d6d4977a1b1f90b4b0a4b305f0ee621ae66b7b6ba45e7eeaa0bbc3517
   - url: https://api.npmjs.org/downloads/point/last-month/@latitude-data/telemetry
-    shows: 'downloads: 27,563 for @latitude-data/telemetry, 2026-07-31 to 2026-08-29'
+    shows: 'downloads: 27,563 for @latitude-data/telemetry, 2026-07-31 to 2026-08-29. A measurement of one
+      component package''s channel, recorded as context and explicitly not the basis of the band.'
     accessed: '2026-09-02'
     http_status: 200
     content_sha256: bef361e197f83bf57bc2ba7c97db929009357882e7e1924416b76b2ceb339cfa
-  - url: https://api.github.com/repos/latitude-dev/latitude-llm
-    shows: stargazers_count = 4,613, forks_count = 387, pushed_at 2026-09-01 (actively maintained)
-    accessed: '2026-09-02'
-    http_status: 200
-    content_sha256: c004e9b0be794405dcd294520bf622f4460733983d7f0548e86824fa66912a47
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/logfire.yaml
+++ b/sources/scores/logfire.yaml
@@ -46,19 +46,42 @@ openness:
     establishes:
     - license
 adoption:
-  level: 5
-  reach: '>10M'
-  signal_type: usage_volume
-  confidence: high
-  note: The logfire package draws 13,695,048 PyPI downloads a month, well inside the >10M band. It rides
-    Pydantic's own large install base and OpenTelemetry-based instrumentation across a wide integration set.
+  level: 3
+  signal_type: reported_traction
+  confidence: low
+  banded_quantity: Vendor-published customer roster for the hosted platform, no count behind it; the 13,695,048
+    monthly PyPI downloads of the logfire SDK are the instrumentation channel and are not banded
+  note: The scored product is the closed hosted platform, and nothing counts its use. The vendor page names
+    a roster of paying customers - Motorola, Sophos, Weaviate, Nous Research, Airbyte, Vox Media, Pictet and
+    about fifteen more - and publishes no user, account or trace-volume figure, so the level rests on that
+    standing as a real, mid-sized commercial observability platform rather than on a measurement. The logfire
+    package's 13,695,048 PyPI downloads a month are deliberately not the band. The SDK exports to any
+    OpenTelemetry backend and is pulled in as a dependency by Pydantic AI and other instrumentation, so an
+    install of it is not a use of the platform, and reading a level 5 off it would credit the platform with
+    the whole Pydantic ecosystem's install base. The repository's 4,450 stars are consistent with a level of
+    this size and would band lower on the stars scale.
   last_verified: '2026-09-02'
   sources:
-  - url: https://pypistats.org/api/packages/logfire/recent
-    shows: last_month = 13,695,048 downloads for logfire (last_week 2,817,073, last_day 559,383)
+  - url: https://pydantic.dev/logfire
+    shows: '"Companies who trust Pydantic Logfire" lists Boosted.ai, DeepScribe, Airbyte, Evergreen.ai, Fleet
+      AI, Seekr, Polar.sh, Stuut, Alpaca, Motorway, WorkWhile, Sophos, Aignostics, Amboss, Motorola, Epistemix,
+      Nous Research, Pictet, SimpleClub, Tiger Data, Vox Media, ZenHub and Weaviate, plus one Dosu case study.
+      The only figure on the page is the free-tier quota ("10M spans, logs, and metrics free every month");
+      no user count, customer count or usage volume appears anywhere.'
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: e37536b846463c346f33b7479eb9a5c0333d515f6691a775e5cc829d4fdcf9d0
+    content_sha256: e54eaefee2d77cbc64111f54d72bc11f8e18b37d288a8a2c6b0a5de8d67a625a
+  - url: https://pypistats.org/api/packages/logfire/recent
+    shows: last_month = 13,695,048 downloads for logfire (last_week 2,817,073, last_day 559,383). A measurement
+      of the SDK channel, recorded as context and explicitly not the basis of the band.
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: 30ab6461394bef09bbaec5f63d86381861382ab88d620d32c3994cba46a4adbd
+  - url: https://api.github.com/repos/pydantic/logfire
+    shows: stargazers_count = 4,450, forks_count = 283, pushed_at 2026-09-02, for pydantic/logfire.
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: 236a19a70e0c73dddfe30cb8b65c7f850f16515bede6a39e74e3a2e6dc3bcfc5
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/monocle.yaml
+++ b/sources/scores/monocle.yaml
@@ -48,22 +48,34 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  reach: null
-  signal_type: unknown
-  confidence: low
-  note: A pypi artifact (monocle_apptrace) is declared for the warehouse to band from `currentai.signal_pypi`.
-    This session's own pypistats.org lookup was rate-limited (429) after the GitHub API budget was spent
-    confirming identity and license, so no manual download figure is recorded here rather than guessed.
-    GitHub shows 337 stars, consistent with a young (2024) Linux Foundation project still building adoption.
+  level: 2
+  reach: 10K-100K
+  signal_type: usage_volume
+  confidence: medium
+  note: The monocle_apptrace package draws 48,842 PyPI downloads a month, inside the 10K-100K band. The
+    package is the product - an instrumentation SDK with no platform behind it - so its install count is
+    Monocle's own usage rather than a proxy. 337 GitHub stars on a project started in 2024 corroborate a
+    young Linux Foundation project still building adoption, without setting the level.
   last_verified: '2026-09-02'
   sources:
+  - url: https://pypistats.org/api/packages/monocle_apptrace/recent
+    shows: last_month = 48,842 downloads for monocle-apptrace (last_week 12,339, last_day 2,256)
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: 969125ae10c08990e0ecee5dd024e1d917698e1f4cfa9803c51a85da8115c65d
+  - url: https://pypi.org/pypi/monocle_apptrace/json
+    shows: 'info.name monocle-apptrace, version 0.8.14, project_urls Homepage https://github.com/monocle2ai/monocle,
+      author "Okahu Inc." <okahu-pypi@okahu.ai>, license Apache-2.0 - the package points back at the declared
+      repository.'
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: 3ffa9d420393ec3916dd03bdaeefbf105c09219af4cb9b7b3186432c31aa76f8
   - url: https://api.github.com/repos/monocle2ai/monocle
     shows: stargazers_count = 337, forks_count = 58, created_at 2024-06-15, pushed_at 2026-09-01 (actively
       maintained)
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: 011f9cf2bb7eb52b3e1d1b9e591de23ca5d32921d09d13dcc8476274ca98709b
+    content_sha256: 0631e1e24c720ecd725fc57fefe6048ab1d52c0a7e13730a71f14092af504f29
 capability:
   score: 3
   basis: feature_matrix

--- a/sources/scores/ragaai-catalyst.yaml
+++ b/sources/scores/ragaai-catalyst.yaml
@@ -56,25 +56,38 @@ openness:
     - source
     - self-host
 adoption:
-  level: 1
-  reach: <10K
-  signal_type: usage_volume
-  confidence: medium
-  note: ragaai-catalyst draws 2,711 PyPI downloads a month, inside the <10K band. The repository's 16,156
-    GitHub stars sit far above what the download count would predict for a package this small, but a download
-    outranks a star count on this axis, and the SDK is the only countable channel for a closed hosted platform.
+  level: null
+  reach: null
+  signal_type: unknown
+  confidence: low
+  note: No instrument measures the hosted platform, so no level is recorded. The ragaai-catalyst PyPI package
+    (2,711 downloads a month) is the client SDK, and a client's installs count the client's users rather than
+    the platform's; the repository's 16,157 stars are the same client's, and stars three orders above a package's
+    monthly downloads is the magnitude tell the adoption guide names, not a usage reading. The vendor side
+    offers nothing to read either - raga.ai serves a JavaScript shell whose only text is a healthcare-agents
+    pitch with no customer roster or count for Catalyst, and catalyst.raga.ai, the platform endpoint every SDK
+    call authenticates against, answers 404. Banding the platform off any of that would be inventing the number.
   last_verified: '2026-09-02'
   sources:
   - url: https://pypistats.org/api/packages/ragaai-catalyst/recent
-    shows: last_month = 2,711 downloads for ragaai-catalyst (last_week 359, last_day 236)
+    shows: last_month = 2,711 downloads for ragaai-catalyst (last_week 359, last_day 236). A measurement of
+      the client SDK's channel, recorded as context and explicitly not the basis of a band.
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: 3157ff38dc1f3af94598b4328c9e92cc64e2638a021ee697ce61875fe9c06196
+    content_sha256: 3f6fd97068618aa9a72bbe63e22021d8a4f7cecfcca8121f4971c0ffa1753db8
   - url: https://api.github.com/repos/raga-ai-hub/RagaAI-Catalyst
-    shows: stargazers_count = 16,156, forks_count = 3,569
+    shows: stargazers_count = 16,157, forks_count = 3,569, pushed_at 2026-02-11, for the client SDK repository.
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: 8e7f9967831d58b2a03cf19a7fb32c03c1e682f58953c380740c5c9061f09df0
+    content_sha256: 0dedb6dc5397a1a697f6b1a91270ccb34015b938c0815e9f1a630b926a0ece5c
+  - url: https://raga.ai/
+    shows: 'A 3 KB HTML shell for a client-rendered app. The only readable text is the title and meta
+      description - "RagaAI | Enterprise Healthcare AI Agent Suites", "purpose-built, production-grade AI
+      Agent Suites for Healthcare, Lifesciences, and Aerospace. Powered by Prism and Catalyst" - with no
+      customer roster, user count or download figure for Catalyst anywhere in the served body.'
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: 03307a335fcf791a6ecc737b535e45a0bcc80b9f8903c4f58026397a2d290b21
 capability:
   score: 4
   basis: feature_matrix
@@ -106,4 +119,4 @@ capability:
       and Red-teaming, each with a working code example.'
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: 1e2c0b45a6c56e6bce6c4c68c3d6c2a2c0a6f3f4d5e8f9a0b1c2d3e4f5061728
+    content_sha256: 4530edece36d9321326cbe0c81888872fbc14b32bd3e2b07db5a28595b353cde

--- a/sources/scores/traccia.yaml
+++ b/sources/scores/traccia.yaml
@@ -56,22 +56,33 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  reach: null
-  signal_type: unknown
-  confidence: low
-  note: A pypi artifact (traccia) is declared for the warehouse to band from `currentai.signal_pypi`. This
-    session's own pypistats.org lookup was rate-limited (429) after the GitHub API budget was spent
-    confirming identity and license, so no manual download figure is recorded here rather than guessed.
-    108 GitHub stars on a repository created earlier this year is consistent with a very young product still
-    building adoption.
+  level: 1
+  reach: <10K
+  signal_type: usage_volume
+  confidence: high
+  note: The traccia package draws 764 PyPI downloads a month, well inside the <10K band. The package is the
+    scored product - the SDK itself, not a client for the hosted Traccia platform - so its install count is
+    the product's own usage. 108 GitHub stars on a repository created in January 2026 are consistent with a
+    very young product still building adoption.
   last_verified: '2026-09-02'
   sources:
+  - url: https://pypistats.org/api/packages/traccia/recent
+    shows: last_month = 764 downloads for traccia (last_week 128, last_day 5)
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: 1ebd9e88eaba0dd16791dc80215e69ab15c8853e12ad39c7ad32f681278be932
+  - url: https://pypi.org/pypi/traccia/json
+    shows: 'info.name traccia, version 0.1.28, project_urls Homepage and Repository https://github.com/traccia-ai/traccia-py,
+      license Apache-2.0, summary "Production-ready distributed tracing SDK for AI agents and LLM applications"
+      - the package points back at the declared repository.'
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: 1c92ac2466c908c9851689523663a2a3e33aa41d0604573ed702aa764ab5a212
   - url: https://api.github.com/repos/traccia-ai/traccia-py
     shows: stargazers_count = 108, forks_count = 20, created_at 2026-01-21, pushed_at 2026-08-24
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: 9d4adc7b01554c644840f82461a0b6e56c2ae1b47c44f6d4a96565dcb0772b72
+    content_sha256: 1a3a85ea6b11c3223b99400eb7f89c2b82f13fe1168d5396104681777acd4aeb
 capability:
   score: 4
   basis: feature_matrix


### PR DESCRIPTION
Review fix for the telemetry_observability leg of #453: measurement-artifact identity on three
products, one fabricated evidence digest, and a refetch pass over all seven.

Test applied to every declared artifact: does installing or starring it measure use of the scored
head product, or of a client/component that varies independently?

| Product | Now declared | Undeclared | Adoption after |
|---|---|---|---|
| ragaai-catalyst | none | PyPI client and the GitHub repo — both the client SDK of a closed hosted platform (the open-satellite shape). Repo ledgered `existing_product → ragaai-catalyst`. Both stay cited as openness evidence. | **null** with a specific reason: the 2,711/mo count is the client's; `catalyst.raga.ai`, the endpoint every SDK call authenticates against, answers 404; repo idle since 2026-02. Capability 4 unchanged. |
| logfire | GitHub | PyPI `logfire` — exports to any OTel backend and is pulled in as a Pydantic AI dependency, so 13.7M installs/mo do not count platform use. | **3, `reported_traction`**, confidence low, on the vendor's 23-company customer roster. The download figure stays recorded, explicitly not banded. |
| latitude-llm | GitHub | PyPI `latitude-telemetry` / npm `@latitude-data/telemetry` — the instrumentation library, one component. | **2, `stars_fallback`** on 4,613 stars (same level, honest instrument). Docker Hub pulls recorded as context. |
| evidently | GitHub + PyPI | — passes: the package ships the library and the `evidently ui` monitoring service | **4, `usage_volume`**, 1,255,790/mo (was null on a 429) |
| monocle | GitHub + PyPI | — passes: the SDK is the product | **2, `usage_volume`**, 48,842/mo (was null) |
| traccia | GitHub + PyPI | — passes because the scored product is now stated unambiguously as the SDK; `app.traccia.ai` is a separate unscored product | **1, `usage_volume`**, 764/mo (was null) |
| axon | GitHub + npm | — passes: the CLI installs and runs the product | unchanged, 1 |

**The digest.** `ragaai-catalyst`'s capability source carried a synthetic
`1e2c0b45…f5061728`. Real fetch: `4530edec…b353cde`, HTTP 200, 15,360 bytes — identical to the
digest already on the openness source for the same URL, so that one was genuine. The capability
claim held on the real body. Three pypistats digests (ragaai, logfire, latitude-telemetry) recorded
the figures the live body serves but did not reproduce; replaced with served values.

`check_refetch --strict` over all seven on the final pass: `[OK] no fabricated digests` on every
product; the only drift is live count endpoints (GitHub repo metadata, Docker Hub pulls).

Validation: validate 0 errors; check_recipe 0 failures; check_rubric telemetry_observability 33/33;
check_verification / check_capability / check_adoption / check_instrument OK; check_artifacts one
pre-existing unrelated finding (qwen repo rename). pytest excluding the five corpus goldens: 1136
passed — goldens re-pinned once, centrally, in #453 after all fix legs merge.

**Two things for a maintainer, not fixed here.** `docs/reference/adoption.md` still says an SDK's
downloads band the hosted platform it talks to (and `langfuse`'s note leans on it); that contradicts
the #438 identity rule as applied in this tranche. And `ragaai-catalyst` may be a dead product —
platform endpoint 404, repo idle since February — which is a retirement question, not a scoring one.
