### PR TITLE
fix(compilers): band adoption on the 18 round-2 promotions and correct the strapline

### DIFF
--- a/sources/categories/compilers.yaml
+++ b/sources/categories/compilers.yaml
@@ -5,8 +5,8 @@ strapline: Almost the whole layer stays OSI-licensed and fully open even after n
   size - 42 of 44 products score 5, and the two exceptions are TensorRT, whose optimizing builder
   ships as a binary that the public repository links against, and mLSTM Kernels, whose NXAI
   Community License gates commercial use above a revenue threshold. What is scarce here is reach
-  rather than openness, since about a third of the roster bands at capability level 2 or below,
-  because compilers and kernel libraries are built from source far more often than they are
+  rather than openness, since two-thirds of the roster - 29 of 44 - bands at adoption level 2 or
+  below, because compilers and kernel libraries are built from source far more often than they are
   installed from a package.
 weights:
   adopt: 0.5

--- a/sources/products/finch-jl.yaml
+++ b/sources/products/finch-jl.yaml
@@ -6,6 +6,4 @@ description: Finch.jl is a Julia-to-Julia compiler for sparse and structured mul
   sparse tensor compiler techniques to a wider range of array formats.
 github:
 - url: https://github.com/finch-tensor/Finch.jl
-pypi:
-- url: https://pypi.org/project/finch-tensor/
 comments: Verified 2026-09-02 via the GitHub API and the LICENSE body.

--- a/sources/products/flash-sparse-attention.yaml
+++ b/sources/products/flash-sparse-attention.yaml
@@ -6,4 +6,6 @@ description: Flash-Sparse-Attention is a trainable sparse attention kernel libra
   training and inference, including grouped-query attention, paged attention and fused-quant low-precision computation.
 github:
 - url: https://github.com/HKUSTDial/flash-sparse-attention
+pypi:
+- url: https://pypi.org/project/flash-sparse-attn/
 comments: Verified 2026-09-02 via the GitHub API and the LICENSE body.

--- a/sources/products/flashqla.yaml
+++ b/sources/products/flashqla.yaml
@@ -6,4 +6,6 @@ description: FlashQLA is a linear attention kernel library from the Qwen team, b
   library's GDN operators through the standard FLA API.
 github:
 - url: https://github.com/QwenLM/FlashQLA
+pypi:
+- url: https://pypi.org/project/flash-qla/
 comments: Verified 2026-09-02 via the GitHub API and the LICENSE body.

--- a/sources/products/mlstm-kernels.yaml
+++ b/sources/products/mlstm-kernels.yaml
@@ -6,4 +6,6 @@ description: mLSTM Kernels (Tiled Flash Linear Attention) provides fast, chunkwi
   distributes it under its own restrictive community license rather than an OSI-approved one.
 github:
 - url: https://github.com/NX-AI/mlstm_kernels
+pypi:
+- url: https://pypi.org/project/mlstm-kernels/
 comments: Verified 2026-09-02 via the GitHub API and the LICENSE body.

--- a/sources/products/torch-tensorrt.yaml
+++ b/sources/products/torch-tensorrt.yaml
@@ -5,4 +5,6 @@ description: Torch-TensorRT is PyTorch's official compiler that lowers PyTorch, 
   engines, accelerating inference on NVIDIA GPUs while staying inside the PyTorch runtime.
 github:
 - url: https://github.com/pytorch/TensorRT
+pypi:
+- url: https://pypi.org/project/torch-tensorrt/
 comments: Verified 2026-09-02 via the GitHub API and the LICENSE body.

--- a/sources/scores/attention-gym.yaml
+++ b/sources/scores/attention-gym.yaml
@@ -43,16 +43,17 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
+  level: 1
+  reach: <1K stars
+  signal_type: stars_fallback
   confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  note: 43 GitHub stars, which lands in the <1K stars band of the stars scale, level 1. The `attn-gym` package on PyPI is
+    pytorch-labs' flex-attention examples project, not this repository, and Attention-Gym itself has no registry package,
+    so no download count exists and the stars scale applies.
   last_verified: '2026-09-02'
   sources:
   - url: https://api.github.com/repos/RiseAI-Sys/attention-gym
