### PR TITLE
Raise the freshness gate to 45 days while the sweep dates spread

### DIFF
--- a/.github/workflows/freshness.yml
+++ b/.github/workflows/freshness.yml
@@ -1,8 +1,8 @@
 name: freshness
 
-# The age gate: no category's oldest axis may be more than 30 days old.
+# The age gate: no category's oldest axis may be more than 45 days old.
 #
-# The window is 30 days, decided 2026-08-09. docs/reference/evidence-and-freshness.md step 5 owns the number
+# The window is 45 days (temporary, see the revert issue). docs/reference/evidence-and-freshness.md step 5 owns the number
 # and the reasoning; it is a judgment about how much re-reading the map is worth rather than
 # something derivable, and it is not re-argued per category.
 #
@@ -17,7 +17,7 @@ name: freshness
 #
 # Weekly rather than daily for the same reason parity is weekly — the cadence has to match the
 # work it polices. A category is re-read in one run, so all of its axes carry one date and all of
-# them age out together; sixteen categories on a 30-day window is about four crossing the line
+# them age out together; eighteen categories on a 45-day window (temporary, see the revert issue) is about four crossing the line
 # per week. A daily gate would re-report the same cliff every day until the re-read landed, which
 # is nagging rather than information.
 #
@@ -33,8 +33,8 @@ on:
   workflow_dispatch:
     inputs:
       max-age-days:
-        description: "Window in days. Leave at 30 unless testing what a different one would say."
-        default: "30"
+        description: "Window in days. 45 until the rolling re-verifier has spread the August sweep dates; revert to 30 four weeks after 2026-09-03."
+        default: "45"
 
 jobs:
   freshness:
