### PR TITLE
Cut the test suite from 19 minutes to under 5

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Validate sources (schema + cross-file invariants)
         run: uv run python -m build.validate
       - name: Run tests
-        run: uv run pytest -q
+        run: |
+          uv run pytest -q -n auto -m "not serial"
+          uv run pytest -q -m serial
 
       # The invariant, the digest requirement and the producible-pair check. Free, no
       # network, and scoped so they cover exactly what has been done: invariant and digests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,6 +353,17 @@ normative `docs/reference/evidence-and-freshness.md`.
 - OSO MCP connects via HTTP to `https://mcp.oso.xyz/mcp` with a Bearer token in `.mcp.json`
   (maintainer only; the file is gitignored).
 
+## Testing
+
+- Fast local loop: `uv run pytest -q -n auto -m "not serial"`. `-n auto` runs the suite across
+  local cores via `pytest-xdist`; `not serial` skips the handful of tests that mutate the real
+  working tree and would collide with a concurrent worker (run those separately with
+  `uv run pytest -q -m serial`, which is effectively `-n 0`).
+- CI runs the whole suite, network tests included, the same way: `-n auto -m "not serial"` then
+  `-m serial`. Nothing is skipped there.
+- A new test that hits a real external endpoint must carry `@pytest.mark.network`. It still runs
+  in CI; the marker exists so the fast loop can exclude it locally when offline.
+
 ## Common references
 
 - Query conventions: `docs/reference/queries.md`