-    shows: Repo metadata for attention-gym's canonical repository carries no package-registry download figure of its own;
-      banding is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+    shows: Repo metadata - stargazers_count = 43 - for RiseAI-Sys/attention-gym.
     accessed: '2026-09-02'
     http_status: 200
     content_sha256: 5d012bc012502f845ca7d845c9c193d9dcfb4ecb607ece625622890e20c47650

--- a/sources/scores/auto-round.yaml
+++ b/sources/scores/auto-round.yaml
@@ -28,7 +28,7 @@ openness:
     shows: Repo metadata for auto-round's canonical repository - private false, archived false, fork false.
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: 5927b97f33d2daa17980e1b6f108713548c72d60c97bfac21d7ece0c22da3051
+    content_sha256: 940724739e0f8fa64b4b0cf01cbd512832da41e1f5784dd93a8f5e6ee5729de4
     establishes:
     - license
     - source
@@ -38,24 +38,25 @@ openness:
       license-gated build beside the published source.
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: 63fd2ea00530abad3f2465f24b38b8995ca7046492698c041a9f9e60c171d9a1
+    content_sha256: 35f373bc77cb4ac8690a6e24fd9b84c5497a9bd8c413d91ec09829ffb6e443e0
     establishes:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
-  confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  level: 3
+  reach: 100K-1M
+  signal_type: usage_volume
+  confidence: high
+  note: 416,661 PyPI downloads of `auto-round` in the trailing 30 days, which lands in the 100K-1M band of the software usage
+    scale, level 3. The `auto-round-nightly` and `auto-round-hpu` variants the README also offers are not summed, so the figure
+    is a floor.
   last_verified: '2026-09-02'
   sources:
-  - url: https://api.github.com/repos/intel/auto-round
-    shows: Repo metadata for auto-round's canonical repository carries no package-registry download figure of its own; banding
-      is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+  - url: https://pypistats.org/api/packages/auto-round/recent
+    shows: last_month downloads = 416,661 for auto-round
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: 5927b97f33d2daa17980e1b6f108713548c72d60c97bfac21d7ece0c22da3051
+    content_sha256: 1a16a9ede9e2520101c4b13036e96a20d577e81cbd26c3918497834b6ca82782
 capability:
   score: 3
   basis: feature_matrix
@@ -76,7 +77,7 @@ capability:
       license-gated build beside the published source.
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: 63fd2ea00530abad3f2465f24b38b8995ca7046492698c041a9f9e60c171d9a1
+    content_sha256: 35f373bc77cb4ac8690a6e24fd9b84c5497a9bd8c413d91ec09829ffb6e443e0
   comparison:
     last_attested: '2026-09-02'
     sources:

--- a/sources/scores/block-sparse-attention.yaml
+++ b/sources/scores/block-sparse-attention.yaml
@@ -43,16 +43,16 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
+  level: 1
+  reach: <1K stars
+  signal_type: stars_fallback
   confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  note: 549 GitHub stars, which lands in the <1K stars band of the stars scale, level 1. Block-Sparse-Attention has no registry
+    package and installs from source, so no download count exists and the stars scale applies.
   last_verified: '2026-09-02'
   sources:
   - url: https://api.github.com/repos/mit-han-lab/Block-Sparse-Attention
-    shows: Repo metadata for block-sparse-attention's canonical repository carries no package-registry download figure of
-      its own; banding is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+    shows: Repo metadata - stargazers_count = 549 - for mit-han-lab/Block-Sparse-Attention.
     accessed: '2026-09-02'
     http_status: 200
     content_sha256: 2c3de6beb07389b64b445b56d80c86f1f2cf1d1bfceb9056b1aef008969c7b83