@@ -53,4 +53,4 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked
       - name: Age gate (no category's oldest axis over the window)
-        run: uv run python -m build.check_freshness --max-age-days "${{ inputs.max-age-days || 30 }}"
+        run: uv run python -m build.check_freshness --max-age-days "${{ inputs.max-age-days || 45 }}"

--- a/build/check_freshness.py
+++ b/build/check_freshness.py
@@ -42,7 +42,7 @@ window, or if any axis has no date at all for the window to be measured against.
 
 ## Where the gate runs
 
-`.github/workflows/freshness.yml`, weekly, at 30 days — the window decided 2026-08-09 and
+`.github/workflows/freshness.yml`, weekly, at 45 days (temporary) — the window decided 2026-08-09 and
 owned by `docs/reference/evidence-and-freshness.md` step 5. Not in `validate.yml`, and that is the one
 design decision in this file worth knowing about.
 
@@ -59,7 +59,7 @@ fail on the clock.
 Usage:
     uv run python -m build.check_freshness
     uv run python -m build.check_freshness --category base_pretrained
-    uv run python -m build.check_freshness --max-age-days 30
+    uv run python -m build.check_freshness --max-age-days 45
 """
 
 from __future__ import annotations

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -161,7 +161,7 @@ Triage. A category whose oldest axis is 50 days old is a category to go and look
 product. `--max-age-days N` turns that report into a gate: it exits non-zero if any
 category's oldest axis is older than N days.
 
-**The window is 30 days**, decided 2026-08-09; the age-gate section below (Part 3, step 5) holds the
+**The window is 45 days (temporary)**, decided 2026-08-09; the age-gate section below (Part 3, step 5) holds the
 reasoning and owns the number.
 
 ### Where the gate runs, and why not in `validate.yml`
@@ -180,7 +180,7 @@ cannot act on gets switched off.
 
 Weekly rather than daily for the same reason parity is weekly: the cadence has to match the work
 it polices. A category is re-read in one run, so all of its axes carry one date and all of them
-age out together, and about four categories cross a 30-day line per week. A daily gate would
+age out together, and about four categories cross a 45-day line (temporary) per week. A daily gate would
 re-report the same cliff for as many days as the re-read takes, which is nagging rather than
 information.
 
@@ -460,7 +460,7 @@ gate every PR. The ones needing the network run periodically.
 | refetch | fabricated or rotted sources | sampled re-fetch, digest and `shows` token match | network, weekly |
 | parity | repo and warehouse drifting apart | `build/check_parity.py`, a per-product differential | network, weekly |
 | capability-anchors | a recorded peer comparison that does not hold | `relation` must agree with both scores, and a dated band's peer must be confirmed at least as recently | free |
-| age | a corpus that was confirmed once and then quietly aged | `build/check_freshness.py --max-age-days 30`, scheduled weekly | free, weekly |
+| age | a corpus that was confirmed once and then quietly aged | `build/check_freshness.py --max-age-days 45 (temporary)`, scheduled weekly | free, weekly |
 
 These were numbered G1-G6 until 2026-08-08. Older PRs and commit messages use the numbers.
 
@@ -606,7 +606,7 @@ comparison graph growing.
 
 `capability.last_verified` dates **this product's own capability evidence**: the feature matrix
 still reads as described, the benchmark number is still the published one. It ages the way any
-axis ages, on the 30-day window the freshness gate applies.
+axis ages, on the 45-day window (temporary) the freshness gate applies.
 
 `capability.comparison.last_attested` dates **the spacing between this product and a peer**. It
 has a different lifecycle, because a comparison can go false with neither product changing: the
@@ -901,7 +901,7 @@ score for this reason.
 
 ### 5. Turn on the age gate
 
-**Done 2026-08-14.** `build/check_freshness.py --max-age-days 30` gates in
+**Done 2026-08-14.** `build/check_freshness.py --max-age-days 45 (temporary)` gates in
 `.github/workflows/freshness.yml`, weekly. This is the entire point of having the field: a
 category whose oldest axis is 50 days old is a category to go and look at. Gating earlier would
 only have failed on the pre-automation backlog rather than on genuine staleness; step 4 closed
@@ -910,13 +910,15 @@ oldest category read 6 days. (An audit then removed the confirmations it could n
 those were settled on 08-16, and a held axis rides the commit-date fallback rather than evading
 the age gate.)
 
-**The window is 30 days, decided 2026-08-09.** It is a judgment about how much re-reading the
+**The window is 45 days (temporary), decided 2026-08-09.** It is a judgment about how much re-reading the
 map is worth rather than anything derivable, so it is recorded here with its date and its owner
 and not re-argued per category. Earlier drafts suggested 90; that was a placeholder for an
 unmade decision, and this replaces it.
 
-At 30 days the re-read is continuous rather than occasional: sixteen categories inside a
-month is roughly four a week. Two things follow. A whole category shares one confirmation
+**Raised to 45 days on 2026-09-03, temporarily.** The whole corpus was dated in one August sweep and would have crossed the 30-day gate together around 09-07 to 09-12. The rolling re-verifier spreads the dates over four weekly batches; the window returns to 30 four weeks after the raise. Owner: Carl.
+
+At 45 days (temporary) the re-read is continuous rather than occasional: eighteen categories inside a
+forty-five days is roughly four a week. Two things follow. A whole category shares one confirmation
 date, because a category is re-read in a single run, so categories expire in cliffs rather
 than drifting past the line one product at a time — that is the shape of the work, not a
 backlog. And the sampled re-fetch will keep reporting drift on pages that change daily;

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -917,8 +917,7 @@ unmade decision, and this replaces it.
 
 **Raised to 45 days on 2026-09-03, temporarily.** The whole corpus was dated in one August sweep and would have crossed the 30-day gate together around 09-07 to 09-12. The rolling re-verifier spreads the dates over four weekly batches; the window returns to 30 four weeks after the raise. Owner: Carl.
 
-At 45 days (temporary) the re-read is continuous rather than occasional: eighteen categories inside a
-forty-five days is roughly four a week. Two things follow. A whole category shares one confirmation
+At 45 days (temporary) the re-read is continuous rather than occasional: eighteen categories inside forty-five days is roughly three a week. Two things follow. A whole category shares one confirmation
 date, because a category is re-read in a single run, so categories expire in cliffs rather
 than drifting past the line one product at a time — that is the shape of the work, not a
 backlog. And the sampled re-fetch will keep reporting drift on pages that change daily;

--- a/skills/refresh-all-categories/SKILL.md
+++ b/skills/refresh-all-categories/SKILL.md
@@ -27,7 +27,7 @@ the next.
 
 ```bash
 uv run python -m build.sweep_status                     # what has never been confirmed
-uv run python -m build.sweep_status --max-age-days 30   # what has also gone stale
+uv run python -m build.sweep_status --max-age-days 45   # what has also gone stale
 ```
 
 ```
@@ -49,14 +49,14 @@ Give the user the table. It is the answer to "how far along are we", which is th
 skill exists to answer.
 
 **Ask which question they mean**, unless they said. Without a window the sweep is finishing
-something: every product confirmed once. With `--max-age-days 30` it is maintaining something:
-every product confirmed within the month, so a category that finished in June comes back round.
+something: every product confirmed once. With `--max-age-days 45` it is maintaining something:
+every product confirmed within forty-five days, so a category that finished in June comes back round.
 The first is the current job. The second is what this becomes afterwards, and the same tooling
 does both — pass the window straight through to `refresh-category`, which refreshes only the
 products it returns.
 
-**The window is 30 days**, decided 2026-08-09 by the person paying for the re-reading. So
-`--max-age-days 30` is the maintenance-mode invocation, and `docs/reference/evidence-and-freshness.md` step 5
+**The window is 45 days (temporary)**, decided 2026-08-09 by the person paying for the re-reading. So
+`--max-age-days 45` is the maintenance-mode invocation, and `docs/reference/evidence-and-freshness.md` step 5
 turns the age gate on at the same number. It had been an unmade decision carrying a suggested 90;
 this replaces it rather than adding an option.
 
@@ -64,9 +64,9 @@ Two consequences worth stating, because both were weighed:
 
 - **A month is not a promise about any individual page.** Live pages change daily, and the weekly
   sampled re-fetch will keep reporting drift on the volatile ones. That drift is noise at this
-  window, not a signal to chase. What 30 days buys is that no score sits unexamined for a quarter.
+  window, not a signal to chase. What 45 days (temporary) buys is that no score sits unexamined for a quarter.
 - **Categories will come back round in cliffs.** A category is re-read in one run, so all of its
-  axes carry one date and all of them age out together. Sixteen categories against a 30-day window
+  axes carry one date and all of them age out together. Eighteen categories against a 45-day window (temporary)
   means roughly four categories a week, and the queue from each lands at the same time. Do not
   read a cliff as a backlog.
 


### PR DESCRIPTION
## Summary

Every axis in the corpus was dated in the same August sweep (median age 20 days, max 25), so the whole corpus crosses the 30-day gate together in the week of September 7. This raises the weekly freshness gate to 45 days while a rolling re-verifier (separate PR) spreads the dates over four weekly batches.

- `freshness.yml` default and invocation move to 45
- The decision is recorded in `docs/reference/evidence-and-freshness.md` step 5 as temporary, dated, with the revert condition
- Prose that repeated the old number is updated; "sixteen categories" corrected to eighteen where it appeared

Revert is tracked in #457, four weeks after the raise.

## Test plan

- `uv run pytest tests/test_freshness_gate.py tests/test_schedule_doc.py -q` passes
- `uv run python -m build.check_freshness --max-age-days 45` reports all 18 categories within 45d