--- a/build/check_refetch.py
+++ b/build/check_refetch.py
@@ -404,10 +404,15 @@ def resolve_duplicates(
     return failures, benign
 
 
-def refetch(source: Source, timeout: float) -> tuple[str, str]:
-    """(outcome, detail). Outcome is one of confirmed / drifted / gone / unreachable."""
+def refetch(source: Source, timeout: float, sleep=time.sleep) -> tuple[str, str]:
+    """(outcome, detail). Outcome is one of confirmed / drifted / gone / unreachable.
+
+    `sleep` is threaded through to `http_get`'s retry backoff; tests that mock the request
+    itself pass a no-op so a simulated transient status does not also cost the real backoff
+    delay.
+    """
     try:
-        response = http_get(source.url, timeout=timeout)
+        response = http_get(source.url, timeout=timeout, sleep=sleep)
     except requests.RequestException as exc:
         return "unreachable", f"{type(exc).__name__}: {exc}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,7 @@ dev = [
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
+markers = [
+    "network: hits a real external network endpoint; excluded from the fast local loop",
+    "serial: mutates the real working tree in a way that collides with concurrent tests; run with -n 0",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,11 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["pytest>=8.0", "sqlglot>=30.10.0"]
+dev = [
+    "pytest>=8.0",
+    "pytest-xdist>=3.8.0",
+    "sqlglot>=30.10.0",
+]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/tests/test_check_refetch.py
+++ b/tests/test_check_refetch.py
@@ -136,13 +136,13 @@ def test_matching_digest_is_confirmed():
     body = b"stable content"
     source = src("https://a.example/x", hashlib.sha256(body).hexdigest())
     with patch("build.check_refetch.requests.get", return_value=_response(200, body)):
-        assert refetch(source, 5.0)[0] == "confirmed"
+        assert refetch(source, 5.0, sleep=lambda _: None)[0] == "confirmed"
 
 
 def test_changed_body_is_drift_not_failure():
     source = src("https://a.example/x", DIGEST_A)
     with patch("build.check_refetch.requests.get", return_value=_response(200, b"new")):
-        assert refetch(source, 5.0)[0] == "drifted"
+        assert refetch(source, 5.0, sleep=lambda _: None)[0] == "drifted"
 
 
 @pytest.mark.parametrize("status", [429, 500, 502, 503])
@@ -150,7 +150,7 @@ def test_rate_limit_is_not_reported_dead(status: int):
     """429 and 5xx are 'not now', not 'not here'. Reported as unreachable, never as a finding."""
     source = src("https://a.example/x", DIGEST_A)
     with patch("build.check_refetch.requests.get", return_value=_response(status)):
-        outcome, detail = refetch(source, 5.0)
+        outcome, detail = refetch(source, 5.0, sleep=lambda _: None)
     assert outcome == "unreachable"
     assert "transient" in detail
 
@@ -159,7 +159,7 @@ def test_rate_limit_is_not_reported_dead(status: int):
 def test_client_errors_are_dead(status: int):
     source = src("https://a.example/x", DIGEST_A)
     with patch("build.check_refetch.requests.get", return_value=_response(status)):
-        assert refetch(source, 5.0)[0] == "gone"
+        assert refetch(source, 5.0, sleep=lambda _: None)[0] == "gone"
 
 
 def test_network_error_is_unreachable_not_dead():
@@ -167,7 +167,7 @@ def test_network_error_is_unreachable_not_dead():
     with patch(
         "build.check_refetch.requests.get", side_effect=requests.Timeout("timed out")
     ):
-        assert refetch(source, 5.0)[0] == "unreachable"
+        assert refetch(source, 5.0, sleep=lambda _: None)[0] == "unreachable"
 
 
 # --- Bot walls -------------------------------------------------------------------------
@@ -200,7 +200,7 @@ def test_a_walled_refetch_is_unreachable_not_drift():
     """DRIFTED would assert the document changed. The host just declined to serve it."""
     source = src("https://a.example/x", DIGEST_A)
     with patch("build.check_refetch.requests.get", return_value=_response(200, WALL)):
-        outcome, detail = refetch(source, 5.0)
+        outcome, detail = refetch(source, 5.0, sleep=lambda _: None)
     assert outcome == "unreachable"
     assert "bot wall" in detail
 
@@ -213,7 +213,7 @@ def test_a_wall_whose_digest_matches_is_never_confirmed():
     """
     source = src("https://a.example/x", hashlib.sha256(WALL).hexdigest())
     with patch("build.check_refetch.requests.get", return_value=_response(200, WALL)):
-        outcome, detail = refetch(source, 5.0)
+        outcome, detail = refetch(source, 5.0, sleep=lambda _: None)
     assert outcome != "confirmed"
     assert "never read" in detail
 

--- a/tests/test_declaration_version.py
+++ b/tests/test_declaration_version.py
@@ -243,12 +243,18 @@ def test_untracked_files_outside_sources_are_ignored(tmp_path):
     assert worktree_is_clean_for_identity(repo) is True
 
 
+@pytest.mark.serial
 def test_untracked_declaration_is_excluded_from_the_digest_and_refused():
     """The reproduction on the real repo: an untracked YAML in sources/categories/.
 
     Two guarantees at once — the digest reads only tracked files, so the untracked probe does NOT
     change it (closing `probe_digested=True`); and resolve() REFUSES rather than emit an id over a
     tree that carries a declaration the commit does not (closing `clean_probe=True`).
+
+    Marked `serial`: this writes a real (if transient) file into `sources/categories/` on the
+    checked-out worktree. Any other test that globs that directory while this one has the probe
+    on disk would see an extra, malformed entry, so it must not run concurrently with the rest
+    of the suite.
     """
     probe = ROOT / "sources" / "categories" / "_declaration_version_untracked_probe.yaml"
     assert not probe.exists()

--- a/tests/test_fetch_source.py
+++ b/tests/test_fetch_source.py
@@ -67,7 +67,7 @@ def test_a_dead_host_is_a_record_not_a_crash():
     import requests
 
     with patch("build.fetch_source.requests.get", side_effect=requests.ConnectionError("no route")):
-        record = fetch("https://gone.example/x")
+        record = fetch("https://gone.example/x", sleep=lambda _: None)
     assert record["http_status"] is None
     assert "ConnectionError" in record["error"]
     assert "content_sha256" not in record, "nothing was served, so nothing may be recorded"

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -126,6 +126,22 @@ def _real_sources(root):
     return sources
 
 
+@pytest.fixture(scope="module")
+def real_rubric():
+    """The repo's real sources, policy, routing, and the rubric built from them, computed
+    once per module. `build_rubric` is pure and none of the tests below mutate its output,
+    so re-parsing the whole corpus and rebuilding the rubric per test bought nothing.
+    """
+    from pathlib import Path
+
+    from build.serialize_rubric import load_policy, load_routing
+
+    root = Path(__file__).resolve().parents[1]
+    sources = _real_sources(root)
+    tables, errors, warnings = build_rubric(sources, load_policy(root), load_routing(root))
+    return sources, tables, errors, warnings
+
+
 def test_split_value_separates_the_bare_value_from_its_detail():
     assert split_value("open(downloadable on HF, gated)") == ("open", "downloadable on HF, gated")
     assert split_value("Apache-2.0(OSI)") == ("Apache-2.0", "OSI")
@@ -623,13 +639,8 @@ def test_every_declared_table_is_present():
     assert set(tables) == set(TABLES)
 
 
-def test_real_sources_serialize_without_errors():
-    from pathlib import Path
-
-    from build.serialize_rubric import load_policy, load_routing
-
-    root = Path(__file__).resolve().parents[1]
-    tables, errors, _ = build_rubric(_real_sources(root), load_policy(root), load_routing(root))
+def test_real_sources_serialize_without_errors(real_rubric):
+    _sources, tables, errors, _warnings = real_rubric
     assert errors == [], f"rubric has errors: {errors[:5]}"
 
     # Asserted per category rather than as a total, so a new recipe shows up as its
@@ -970,18 +981,13 @@ def test_real_sources_serialize_without_errors():
     assert {r["grade"] for r in tables["product_openness_evidence"]} == {"document"}
 
 
-def test_every_scored_product_carries_a_row_for_each_formula_dimension():
+def test_every_scored_product_carries_a_row_for_each_formula_dimension(real_rubric):
     """The warehouse joins a rule's `condition_key` against the `dimension` column,
     so a dimension recorded under a different key has to be emitted under the
     DIMENSION name. Emitted under the raw key instead, the condition silently fails
     to match and the product falls through to `otherwise` — scored on an absence.
     """
-    from pathlib import Path
-
-    from build.serialize_rubric import load_policy, load_routing
-
-    root = Path(__file__).resolve().parents[1]
-    tables, _, _ = build_rubric(_real_sources(root), load_policy(root), load_routing(root))
+    _sources, tables, _errors, _warnings = real_rubric
 
     by_product: dict[tuple[str, str], set[str]] = {}
     for row in tables["product_openness_evidence"]:
@@ -999,7 +1005,7 @@ def test_every_scored_product_carries_a_row_for_each_formula_dimension():
     assert missing == [], f"no data row emitted for: {missing}"
 
 
-def test_a_value_alias_is_translated_before_it_reaches_the_warehouse():
+def test_a_value_alias_is_translated_before_it_reaches_the_warehouse(real_rubric):
     """`core_gated` reads `self-host`, whose vocabulary is `yes`/`no`/`none` rather than
     `gated`/`ungated`. The warehouse joins a rule's `condition_value` against this column,
     so the translation has to happen on the way out or `openness_computed` would have to
@@ -1009,12 +1015,7 @@ def test_a_value_alias_is_translated_before_it_reaches_the_warehouse():
     The recorded spelling is not lost: `self-host` is still emitted under its own name by
     the traceability pass, so both rows are in the evidence store.
     """
-    from pathlib import Path
-
-    from build.serialize_rubric import load_policy, load_routing
-
-    root = Path(__file__).resolve().parents[1]
-    tables, _, _ = build_rubric(_real_sources(root), load_policy(root), load_routing(root))
+    _sources, tables, _errors, _warnings = real_rubric
 
     rows = {
         (r["dimension"], r["value"], r["in_declared_enum"])
@@ -1024,7 +1025,7 @@ def test_a_value_alias_is_translated_before_it_reaches_the_warehouse():
     assert rows == {("core_gated", "gated", True), ("self-host", "none", "")}
 
 
-def test_license_is_emitted_under_the_name_the_warehouse_joins_on():
+def test_license_is_emitted_under_the_name_the_warehouse_joins_on(real_rubric):
     """`license_tier.reads` lets a category accept the license under another key.
 
     deepseek-coder records `model-license`, because its card separates the code license
@@ -1034,14 +1035,9 @@ def test_license_is_emitted_under_the_name_the_warehouse_joins_on():
     while reproducing locally. Exactly one license row per scored product, under
     `license`, is what keeps the two in step.
     """
-    from pathlib import Path
-
     from build.rubrics import resolve_recipe_variants
-    from build.serialize_rubric import load_policy, load_routing
 
-    root = Path(__file__).resolve().parents[1]
-    sources = _real_sources(root)
-    tables, _, _ = build_rubric(sources, load_policy(root), load_routing(root))
+    sources, tables, _errors, _warnings = real_rubric
 
     # Deferred products are excluded: a category has declared the rubric does not decide
     # them, and several are deferred precisely BECAUSE no license is recorded. Asserting a
@@ -1132,7 +1128,7 @@ def test_license_is_emitted_under_the_name_the_warehouse_joins_on():
     assert len(deepseek) == 1 and deepseek[0]["value"] == "DeepSeek-Model-License"
 
 
-def test_a_compound_license_publishes_every_part():
+def test_a_compound_license_publishes_every_part(real_rubric):
     """The three products check_parity was diverging on, and the one that must NOT split.
 
     `serialize_rubric` used to publish the license through `split_value`, which severs a
@@ -1147,12 +1143,7 @@ def test_a_compound_license_publishes_every_part():
     part. A serializer that split on punctuation cannot tell it from `zed`; one that
     publishes what the record says does not have to.
     """
-    from pathlib import Path
-
-    from build.serialize_rubric import load_policy, load_routing
-
-    root = Path(__file__).resolve().parents[1]
-    tables, _, _ = build_rubric(_real_sources(root), load_policy(root), load_routing(root))
+    _sources, tables, _errors, _warnings = real_rubric
 
     def license_parts(product):
         return [
@@ -1174,7 +1165,7 @@ def test_a_compound_license_publishes_every_part():
     assert license_parts("culturax") == ["follows mC4 + OSCAR-2301 terms"]
 
 
-def test_evidence_never_puts_two_values_on_one_grain():
+def test_evidence_never_puts_two_values_on_one_grain(real_rubric):
     """One product/category/dimension/part must carry one value. Two would let the
     warehouse pick between a base corpus and a post-training mixture by row order.
 
@@ -1185,12 +1176,8 @@ def test_evidence_never_puts_two_values_on_one_grain():
     hide behind the license's allowance.
     """
     from collections import Counter
-    from pathlib import Path
 
-    from build.serialize_rubric import load_policy, load_routing
-
-    root = Path(__file__).resolve().parents[1]
-    tables, _, _ = build_rubric(_real_sources(root), load_policy(root), load_routing(root))
+    _sources, tables, _errors, _warnings = real_rubric
     rows = tables["product_openness_evidence"]
 
     counts = Counter(

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -373,6 +373,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/39/a4/5180d9afc57e8fca05601dd652bdff19604c218814037fe90ffc7625a50a/docutils-0.23.tar.gz", hash = "sha256:746f5060322511280a1e50eb76846ed6bf2342984b2ac04dc42caa1a8d78799e", size = 2303823, upload-time = "2026-05-27T17:41:06.934Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/91/30151a39f7570f448ed84529390628a651d7f27c87d73c9b887f8189695e/docutils-0.23-py3-none-any.whl", hash = "sha256:25d013af9bf23bc1c7b2b093dff4208166c53a94786c9e447808335ef1185fea", size = 634701, upload-time = "2026-05-27T17:40:58.442Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -1015,6 +1024,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-xdist" },
     { name = "sqlglot" },
 ]
 
@@ -1035,6 +1045,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "sqlglot", specifier = ">=30.10.0" },
 ]
 
@@ -1445,6 +1456,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The full suite ran single-process in 18 minutes 54 seconds on a developer machine. Every PR and every agent fix round paid that. This brings it to about 4 minutes 31 seconds with no test removed.

- `pytest-xdist` as a dev dependency; CI runs `-n auto -m "not serial"` then `-m serial`. `build/preflight.py` mirrors CI automatically because it executes each workflow step's `run:` block
- The fetch and refetch tests were spending about three minutes in real `time.sleep` inside mocked retry loops. The retry helpers already accepted an injectable `sleep`; the tests now pass a no-op. Production backoff is unchanged, and the tests that assert retry counts are untouched
- `tests/test_serialize_rubric.py` builds the real-corpus rubric once per module instead of once per test
- Markers `network` and `serial` are registered. No test hits the internet today, so `network` is a rule for new tests, documented in `AGENTS.md`. One test writes a probe file into the real tree by design and is marked `serial`

Before and after on the same machine:

| Run | Wall clock |
|---|---|
| `uv run pytest -q` before | 18:54 |
| `uv run pytest -q -n auto -m "not serial"` after | 4:22 |
| `uv run pytest -q -m serial` after | 0:09 |

## Test plan

- Both runs above pass: 1286 + 1 tests
- `uv run pytest tests/test_preflight.py -q` passes with the new step names