--- a/sources/scores/cuda-tile.yaml
+++ b/sources/scores/cuda-tile.yaml
@@ -29,7 +29,7 @@ openness:
     shows: Repo metadata for cuda-tile's canonical repository - private false, archived false, fork false.
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: 74507ae92425bce7659e6973f30c20d6c8d0117e9571bc6712db85b6cfd58e3e
+    content_sha256: 9bc44d317956d3d80d9532dcec9c0e9e724d21a1489b30b38fe5c778f22381c8
     establishes:
     - license
     - source
@@ -44,19 +44,22 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
+  level: 2
+  reach: 1K-10K stars
+  signal_type: stars_fallback
   confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  note: 1,021 GitHub stars, which lands in the 1K-10K stars band of the stars scale, level 2. The `cuda-tile` package on PyPI
+    (about 3.7M downloads a month) is cuTile Python, published from the separate nvidia/cutile-python repository and pulled
+    in as a dependency of the CUDA Python stack, so it measures a different project's installs rather than this compiler,
+    which the README builds from source with CMake against an LLVM install. No package channel of its own is published, which
+    leaves the stars scale and its cap of 3.
   last_verified: '2026-09-02'
   sources:
   - url: https://api.github.com/repos/NVIDIA/cuda-tile
-    shows: Repo metadata for cuda-tile's canonical repository carries no package-registry download figure of its own; banding
-      is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+    shows: Repo metadata - stargazers_count = 1,021 - for NVIDIA/cuda-tile.
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: 74507ae92425bce7659e6973f30c20d6c8d0117e9571bc6712db85b6cfd58e3e
+    content_sha256: 9bc44d317956d3d80d9532dcec9c0e9e724d21a1489b30b38fe5c778f22381c8
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/cula.yaml
+++ b/sources/scores/cula.yaml
@@ -43,16 +43,16 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
+  level: 1
+  reach: <1K stars
+  signal_type: stars_fallback
   confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  note: 544 GitHub stars, which lands in the <1K stars band of the stars scale, level 1. cuLA has no registry package and
+    is built from source, so no download count exists and the stars scale applies.
   last_verified: '2026-09-02'
   sources:
   - url: https://api.github.com/repos/inclusionAI/cuLA
-    shows: Repo metadata for cula's canonical repository carries no package-registry download figure of its own; banding
-      is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+    shows: Repo metadata - stargazers_count = 544 - for inclusionAI/cuLA.
     accessed: '2026-09-02'
     http_status: 200
     content_sha256: 751ac3757520504229b87f9f68a5641436a8f96cd1217d22c01a87423f494ef7

--- a/sources/scores/finch-jl.yaml
+++ b/sources/scores/finch-jl.yaml
@@ -42,16 +42,19 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
+  level: 1
+  reach: <1K stars
+  signal_type: stars_fallback
   confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  note: 245 GitHub stars, which lands in the <1K stars band of the stars scale, level 1. Finch.jl is installed from the Julia
+    General registry (`Pkg.add("Finch")`), which publishes no download count. The `finch-tensor` package on PyPI is a separate
+    Python library from the finch-tensor/finch-tensor repository that pulls in Finch.jl only as an optional `julia` extra,
+    so its downloads count a different project's users and it is not declared here. That leaves the stars scale and its cap
+    of 3.
   last_verified: '2026-09-02'
   sources:
   - url: https://api.github.com/repos/finch-tensor/Finch.jl
-    shows: Repo metadata for finch-jl's canonical repository carries no package-registry download figure of its own; banding
-      is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+    shows: Repo metadata - stargazers_count = 245 - for finch-tensor/Finch.jl.
     accessed: '2026-09-02'
     http_status: 200
     content_sha256: 4b81c0bb16c1684945c29b0deee07d7fd0a2240a82d73609ee15eee667606e70

--- a/sources/scores/flash-sparse-attention.yaml
+++ b/sources/scores/flash-sparse-attention.yaml
@@ -43,19 +43,26 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
-  confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  level: 1
+  reach: <10K
+  signal_type: usage_volume
+  confidence: high
+  note: 64 PyPI downloads of `flash-sparse-attn` in the trailing 30 days, which lands in the <10K band of the software usage
+    scale, level 1. The package is published from HKUSTDial/flash-sparse-attention and `pip install flash-sparse-attn` is
+    the README's install path.
   last_verified: '2026-09-02'
   sources:
-  - url: https://api.github.com/repos/HKUSTDial/flash-sparse-attention
-    shows: Repo metadata for flash-sparse-attention's canonical repository carries no package-registry download figure of
-      its own; banding is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+  - url: https://pypistats.org/api/packages/flash-sparse-attn/recent
+    shows: last_month downloads = 64 for flash-sparse-attn
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: acf9daa1686fe0f3b62fb208319c4cf5eede8a160734a30fc7b995a60b8ef2c4
+    content_sha256: 17a87a6a27870aa49c3192dd822147b098cebfccabaf307c971ba07e84fdec42
+  - url: https://pypi.org/pypi/flash-sparse-attn/json
+    shows: 'PyPI metadata for flash-sparse-attn 2.0.5 - project_urls Source = https://github.com/HKUSTDial/flash-sparse-attention,
+      summary ''Flash Sparse Attention: Fast and Memory-Efficient Trainable Sparse Attention''.'
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: 808d6507c22c2ad26852d197a1ba473c54f3f67c1d3d9884a023a34ca4d88dd0
 capability:
   score: 3
   basis: feature_matrix

--- a/sources/scores/flashkda.yaml
+++ b/sources/scores/flashkda.yaml
@@ -27,7 +27,7 @@ openness:
     shows: Repo metadata for flashkda's canonical repository - private false, archived false, fork false.
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: b993effb2c41c6c5fec3339b49a407a143075906fe8585a4b276e56427a41337
+    content_sha256: 5b7f76d44f6cae63b68b26104ac2a88ff1da7e30d70d79157d631c2fd25b5600
     establishes:
     - license
     - source
@@ -42,19 +42,19 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
+  level: 2
+  reach: 1K-10K stars
+  signal_type: stars_fallback
   confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  note: 1,243 GitHub stars, which lands in the 1K-10K stars band of the stars scale, level 2. FlashKDA has no registry package
+    and installs from source, so no download count exists and the stars scale applies.
   last_verified: '2026-09-02'
   sources:
   - url: https://api.github.com/repos/MoonshotAI/FlashKDA
-    shows: Repo metadata for flashkda's canonical repository carries no package-registry download figure of its own; banding
-      is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+    shows: Repo metadata - stargazers_count = 1,243 - for MoonshotAI/FlashKDA.
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: b993effb2c41c6c5fec3339b49a407a143075906fe8585a4b276e56427a41337
+    content_sha256: 5b7f76d44f6cae63b68b26104ac2a88ff1da7e30d70d79157d631c2fd25b5600
 capability:
   score: 2
   basis: feature_matrix

--- a/sources/scores/flashmla.yaml
+++ b/sources/scores/flashmla.yaml
@@ -27,7 +27,7 @@ openness:
     shows: Repo metadata for flashmla's canonical repository - private false, archived false, fork false.
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: ac524409aeab31aed141958dcc8286640c8653ce2b8697379d85bbe3ee7f1f42
+    content_sha256: 91f4cc78775ec7ca4b54ed66994e3361fa2ffe8b20ede63999a8095f83879fe7
     establishes:
     - license
     - source
@@ -41,19 +41,20 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
+  level: 3
+  reach: '>10K stars'
+  signal_type: stars_fallback
   confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  note: 12,895 GitHub stars, which lands in the >10K stars band of the stars scale, level 3. The `flash-mla` name on PyPI
+    holds a single 1.0.0.dev0 release with no summary or project URL, which is not DeepSeek's distribution; the README installs
+    from source with `pip install -v .`, so no download count exists and the stars scale applies with its cap of 3.
   last_verified: '2026-09-02'
   sources:
   - url: https://api.github.com/repos/deepseek-ai/FlashMLA
-    shows: Repo metadata for flashmla's canonical repository carries no package-registry download figure of its own; banding
-      is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+    shows: Repo metadata - stargazers_count = 12,895 - for deepseek-ai/FlashMLA.
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: ac524409aeab31aed141958dcc8286640c8653ce2b8697379d85bbe3ee7f1f42
+    content_sha256: 91f4cc78775ec7ca4b54ed66994e3361fa2ffe8b20ede63999a8095f83879fe7
 capability:
   score: 2
   basis: feature_matrix

--- a/sources/scores/flashqla.yaml
+++ b/sources/scores/flashqla.yaml
@@ -27,7 +27,7 @@ openness:
     shows: Repo metadata for flashqla's canonical repository - private false, archived false, fork false.
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: 07360406b5464b8f706de9833a50200741dddf7f276523a9aa91ea42a06d7cb6
+    content_sha256: bd16fe61b839913652c0fd55b99f021fa8122cdea3f7a538f0825151daf5bc29
     establishes:
     - license
     - source
@@ -42,19 +42,25 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
-  confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  level: 1
+  reach: <10K
+  signal_type: usage_volume
+  confidence: high
+  note: 2,326 PyPI downloads of `flash-qla` in the trailing 30 days, which lands in the <10K band of the software usage scale,
+    level 1. `pip install flash-qla` is the README's install path and the package description links back to QwenLM/FlashQLA.
   last_verified: '2026-09-02'
   sources:
-  - url: https://api.github.com/repos/QwenLM/FlashQLA
-    shows: Repo metadata for flashqla's canonical repository carries no package-registry download figure of its own; banding
-      is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+  - url: https://pypistats.org/api/packages/flash-qla/recent
+    shows: last_month downloads = 2,326 for flash-qla
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: 07360406b5464b8f706de9833a50200741dddf7f276523a9aa91ea42a06d7cb6
+    content_sha256: 60d33026c71ceaa41bca2c8b6f7281a51fad6ffa798da8655df823c4cddbeec2
+  - url: https://pypi.org/pypi/flash-qla/json
+    shows: 'PyPI metadata for flash-qla 0.1.2 - summary ''FlashQLA: Fused TileLang kernels for Linear Attention'', description
+      links https://github.com/QwenLM/FlashQLA, requires tilelang.'
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: 9340429581874695351fbef966ce9b472c9e03b30d5d37d016151d98d790a88b
 capability:
   score: 2
   basis: feature_matrix

--- a/sources/scores/freetensor.yaml
+++ b/sources/scores/freetensor.yaml
@@ -43,16 +43,16 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
+  level: 1
+  reach: <1K stars
+  signal_type: stars_fallback
   confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  note: 152 GitHub stars, which lands in the <1K stars band of the stars scale, level 1. FreeTensor has no PyPI or other registry
+    package and is built from source, so no download count exists and the stars scale applies.
   last_verified: '2026-09-02'
   sources:
   - url: https://api.github.com/repos/roastduck/FreeTensor
-    shows: Repo metadata for freetensor's canonical repository carries no package-registry download figure of its own; banding
-      is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+    shows: Repo metadata - stargazers_count = 152 - for roastduck/FreeTensor.
     accessed: '2026-09-02'
     http_status: 200
     content_sha256: 5e069b8983c910fdce65244ed8447a5a2ffa5f3c96b0f3b9d281e783c7e99343

--- a/sources/scores/humming.yaml
+++ b/sources/scores/humming.yaml
@@ -43,16 +43,16 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
+  level: 1
+  reach: <1K stars
+  signal_type: stars_fallback
   confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  note: 219 GitHub stars, which lands in the <1K stars band of the stars scale, level 1. Humming has no registry package and
+    is built from source, so no download count exists and the stars scale applies.
   last_verified: '2026-09-02'
   sources:
   - url: https://api.github.com/repos/inclusionAI/humming
-    shows: Repo metadata for humming's canonical repository carries no package-registry download figure of its own; banding
-      is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+    shows: Repo metadata - stargazers_count = 219 - for inclusionAI/humming.
     accessed: '2026-09-02'
     http_status: 200
     content_sha256: b94569b92273de1648b2fe143ce375da43e72c0f7a8062989bc0ace71f2ca876

--- a/sources/scores/miopen.yaml
+++ b/sources/scores/miopen.yaml
@@ -44,16 +44,17 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
+  level: 2
+  reach: 1K-10K stars
+  signal_type: stars_fallback
   confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  note: 1,193 GitHub stars, which lands in the 1K-10K stars band of the stars scale, level 2. MIOpen ships inside the ROCm
+    distribution packages (apt, dnf, zypper) and as a source build, and AMD publishes no download count for either, so the
+    stars scale applies with its cap of 3.
   last_verified: '2026-09-02'
   sources:
   - url: https://api.github.com/repos/ROCm/MIOpen
-    shows: Repo metadata for miopen's canonical repository carries no package-registry download figure of its own; banding
-      is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+    shows: Repo metadata - stargazers_count = 1,193 - for ROCm/MIOpen.
     accessed: '2026-09-02'
     http_status: 200
     content_sha256: 4c149938cebc92d72f272f89b9e60ba7646723283b36b894f1e34e93f308744a

--- a/sources/scores/mlstm-kernels.yaml
+++ b/sources/scores/mlstm-kernels.yaml
@@ -49,19 +49,26 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
-  confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  level: 2
+  reach: 10K-100K
+  signal_type: usage_volume
+  confidence: high
+  note: 11,616 PyPI downloads of `mlstm-kernels` in the trailing 30 days, which lands in the 10K-100K band of the software
+    usage scale, level 2. `pip install mlstm_kernels` is the README's install path and the package is published by the NX-AI
+    authors.
   last_verified: '2026-09-02'
   sources:
-  - url: https://api.github.com/repos/NX-AI/mlstm_kernels
-    shows: Repo metadata for mlstm-kernels's canonical repository carries no package-registry download figure of its own;
-      banding is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+  - url: https://pypistats.org/api/packages/mlstm-kernels/recent
+    shows: last_month downloads = 11,616 for mlstm-kernels
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: 523b6725ed609f39041d5b5d2e222ed9fc57f25e2c0642c7ca794f0014312d26
+    content_sha256: 3664c987269a48b4afca877db23e8da01b9385c4648704924d9bf73abe99e956
+  - url: https://pypi.org/pypi/mlstm-kernels/json
+    shows: PyPI metadata for mlstm-kernels 2.0.4 - summary 'A library providing fast and efficient mLSTM kernels for the xLSTM',
+      authors Beck, Poeppel, Lippe and Boeck (nx-ai.com), license text NXAI COMMUNITY LICENSE AGREEMENT.
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: c8e8d4b2dc737eb5b811dd3794e73691b9cb20acd8d58e8104cae37ec02fc604
 capability:
   score: 2
   basis: feature_matrix

--- a/sources/scores/nvidia-tensor-ir.yaml
+++ b/sources/scores/nvidia-tensor-ir.yaml
@@ -28,7 +28,7 @@ openness:
     shows: Repo metadata for nvidia-tensor-ir's canonical repository - private false, archived false, fork false.
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: b2f91ce4b7a83d60e7bc6b38471eab59c4bea0ef7ca22bf5a20c15e24943c303
+    content_sha256: 18c3377bd144d7eddb6eed29bf5e72bdd3d3b1807a738af71ba16fe034be66e4
     establishes:
     - license
     - source
@@ -42,19 +42,19 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
+  level: 1
+  reach: <1K stars
+  signal_type: stars_fallback
   confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  note: 111 GitHub stars, which lands in the <1K stars band of the stars scale, level 1. No package registry publishes Tensor
+    IR and the repository is built from source, so no download count exists and the stars scale applies.
   last_verified: '2026-09-02'
   sources:
   - url: https://api.github.com/repos/NVIDIA/tensor-ir
-    shows: Repo metadata for nvidia-tensor-ir's canonical repository carries no package-registry download figure of its
-      own; banding is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+    shows: Repo metadata - stargazers_count = 111 - for NVIDIA/tensor-ir.
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: b2f91ce4b7a83d60e7bc6b38471eab59c4bea0ef7ca22bf5a20c15e24943c303
+    content_sha256: 18c3377bd144d7eddb6eed29bf5e72bdd3d3b1807a738af71ba16fe034be66e4
 capability:
   score: 4
   basis: feature_matrix

--- a/sources/scores/onemath.yaml
+++ b/sources/scores/onemath.yaml
@@ -44,16 +44,16 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
+  level: 1
+  reach: <1K stars
+  signal_type: stars_fallback
   confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  note: 773 GitHub stars, which lands in the <1K stars band of the stars scale, level 1. oneMath ships as a source build and
+    inside the oneAPI toolkit installers, neither of which publishes a download count, so the stars scale applies.
   last_verified: '2026-09-02'
   sources:
   - url: https://api.github.com/repos/uxlfoundation/oneMath
-    shows: Repo metadata for onemath's canonical repository carries no package-registry download figure of its own; banding
-      is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+    shows: Repo metadata - stargazers_count = 773 - for uxlfoundation/oneMath.
     accessed: '2026-09-02'
     http_status: 200
     content_sha256: e3b839a1d80619dbc8841b7568488498dfd66b731cfa2173ab9cbad6a7b6258e

--- a/sources/scores/taco.yaml
+++ b/sources/scores/taco.yaml
@@ -42,16 +42,17 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
+  level: 2
+  reach: 1K-10K stars
+  signal_type: stars_fallback
   confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  note: 1,367 GitHub stars, which lands in the 1K-10K stars band of the stars scale, level 2. The `taco` package on PyPI is
+    an unrelated project by another author, and TACO itself ships only as a source build, so no download count exists and
+    the stars scale applies.
   last_verified: '2026-09-02'
   sources:
   - url: https://api.github.com/repos/tensor-compiler/taco
-    shows: Repo metadata for taco's canonical repository carries no package-registry download figure of its own; banding
-      is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+    shows: Repo metadata - stargazers_count = 1,367 - for tensor-compiler/taco.
     accessed: '2026-09-02'
     http_status: 200
     content_sha256: 915bd16a9bfa59fceac7415e0ee2a2c4c827b5494653a21992a02a78bed2611c

--- a/sources/scores/torch-tensorrt.yaml
+++ b/sources/scores/torch-tensorrt.yaml
@@ -28,7 +28,7 @@ openness:
     shows: Repo metadata for torch-tensorrt's canonical repository - private false, archived false, fork false.
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: dba0bfdb02cef522c2daa4ed2ee14270af99bec5dd4d6d42bcbb84132841ae4d
+    content_sha256: 95387fe7378846be1737a5fdb5a8006b1abd09f4261e12e5102b68db72c18d25
     establishes:
     - license
     - source
@@ -43,19 +43,27 @@ openness:
     - source
     - core-gated
 adoption:
-  level: null
-  signal_type: unknown
-  confidence: low
-  note: Left for the warehouse to band from artifact download signals; no first-party usage figure recorded at promotion
-    time.
+  level: 2
+  reach: 10K-100K
+  signal_type: usage_volume
+  confidence: high
+  note: 33,392 PyPI downloads of `torch-tensorrt` in the trailing 30 days, which lands in the 10K-100K band of the software
+    usage scale, level 2. The package is published from pytorch/TensorRT and `pip install torch-tensorrt` is the README's
+    install path. Torch-TensorRT also ships preinstalled in NVIDIA's PyTorch NGC containers, a channel that publishes no count,
+    so the band is a floor.
   last_verified: '2026-09-02'
   sources:
-  - url: https://api.github.com/repos/pytorch/TensorRT
-    shows: Repo metadata for torch-tensorrt's canonical repository carries no package-registry download figure of its own;
-      banding is left for the warehouse's artifact signal pipeline rather than guessed from stars.
+  - url: https://pypistats.org/api/packages/torch-tensorrt/recent
+    shows: last_month downloads = 33,392 for torch-tensorrt
     accessed: '2026-09-02'
     http_status: 200
-    content_sha256: dba0bfdb02cef522c2daa4ed2ee14270af99bec5dd4d6d42bcbb84132841ae4d
+    content_sha256: f12e3f5a08ac77234abbd6b42a174e9e387942c0c170bc60352d49ff4c12da7a
+  - url: https://pypi.org/pypi/torch-tensorrt/json
+    shows: PyPI metadata for torch-tensorrt 2.13.0 - project_urls Repository = https://github.com/pytorch/tensorrt.git, summary
+      'Torch-TensorRT is a package which allows users to automatically compile PyTorch and TorchScript modules to TensorRT'.
+    accessed: '2026-09-02'
+    http_status: 200
+    content_sha256: 6db7d00ec57efbc8aa8c9658b958b22b64f2713312d0c39ecae91bbf1c716082
 capability:
   score: 4
   basis: feature_matrix


### PR DESCRIPTION
Review fix for the compilers leg of #453: adoption had been defaulted to `null` for the whole
tranche; every one of the 18 records now carries a band, plus the strapline correction and a refetch
pass.

| slug | instrument | raw | band |
|---|---|---|---|
| auto-round | usage_volume, PyPI `auto-round` | 416,661/mo | 3 |
| torch-tensorrt | usage_volume, PyPI `torch-tensorrt` (newly declared; README install path, backlink) | 33,392/mo | 2 — NGC container channel uncounted, band is a floor |
| mlstm-kernels | usage_volume, PyPI `mlstm-kernels` (newly declared) | 11,616/mo | 2 |
| flashqla | usage_volume, PyPI `flash-qla` (newly declared) | 2,326/mo | 1 |
| flash-sparse-attention | usage_volume, PyPI `flash-sparse-attn` (newly declared) | 64/mo | 1 |
| flashmla | stars_fallback | 12,895 | 3 |
| cuda-tile, taco, miopen, flashkda | stars_fallback | 1,021 / 1,367 / 1,193 / 1,243 | 2 |
| nvidia-tensor-ir, finch-jl, freetensor, onemath, humming, block-sparse-attention, cula, attention-gym | stars_fallback | 43–773 | 1 |

No record stays null; every stars record's note says specifically why no usage instrument resolves.
Roster after fills: levels 1: 11, 2: 18, 3: 11, 4: 4 (29 of 44 at ≤2); 24 usage_volume, 20
stars_fallback.

Identity calls under the "does installing it measure the head product" test, worth a look:
- **cuda-tile**: PyPI `cuda-tile` (3.7M/mo) is cuTile Python from `nvidia/cutile-python`, a
  different repo, pulled in as a dependency of the CUDA Python stack. Not declared; the compiler in
  `NVIDIA/cuda-tile` builds from source.
- **finch-jl**: removed the `finch-tensor` PyPI artifact the promotion leg had declared — its
  metadata points at `finch-tensor/finch-tensor`, a separate Python library that pulls Finch.jl only
  as an optional `julia` extra. Julia's General registry publishes no count, so stars.
- **taco** (PyPI `taco` is an unrelated project), **attention-gym** (PyPI `attn-gym` is
  pytorch-labs' flex-attention), **flashmla** (PyPI `flash-mla` is a 1.0.0.dev0 stub): none
  declared.

**Strapline.** "about a third of the roster bands at capability level 2 or below" → "two-thirds of
the roster - 29 of 44 - bands at adoption level 2 or below". The openness sentence (42 of 44 at 5,
exceptions TensorRT and mLSTM Kernels) re-checked and still holds.

**Refetch.** All 57 distinct source URLs plus the 9 new pypistats/PyPI sources re-fetched through
`build.fetch_source.fetch`. Every LICENSE, README and comparison blob reproduced unchanged; seven
`api.github.com/repos/*` bodies and the auto-round README drifted (counters, news entries — claims
re-read and hold) and were replaced. No fabricated digests in this leg. `check_refetch --strict`
exit 0 on all 18.

Validation: validate 0 errors; check_recipe 0 failures; check_rubric compilers 44/44;
check_verification / check_capability / check_adoption (590) / check_instrument OK. pytest excluding
the corpus goldens: 1136 passed; `test_axis_assessments` and `test_adoption_evaluation` goldens fail
as expected and are re-pinned once, centrally, in #453.
