### PR TITLE
Deterministic rolling re-verifier for the oldest products

### DIFF
--- a/.github/workflows/reverify.yml
+++ b/.github/workflows/reverify.yml
@@ -1,0 +1,71 @@
+# Deterministic rolling re-verification (Phase 0 form). Re-fetches the digested openness
+# sources of the oldest N products and stamps a date only where every recorded dimension
+# came back byte-identical. Opens one PR per run. Drift and transient results go in the
+# report attached to the PR for the agent leg; this workflow never edits an axis whose
+# evidence changed. See build/reverify.py and docs/reference/evidence-and-freshness.md.
+name: reverify
+on:
+  schedule:
+    - cron: "0 10 * * 2"      # Tuesday 10:00 UTC, clear of the Monday gates and Thursday refetch
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "How many of the oldest products to re-verify"
+        default: "150"
+permissions:
+  contents: write
+  pull-requests: write
+concurrency:
+  group: reverify
+  cancel-in-progress: false
+jobs:
+  reverify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - run: uv sync --locked
+      - name: Re-verify the oldest products
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          uv run python -m build.reverify --limit "${{ inputs.limit || 150 }}" --report reverify-report.json --pace 1
+      - name: Gates on the result
+        run: |
+          uv run python -m build.validate
+          uv run python -m build.check_verification --verbose
+          uv run python -m build.check_capability
+      - name: Open the freshness PR
+        env:
+          GH_TOKEN: ${{ secrets.GH_FETCH_TOKEN }}
+        run: |
+          if [ -z "$(git status --porcelain sources/scores/)" ]; then
+            echo "Nothing re-dated; no PR."
+            exit 0
+          fi
+          BRANCH="reverify/$(date -u +%F)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add sources/scores/
+          git commit -m "chore(freshness): re-verify $(git diff --cached --name-only | wc -l | tr -d ' ') products, openness re-dated where evidence was unchanged"
+          git push -u origin "$BRANCH"
+          {
+            echo "Deterministic re-verification of the oldest products. Openness dates were stamped only where every recorded dimension's digested source came back byte-identical."
+            echo
+            echo '```'
+            uv run python - <<'PY'
+          import json
+          r = json.load(open("reverify-report.json"))
+          for p in r["products"]:
+              print(f'{p["slug"]:32} stamped={p["stamped"]} drifted={len(p["drifted"])} transient={len(p["transient"])} skipped={len(p["skipped"])}')
+          PY
+            echo '```'
+            echo
+            echo "Drifted and transient axes need the agent leg (refresh-category, scoped to these products)."
+          } > pr-body.md
+          gh pr create --title "chore(freshness): rolling re-verification $(date -u +%F)" --body-file pr-body.md --label freshness

--- a/build/check_refetch.py
+++ b/build/check_refetch.py
@@ -69,12 +69,14 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import os
 import random
 import re
 import time
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlparse
 
 import requests
 import yaml
@@ -147,6 +149,12 @@ USER_AGENT = (
 # it can decode, and this environment has no brotli; forcing `br` returned a 200 whose
 # `.content` was raw compressed bytes. Every digest taken that way would be a digest of
 # ciphertext-looking garbage that no re-fetch could reproduce or read.
+#
+# `Authorization` is the one addition, and it is scoped to GitHub's own hosts only: the
+# anonymous 60/hour limit turns a 150-product weekly re-verify into a wall of TRANSIENT
+# 429s that stamps nothing, and a token only changes GitHub's rate-limit accounting — it
+# does not change what bytes a public repo serves, so it carries none of the drift risk the
+# rest of this comment warns about.
 
 # Statuses that mean "not now" rather than "not here" — a WAF, a rate limiter or a bad
 # gateway, none of which say anything about whether the page exists.
@@ -183,6 +191,21 @@ def canonical(url: str) -> str:
     return f"https://raw.githubusercontent.com/{owner}/{repo}/{rest}"
 
 
+# Hosts that share GitHub's anonymous rate limit and accept a token on the same header.
+GITHUB_HOSTS = {"github.com", "raw.githubusercontent.com", "api.github.com"}
+
+
+def _headers(url: str) -> dict[str, str]:
+    """`User-Agent` always; `Authorization` added only for GitHub hosts, only when
+    `GITHUB_TOKEN` is set. See the note above USER_AGENT for why this is scoped so narrowly.
+    """
+    headers = {"User-Agent": USER_AGENT}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token and urlparse(url).hostname in GITHUB_HOSTS:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
 def http_get(
     url: str,
     timeout: float = 20.0,
@@ -209,7 +232,7 @@ def http_get(
         attempts += 1
         try:
             response = requests.get(
-                url, timeout=timeout, headers={"User-Agent": USER_AGENT}, allow_redirects=True
+                url, timeout=timeout, headers=_headers(url), allow_redirects=True
             )
         except requests.RequestException:
             if attempts <= retries:

--- a/build/reverify.py
+++ b/build/reverify.py
@@ -2,23 +2,40 @@
 
 What it does: for each of the N oldest products (by the oldest of its three axis dates,
 ties broken by slug), re-fetch every digested source that `establishes` a recorded
-dimension on the selected axes through build.fetch_source. Where every establishing source
-for an axis came back byte-identical (same content_sha256, non-transient), write `accessed`
-and `http_status` on those sources and stamp that axis's `last_verified` to today. Any
-drift, any transient result, or any dimension with no digested establishing source leaves
-the axis untouched and goes in the report for the agent leg.
+dimension on the selected axes through build.fetch_source. A dimension re-confirms when
+every establishing source's fresh fetch is non-transient and either (a) the body is
+byte-identical to what was recorded, (b) the source's recorded `shows` excerpt still
+occurs in the fresh body, or (c) for a GitHub license API / repo endpoint or a Hugging
+Face model-info source, the fresh SPDX id normalizes to the same license already recorded.
+Whichever path confirms it, the source takes the new `accessed`, `http_status` and
+`content_sha256`, and once every dimension an axis records has confirmed, that axis's
+`last_verified` is stamped to today. Any drift, any transient result, or any dimension
+with no digested establishing source leaves the axis untouched and goes in the report for
+the agent leg.
+
+The dimension set an axis must confirm is not re-derived here: `build.check_verification`
+already owns the definition the `invariant` gate enforces (it excludes non-evidence keys
+like `free_text`), so this module imports and reuses it rather than keeping a second copy
+that could drift from the gate.
 
 What it never does: derive a date from `accessed`, record a transient fetch as evidence,
 touch an axis whose evidence changed, or write YAML by any route other than
 build.components. Ruled on #445 (2026-09): a byte-identical re-fetch confirms an openness
 dimension; adoption and capability sources carry numbers that move, so they are excluded
-by default (--axes openness). See docs/reference/evidence-and-freshness.md.
+by default (--axes openness). Ruled again 2026-09-03 (#445 follow-up): shows-match and
+SPDX comparison are also acceptable confirmations, since byte identity is the wrong test
+for evidence pages that legitimately re-render on every load. See
+docs/reference/evidence-and-freshness.md.
 """
 from __future__ import annotations
 
 import argparse
+import functools
+import html
 import json
+import re
 import sys
+import tempfile
 import time
 from dataclasses import dataclass, field
 from datetime import date
@@ -28,11 +45,23 @@ import yaml
 
 from build import components
 from build.check_freshness import parse_date
+from build.check_rubric import components_of, license_part, license_segments, normalize_license
+from build.check_verification import PLACEHOLDER_SHOWS, category_of, recorded_dimensions
 from build.fetch_source import fetch as _fetch
+from build.rubrics import load_product_types, load_shared, recipe_for, resolve_recipe_variants
 from build.taxonomy import category_statuses
 from build.vocabulary import axes as _axes
 
 ROOT = Path(__file__).resolve().parents[1]
+
+# api.github.com/repos/<owner>/<repo>/license and the bare repo endpoint both carry a
+# `license.spdx_id`; a Hugging Face model-info endpoint carries the license under
+# `cardData.license` or, on older records, a top-level `license`.
+_GITHUB_LICENSE_RE = re.compile(r"^https://api\.github\.com/repos/[^/]+/[^/]+/license/?$")
+_GITHUB_REPO_RE = re.compile(r"^https://api\.github\.com/repos/[^/]+/[^/]+/?$")
+_HF_MODEL_RE = re.compile(r"^https://huggingface\.co/api/models/.+$")
+
+_ABSTAIN_SPDX = {"", "noassertion", "other"}
 
 
 def _published_slugs(root: Path) -> list[str]:
@@ -73,47 +102,152 @@ def oldest_products(root: Path, limit: int) -> list[tuple[date, str]]:
 class ProductResult:
     slug: str
     stamped: list[str] = field(default_factory=list)
-    reconfirmed: dict[str, list[str]] = field(default_factory=dict)  # axis -> urls to re-date
+    # axis -> url -> the fetch record that confirmed it (http_status, content_sha256, ...)
+    reconfirmed: dict[str, dict[str, dict]] = field(default_factory=dict)
+    reconfirmed_by_shows: list[tuple[str, str]] = field(default_factory=list)
+    reconfirmed_by_spdx: list[tuple[str, str]] = field(default_factory=list)
     drifted: list[tuple[str, str]] = field(default_factory=list)
     transient: list[tuple[str, str]] = field(default_factory=list)
     skipped: list[tuple[str, str]] = field(default_factory=list)
 
 
-def _recorded_dimensions(axis: str, block: dict) -> list[str]:
-    if axis == "openness":
-        comps = block.get("components")
-        return sorted(comps) if isinstance(comps, dict) else []
-    # adoption and capability record one dimension each for freshness purposes
-    return [axis]
+@functools.lru_cache(maxsize=None)
+def _recipe_context(root_str: str) -> tuple[dict[str, str], dict[str, dict], dict[str, str]]:
+    """(category slug per product, resolved recipe variants per category, product type per product).
+
+    Loaded the same way `build.check_verification.load` loads it, just parametrized on
+    `root` so tests can point it at a fixture corpus instead of the real one.
+    """
+    root = Path(root_str)
+    categories = {
+        p.stem: yaml.safe_load(p.read_text()) or {}
+        for p in sorted((root / "sources" / "categories").glob("*.yaml"))
+    }
+    shared = load_shared(root)
+    recipes: dict[str, dict] = {}
+    for slug, category in categories.items():
+        variants, errors = resolve_recipe_variants(category, shared)
+        if variants and not errors:
+            recipes[slug] = variants
+    return category_of(categories), recipes, load_product_types(root)
 
 
-def plan_product(score: dict, axes: tuple[str, ...]) -> dict[str, dict[str, list[dict]]]:
+def _openness_dimensions(root: Path, slug: str, block: dict) -> dict[str, str]:
+    """dimension name -> recorded key, for exactly the dimensions `check_verification`'s
+    invariant gate requires an establishing source for. Not re-derived: this calls the
+    gate's own `recorded_dimensions` against the recipe governing this product."""
+    owner, recipes, product_types = _recipe_context(str(root))
+    variants = recipes.get(owner.get(slug, ""), {})
+    recipe, _ = recipe_for(variants, product_types.get(slug, ""))
+    return recorded_dimensions(components_of(block), recipe or {})
+
+
+def plan_product(root: Path, slug: str, score: dict, axes: tuple[str, ...]
+                 ) -> dict[str, dict[str, list[dict]]]:
     """axis -> dimension -> digested sources that establish it."""
     plan: dict[str, dict[str, list[dict]]] = {}
     for axis in axes:
         block = score.get(axis)
         if not isinstance(block, dict) or not block.get("last_verified"):
             continue
-        dims = {d: [] for d in _recorded_dimensions(axis, block)}
+        if axis == "openness":
+            required = _openness_dimensions(root, slug, block)  # name -> recorded key
+        else:
+            required = {axis: axis}
+        dims: dict[str, list[dict]] = {name: [] for name in required}
+        # A source may name either the dimension or the recorded key that answers it
+        # (`establishes: [post-training-data]` is more precise than `[data]`) — the same
+        # either-or the invariant gate itself accepts.
+        aliases = {key: name for name, key in required.items() if key != name}
         for src in block.get("sources") or []:
             if not src.get("content_sha256"):
                 continue
             targets = src.get("establishes") if axis == "openness" else [axis]
             for d in targets or []:
-                if d in dims:
-                    dims[d].append(src)
+                name = d if d in dims else aliases.get(d)
+                if name:
+                    dims[name].append(src)
         plan[axis] = dims
     return plan
 
 
+def _normalize_text(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _is_placeholder_shows(shows: object) -> bool:
+    normalized = _normalize_text(str(shows or ""))
+    return any(marker in normalized for marker in PLACEHOLDER_SHOWS)
+
+
+def _read_body(fetched: dict) -> str | None:
+    body_path = fetched.get("body_path")
+    if not body_path:
+        return None
+    try:
+        raw = Path(body_path).read_bytes()
+    except OSError:
+        return None
+    return html.unescape(raw.decode("utf-8", errors="replace"))
+
+
+def _shows_confirms(src: dict, fetched: dict) -> bool:
+    """The source's recorded `shows` excerpt still occurs in the fresh body."""
+    shows = src.get("shows")
+    if not shows or _is_placeholder_shows(shows):
+        return False
+    body = _read_body(fetched)
+    if body is None:
+        return False
+    return _normalize_text(str(shows)) in _normalize_text(body)
+
+
+def _spdx_confirms(url: str, fetched: dict, recorded_license: str) -> bool:
+    """A GitHub license/repo API or HF model-info source whose fresh spdx id normalizes
+    to the recorded license. Abstains (falls through to shows-match, then drift) on a
+    compound license, a missing/NOASSERTION/other spdx id, or a non-matching source URL."""
+    if not recorded_license:
+        return False
+    segments = license_segments(recorded_license)
+    if len(segments) != 1:
+        return False
+    body = _read_body(fetched)
+    if body is None:
+        return False
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        return False
+    if _GITHUB_LICENSE_RE.match(url) or _GITHUB_REPO_RE.match(url):
+        spdx = (payload.get("license") or {}).get("spdx_id") if isinstance(payload, dict) else None
+    elif _HF_MODEL_RE.match(url):
+        card = payload.get("cardData") if isinstance(payload, dict) else None
+        spdx = (card or {}).get("license") or (payload.get("license") if isinstance(payload, dict) else None)
+    else:
+        return False
+    if not isinstance(spdx, str) or spdx.strip().lower() in _ABSTAIN_SPDX:
+        return False
+    recorded_name = license_part(segments[0])["name"]
+    return normalize_license(spdx.strip()) == normalize_license(recorded_name)
+
+
 def reverify_product(root: Path, slug: str, today: date, axes: tuple[str, ...] = ("openness",),
-                     fetch=_fetch, pace: float = 0.0, sleep=time.sleep) -> ProductResult:
+                     fetch=_fetch, pace: float = 0.0, sleep=time.sleep,
+                     body_dir: Path | None = None) -> ProductResult:
     score = _score(root, slug)
     result = ProductResult(slug=slug)
     cache: dict[str, dict] = {}
-    for axis, dims in plan_product(score, axes).items():
+    for axis, dims in plan_product(root, slug, score, axes).items():
+        block = score[axis]
+        components_map = components_of(block) if axis == "openness" else {}
+        license_key = None
+        if axis == "openness":
+            required = _openness_dimensions(root, slug, block)
+            license_key = required.get("license")
+        recorded_license = components_map.get(license_key, "") if license_key else ""
+
         ok = True
-        urls: list[str] = []
+        confirmed: dict[str, dict] = {}
         for dim, sources in dims.items():
             if not sources:
                 result.skipped.append((axis, f"{dim} has no digested establishing source"))
@@ -122,30 +256,51 @@ def reverify_product(root: Path, slug: str, today: date, axes: tuple[str, ...] =
             for src in sources:
                 url = src["url"]
                 if url not in cache:
-                    cache[url] = fetch(url)
+                    cache[url] = fetch(url, body_dir=body_dir)
                     if pace:
                         sleep(pace)
                 got = cache[url]
                 if got.get("transient") or not got.get("content_sha256"):
                     result.transient.append((axis, url))
                     ok = False
-                elif got["content_sha256"] != src["content_sha256"]:
-                    result.drifted.append((axis, url))
-                    ok = False
-                else:
-                    urls.append(url)
-        if ok and urls:
+                    continue
+                if got["content_sha256"] == src["content_sha256"]:
+                    confirmed[url] = got
+                    continue
+                if dim == "license" and _spdx_confirms(url, got, recorded_license):
+                    confirmed[url] = got
+                    result.reconfirmed_by_spdx.append((axis, url))
+                    continue
+                if _shows_confirms(src, got):
+                    confirmed[url] = got
+                    result.reconfirmed_by_shows.append((axis, url))
+                    continue
+                result.drifted.append((axis, url))
+                ok = False
+        if ok and confirmed:
             result.stamped.append(axis)
-            result.reconfirmed[axis] = sorted(set(urls))
+            result.reconfirmed[axis] = confirmed
     return result
 
 
 def apply(root: Path, slug: str, result: ProductResult, today: date) -> None:
     path = root / "sources" / "scores" / f"{slug}.yaml"
     text = path.read_text()
+    # Sources confirmed by shows-match or spdx read a body different from what was
+    # recorded, so they must carry the fresh digest and status; a byte-identical source
+    # keeps the pre-existing accessed/http_status-only write for now.
+    shows_or_spdx = set(result.reconfirmed_by_shows) | set(result.reconfirmed_by_spdx)
     for axis in result.stamped:
-        for url in result.reconfirmed[axis]:
-            text = components.set_source(text, axis, url, {"accessed": today.isoformat(), "http_status": 200})
+        for url, fetched in result.reconfirmed[axis].items():
+            if (axis, url) in shows_or_spdx:
+                updates = {
+                    "accessed": today.isoformat(),
+                    "http_status": fetched["http_status"],
+                    "content_sha256": fetched["content_sha256"],
+                }
+            else:
+                updates = {"accessed": today.isoformat(), "http_status": 200}
+            text = components.set_source(text, axis, url, updates)
         text = components.put_field(text, today.isoformat(), axis=axis, key="last_verified", before="sources")
     if text != path.read_text():
         path.write_text(text)
@@ -160,18 +315,23 @@ def main(argv: list[str] | None = None, root: Path | None = None) -> int:
     p.add_argument("--report", type=Path, default=None)
     p.add_argument("--today", default=None)
     p.add_argument("--pace", type=float, default=1.0, help="seconds to sleep between fetches")
+    p.add_argument("--body-dir", type=Path, default=None,
+                    help="where to save fetched bodies for shows/spdx matching (default: a temp dir)")
     args = p.parse_args(argv)
     today = parse_date(args.today) if args.today else date.today()
     axes = tuple(a.strip() for a in args.axes.split(",") if a.strip())
+    body_dir = args.body_dir or Path(tempfile.mkdtemp(prefix="os-ai-map-reverify-"))
 
     report = {"today": today.isoformat(), "axes": axes, "products": []}
     for _oldest, slug in oldest_products(root, args.limit):
-        result = reverify_product(root, slug, today, axes=axes, pace=args.pace)
+        result = reverify_product(root, slug, today, axes=axes, pace=args.pace, body_dir=body_dir)
         if not args.dry_run:
             apply(root, slug, result, today)
         report["products"].append({
             "slug": slug, "stamped": result.stamped, "drifted": result.drifted,
             "transient": result.transient, "skipped": result.skipped,
+            "reconfirmed_by_shows": result.reconfirmed_by_shows,
+            "reconfirmed_by_spdx": result.reconfirmed_by_spdx,
         })
         print(f"{slug}: stamped={result.stamped} drifted={len(result.drifted)} "
               f"transient={len(result.transient)} skipped={len(result.skipped)}")

--- a/build/reverify.py
+++ b/build/reverify.py
@@ -286,21 +286,13 @@ def reverify_product(root: Path, slug: str, today: date, axes: tuple[str, ...] =
 def apply(root: Path, slug: str, result: ProductResult, today: date) -> None:
     path = root / "sources" / "scores" / f"{slug}.yaml"
     text = path.read_text()
-    # Sources confirmed by shows-match or spdx read a body different from what was
-    # recorded, so they must carry the fresh digest and status; a byte-identical source
-    # keeps the pre-existing accessed/http_status-only write for now.
-    shows_or_spdx = set(result.reconfirmed_by_shows) | set(result.reconfirmed_by_spdx)
     for axis in result.stamped:
         for url, fetched in result.reconfirmed[axis].items():
-            if (axis, url) in shows_or_spdx:
-                updates = {
-                    "accessed": today.isoformat(),
-                    "http_status": fetched["http_status"],
-                    "content_sha256": fetched["content_sha256"],
-                }
-            else:
-                updates = {"accessed": today.isoformat(), "http_status": 200}
-            text = components.set_source(text, axis, url, updates)
+            text = components.set_source(text, axis, url, {
+                "accessed": today.isoformat(),
+                "http_status": fetched["http_status"],
+                "content_sha256": fetched["content_sha256"],
+            })
         text = components.put_field(text, today.isoformat(), axis=axis, key="last_verified", before="sources")
     if text != path.read_text():
         path.write_text(text)

--- a/build/reverify.py
+++ b/build/reverify.py
@@ -1,0 +1,186 @@
+"""Deterministic rolling re-verification of the oldest products.
+
+What it does: for each of the N oldest products (by the oldest of its three axis dates,
+ties broken by slug), re-fetch every digested source that `establishes` a recorded
+dimension on the selected axes through build.fetch_source. Where every establishing source
+for an axis came back byte-identical (same content_sha256, non-transient), write `accessed`
+and `http_status` on those sources and stamp that axis's `last_verified` to today. Any
+drift, any transient result, or any dimension with no digested establishing source leaves
+the axis untouched and goes in the report for the agent leg.
+
+What it never does: derive a date from `accessed`, record a transient fetch as evidence,
+touch an axis whose evidence changed, or write YAML by any route other than
+build.components. Ruled on #445 (2026-09): a byte-identical re-fetch confirms an openness
+dimension; adoption and capability sources carry numbers that move, so they are excluded
+by default (--axes openness). See docs/reference/evidence-and-freshness.md.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+
+import yaml
+
+from build import components
+from build.check_freshness import parse_date
+from build.fetch_source import fetch as _fetch
+from build.taxonomy import category_statuses
+from build.vocabulary import axes as _axes
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _published_slugs(root: Path) -> list[str]:
+    taxonomy = yaml.safe_load((root / "sources" / "taxonomy.yaml").read_text())
+    if taxonomy.get("arcs"):
+        # The real corpus groups categories under arcs (see build/taxonomy.py); the unit
+        # test fixture uses the older flat `categories:` shape, handled below.
+        published = {slug for slug, status in category_statuses(taxonomy).items()
+                     if status == "published"}
+    else:
+        published = {c["name"] for c in taxonomy.get("categories") or []
+                     if c.get("status", "published") == "published"}
+    slugs: list[str] = []
+    for path in sorted((root / "sources" / "categories").glob("*.yaml")):
+        cat = yaml.safe_load(path.read_text())
+        if cat["name"] in published:
+            slugs.extend(cat.get("products") or [])
+    return slugs
+
+
+def _score(root: Path, slug: str) -> dict:
+    return yaml.safe_load((root / "sources" / "scores" / f"{slug}.yaml").read_text())
+
+
+def oldest_products(root: Path, limit: int) -> list[tuple[date, str]]:
+    ranked = []
+    for slug in _published_slugs(root):
+        score = _score(root, slug)
+        dates = [parse_date(score[a]["last_verified"]) for a in _axes()
+                 if isinstance(score.get(a), dict) and score[a].get("last_verified")]
+        if dates:
+            ranked.append((min(dates), slug))
+    ranked.sort()
+    return ranked[:limit]
+
+
+@dataclass
+class ProductResult:
+    slug: str
+    stamped: list[str] = field(default_factory=list)
+    reconfirmed: dict[str, list[str]] = field(default_factory=dict)  # axis -> urls to re-date
+    drifted: list[tuple[str, str]] = field(default_factory=list)
+    transient: list[tuple[str, str]] = field(default_factory=list)
+    skipped: list[tuple[str, str]] = field(default_factory=list)
+
+
+def _recorded_dimensions(axis: str, block: dict) -> list[str]:
+    if axis == "openness":
+        comps = block.get("components")
+        return sorted(comps) if isinstance(comps, dict) else []
+    # adoption and capability record one dimension each for freshness purposes
+    return [axis]
+
+
+def plan_product(score: dict, axes: tuple[str, ...]) -> dict[str, dict[str, list[dict]]]:
+    """axis -> dimension -> digested sources that establish it."""
+    plan: dict[str, dict[str, list[dict]]] = {}
+    for axis in axes:
+        block = score.get(axis)
+        if not isinstance(block, dict) or not block.get("last_verified"):
+            continue
+        dims = {d: [] for d in _recorded_dimensions(axis, block)}
+        for src in block.get("sources") or []:
+            if not src.get("content_sha256"):
+                continue
+            targets = src.get("establishes") if axis == "openness" else [axis]
+            for d in targets or []:
+                if d in dims:
+                    dims[d].append(src)
+        plan[axis] = dims
+    return plan
+
+
+def reverify_product(root: Path, slug: str, today: date, axes: tuple[str, ...] = ("openness",),
+                     fetch=_fetch, pace: float = 0.0, sleep=time.sleep) -> ProductResult:
+    score = _score(root, slug)
+    result = ProductResult(slug=slug)
+    cache: dict[str, dict] = {}
+    for axis, dims in plan_product(score, axes).items():
+        ok = True
+        urls: list[str] = []
+        for dim, sources in dims.items():
+            if not sources:
+                result.skipped.append((axis, f"{dim} has no digested establishing source"))
+                ok = False
+                continue
+            for src in sources:
+                url = src["url"]
+                if url not in cache:
+                    cache[url] = fetch(url)
+                    if pace:
+                        sleep(pace)
+                got = cache[url]
+                if got.get("transient") or not got.get("content_sha256"):
+                    result.transient.append((axis, url))
+                    ok = False
+                elif got["content_sha256"] != src["content_sha256"]:
+                    result.drifted.append((axis, url))
+                    ok = False
+                else:
+                    urls.append(url)
+        if ok and urls:
+            result.stamped.append(axis)
+            result.reconfirmed[axis] = sorted(set(urls))
+    return result
+
+
+def apply(root: Path, slug: str, result: ProductResult, today: date) -> None:
+    path = root / "sources" / "scores" / f"{slug}.yaml"
+    text = path.read_text()
+    for axis in result.stamped:
+        for url in result.reconfirmed[axis]:
+            text = components.set_source(text, axis, url, {"accessed": today.isoformat(), "http_status": 200})
+        text = components.put_field(text, today.isoformat(), axis=axis, key="last_verified", before="sources")
+    if text != path.read_text():
+        path.write_text(text)
+
+
+def main(argv: list[str] | None = None, root: Path | None = None) -> int:
+    root = root or ROOT
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--limit", type=int, default=150)
+    p.add_argument("--axes", default="openness", help="comma-separated; default openness (see #445)")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--report", type=Path, default=None)
+    p.add_argument("--today", default=None)
+    p.add_argument("--pace", type=float, default=1.0, help="seconds to sleep between fetches")
+    args = p.parse_args(argv)
+    today = parse_date(args.today) if args.today else date.today()
+    axes = tuple(a.strip() for a in args.axes.split(",") if a.strip())
+
+    report = {"today": today.isoformat(), "axes": axes, "products": []}
+    for _oldest, slug in oldest_products(root, args.limit):
+        result = reverify_product(root, slug, today, axes=axes, pace=args.pace)
+        if not args.dry_run:
+            apply(root, slug, result, today)
+        report["products"].append({
+            "slug": slug, "stamped": result.stamped, "drifted": result.drifted,
+            "transient": result.transient, "skipped": result.skipped,
+        })
+        print(f"{slug}: stamped={result.stamped} drifted={len(result.drifted)} "
+              f"transient={len(result.transient)} skipped={len(result.skipped)}")
+    if args.report:
+        args.report.write_text(json.dumps(report, indent=2))
+    stamped = sum(1 for r in report["products"] if r["stamped"])
+    print(f"{stamped}/{len(report['products'])} products re-dated on {','.join(axes)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/operations/deploy-models.md
+++ b/docs/operations/deploy-models.md
@@ -80,6 +80,7 @@ holds it against the `cron:` lines it quotes.
 | `artifacts` | Monday 07:00 | `.github/workflows/artifacts.yml` |
 | `freshness` report | Monday 08:00 | `.github/workflows/freshness.yml` |
 | `channel-authority` report | Monday 09:00 | `.github/workflows/channel-authority.yml` |
+| `reverify` (re-dates openness on the oldest 150 products where evidence is unchanged; opens one PR) | Tue 10:00 | `.github/workflows/reverify.yml` |
 
 The chain lands two hours before parity grades it, and the warehouse is at most a week behind
 the repo.

--- a/docs/operations/deploy-models.md
+++ b/docs/operations/deploy-models.md
@@ -80,7 +80,7 @@ holds it against the `cron:` lines it quotes.
 | `artifacts` | Monday 07:00 | `.github/workflows/artifacts.yml` |
 | `freshness` report | Monday 08:00 | `.github/workflows/freshness.yml` |
 | `channel-authority` report | Monday 09:00 | `.github/workflows/channel-authority.yml` |
-| `reverify` (re-dates openness on the oldest 150 products where evidence is unchanged; opens one PR) | Tue 10:00 | `.github/workflows/reverify.yml` |
+| `reverify` (re-dates openness on the oldest 150 products where evidence is unchanged; opens one PR) | Tuesday 10:00 | `.github/workflows/reverify.yml` |
 
 The chain lands two hours before parity grades it, and the warehouse is at most a week behind
 the repo.

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -490,7 +490,7 @@ gate every PR. The ones needing the network run periodically.
 | refetch | fabricated or rotted sources | sampled re-fetch, digest and `shows` token match | network, weekly |
 | parity | repo and warehouse drifting apart | `build/check_parity.py`, a per-product differential | network, weekly |
 | capability-anchors | a recorded peer comparison that does not hold | `relation` must agree with both scores, and a dated band's peer must be confirmed at least as recently | free |
-| age | a corpus that was confirmed once and then quietly aged | `build/check_freshness.py --max-age-days 45 (temporary)`, scheduled weekly | free, weekly |
+| age | a corpus that was confirmed once and then quietly aged | `build/check_freshness.py --max-age-days 45` (temporary), scheduled weekly | free, weekly |
 
 These were numbered G1-G6 until 2026-08-08. Older PRs and commit messages use the numbers.
 
@@ -931,7 +931,7 @@ score for this reason.
 
 ### 5. Turn on the age gate
 
-**Done 2026-08-14.** `build/check_freshness.py --max-age-days 45 (temporary)` gates in
+**Done 2026-08-14.** `build/check_freshness.py --max-age-days 45` (temporary) gates in
 `.github/workflows/freshness.yml`, weekly. This is the entire point of having the field: a
 category whose oldest axis is 50 days old is a category to go and look at. Gating earlier would
 only have failed on the pre-automation backlog rather than on genuine staleness; step 4 closed

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -423,15 +423,33 @@ seen in June.
 
 ### Machine re-verification
 
-`build/reverify.py` may write `accessed`, `http_status` and `last_verified`, and only these,
-and only where every recorded dimension of an axis has a digested source that `establishes`
-it and every such source re-fetched byte-identical (same `content_sha256`, non-transient).
-It never derives a date, never records a transient fetch, and never touches an axis whose
-evidence changed. A new verification date records a successful re-evaluation on that date,
-not a claim that the fact was established or the source changed then. Ruling on #445
+`build/reverify.py` may write `accessed`, `http_status` and `content_sha256` on a source, and
+`last_verified` on an axis, and only these, and only where every recorded dimension of the
+axis has a digested source that `establishes` it and every such source re-fetched
+non-transient and confirmed. The dimension set it demands a source for is not a second copy
+of the gate's rule — it calls `build.check_verification.recorded_dimensions` directly, so a
+non-evidence key like `free_text` is never treated as requiring one.
+
+A source confirms one of three ways: the body is byte-identical (same `content_sha256`); the
+source's recorded `shows` excerpt still occurs in the fresh body, after both sides are
+whitespace-normalized and the body is tried through `html.unescape` (a placeholder `shows` —
+see `check_verification.placeholder_shows` — never confirms this way); or, for a source
+answering the `license` dimension from a GitHub license/repo API or a Hugging Face
+model-info endpoint, the fresh response's SPDX id normalizes (through
+`check_rubric.normalize_license`) to the same license already recorded, so long as the
+recorded clause is a single license rather than a `+`-joined compound. Whichever path
+confirms it, the source is rewritten with the fetch's actual `http_status` and its NEW
+`content_sha256` — a shows match records that the page still says what the source was cited
+for; the new digest is recorded so the next re-check compares against what was actually
+read. It never derives a date, never records a transient fetch, and never touches an axis
+whose evidence changed. A new verification date records a successful re-evaluation on that
+date, not a claim that the fact was established or the source changed then. Ruling on #445
 (2026-09): a byte-identical re-fetch confirms an openness dimension; adoption and
 capability are excluded from machine re-dating because their sources carry numbers that
-move. Their re-verification stays with the agent leg in `refresh-category`.
+move. Their re-verification stays with the agent leg in `refresh-category`. Ruled again
+2026-09-03 (#445 follow-up): byte identity is the wrong test for evidence pages that
+legitimately re-render on every load, so shows-match and SPDX comparison are also
+acceptable confirmations, on the terms above.
 
 ### Catching fabrication rather than just inconsistency
 

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -421,6 +421,18 @@ dimension, so the binding constraint is the *least* recently re-read one. `max(a
 across an axis would pass an axis where one dimension was re-read today and three were last
 seen in June.
 
+### Machine re-verification
+
+`build/reverify.py` may write `accessed`, `http_status` and `last_verified`, and only these,
+and only where every recorded dimension of an axis has a digested source that `establishes`
+it and every such source re-fetched byte-identical (same `content_sha256`, non-transient).
+It never derives a date, never records a transient fetch, and never touches an axis whose
+evidence changed. A new verification date records a successful re-evaluation on that date,
+not a claim that the fact was established or the source changed then. Ruling on #445
+(2026-09): a byte-identical re-fetch confirms an openness dimension; adoption and
+capability are excluded from machine re-dating because their sources carry numbers that
+move. Their re-verification stays with the agent leg in `refresh-category`.
+
 ### Catching fabrication rather than just inconsistency
 
 The invariant catches unsupported dates. It cannot catch a source that never said what

--- a/tests/test_check_refetch.py
+++ b/tests/test_check_refetch.py
@@ -20,7 +20,7 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
-from build.check_refetch import Source, offline_failures, refetch
+from build.check_refetch import Source, http_get, offline_failures, refetch
 from build.check_refetch import bot_wall as pr_bot_wall
 
 DIGEST_A = "a" * 64
@@ -168,6 +168,32 @@ def test_network_error_is_unreachable_not_dead():
         "build.check_refetch.requests.get", side_effect=requests.Timeout("timed out")
     ):
         assert refetch(source, 5.0)[0] == "unreachable"
+
+
+# --- GitHub authentication --------------------------------------------------------------
+# A 150-product weekly re-verify against GitHub-hosted sources burns through the anonymous
+# 60/hour limit fast; `Authorization` fixes that without changing what bytes come back, so
+# it is scoped to GitHub's own hosts and only sent when GITHUB_TOKEN is actually set.
+
+def test_github_host_gets_authorization_when_token_is_set(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "secret-token")
+    with patch("build.check_refetch.requests.get", return_value=_response(200)) as get:
+        http_get("https://raw.githubusercontent.com/org/repo/main/LICENSE", timeout=5.0)
+    assert get.call_args.kwargs["headers"]["Authorization"] == "Bearer secret-token"
+
+
+def test_non_github_host_gets_no_authorization_even_with_token_set(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "secret-token")
+    with patch("build.check_refetch.requests.get", return_value=_response(200)) as get:
+        http_get("https://example.com/page", timeout=5.0)
+    assert "Authorization" not in get.call_args.kwargs["headers"]
+
+
+def test_github_host_gets_no_authorization_when_token_is_unset(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    with patch("build.check_refetch.requests.get", return_value=_response(200)) as get:
+        http_get("https://raw.githubusercontent.com/org/repo/main/LICENSE", timeout=5.0)
+    assert "Authorization" not in get.call_args.kwargs["headers"]
 
 
 # --- Bot walls -------------------------------------------------------------------------

--- a/tests/test_reverify.py
+++ b/tests/test_reverify.py
@@ -1,0 +1,109 @@
+from datetime import date
+from pathlib import Path
+
+import yaml
+
+from build import reverify
+
+
+def _corpus(tmp_path: Path, dates: dict[str, tuple[str, str, str]]) -> Path:
+    (tmp_path / "sources" / "scores").mkdir(parents=True)
+    (tmp_path / "sources" / "categories").mkdir()
+    (tmp_path / "sources" / "categories" / "cat.yaml").write_text(
+        yaml.safe_dump({"name": "cat", "display_name": "Cat", "products": sorted(dates)}))
+    (tmp_path / "sources" / "taxonomy.yaml").write_text(
+        yaml.safe_dump({"categories": [{"name": "cat", "status": "published"}]}))
+    for slug, (o, a, c) in dates.items():
+        (tmp_path / "sources" / "scores" / f"{slug}.yaml").write_text(yaml.safe_dump({
+            "product": slug,
+            "openness": {"score": 5, "class": "open_source", "last_verified": o, "sources": []},
+            "adoption": {"level": 3, "last_verified": a, "sources": []},
+            "capability": {"score": 3, "basis": "feature_matrix", "last_verified": c, "sources": []},
+        }))
+    return tmp_path
+
+
+def test_oldest_products_ranks_by_min_axis_then_slug(tmp_path):
+    root = _corpus(tmp_path, {
+        "zeta": ("2026-08-13", "2026-08-20", "2026-08-20"),
+        "alpha": ("2026-08-13", "2026-08-13", "2026-08-13"),
+        "newer": ("2026-08-30", "2026-08-30", "2026-08-30"),
+    })
+    ranked = reverify.oldest_products(root, limit=2)
+    assert ranked == [(date(2026, 8, 13), "alpha"), (date(2026, 8, 13), "zeta")]
+
+
+def _score_with_sources(tmp_path, sources, dims=("license", "source")):
+    root = _corpus(tmp_path, {"p": ("2026-08-13", "2026-08-13", "2026-08-13")})
+    path = root / "sources" / "scores" / "p.yaml"
+    data = yaml.safe_load(path.read_text())
+    data["openness"]["components"] = {d: "x" for d in dims}
+    # `sources:` is the last field of an axis block throughout the corpus (see
+    # sources/scores/accelerate.yaml); drop and re-add it after `components` so this
+    # fixture matches that convention instead of leaving `sources` ahead of `components`.
+    data["openness"].pop("sources", None)
+    data["openness"]["sources"] = sources
+    path.write_text(yaml.safe_dump(data, sort_keys=False, width=100))
+    return root
+
+
+def _src(url, digest, establishes):
+    return {"url": url, "shows": "the license text", "accessed": "2026-08-13",
+            "http_status": 200, "content_sha256": digest, "establishes": establishes}
+
+
+def test_stamps_when_every_dimension_reconfirms(tmp_path):
+    root = _score_with_sources(tmp_path, [
+        _src("https://a/LICENSE", "a" * 64, ["license"]),
+        _src("https://a/README", "b" * 64, ["source"]),
+    ])
+    fake = lambda url, **kw: {"url": url, "http_status": 200,  # noqa: E731
+                              "content_sha256": "a" * 64 if url.endswith("LICENSE") else "b" * 64}
+    result = reverify.reverify_product(root, "p", date(2026, 9, 3), axes=("openness",), fetch=fake)
+    assert result.stamped == ["openness"]
+    assert result.drifted == [] and result.transient == []
+
+
+def test_drift_on_one_source_leaves_the_axis_alone(tmp_path):
+    root = _score_with_sources(tmp_path, [
+        _src("https://a/LICENSE", "a" * 64, ["license"]),
+        _src("https://a/README", "b" * 64, ["source"]),
+    ])
+    fake = lambda url, **kw: {"url": url, "http_status": 200,  # noqa: E731
+                              "content_sha256": "a" * 64 if url.endswith("LICENSE") else "c" * 64}
+    result = reverify.reverify_product(root, "p", date(2026, 9, 3), axes=("openness",), fetch=fake)
+    assert result.stamped == []
+    assert result.drifted == [("openness", "https://a/README")]
+
+
+def test_transient_is_not_evidence(tmp_path):
+    root = _score_with_sources(tmp_path, [_src("https://a/LICENSE", "a" * 64, ["license"])], dims=("license",))
+    fake = lambda url, **kw: {"url": url, "http_status": 429, "transient": True}  # noqa: E731
+    result = reverify.reverify_product(root, "p", date(2026, 9, 3), axes=("openness",), fetch=fake)
+    assert result.stamped == [] and result.transient == [("openness", "https://a/LICENSE")]
+
+
+def test_dimension_without_digested_source_is_skipped(tmp_path):
+    root = _score_with_sources(tmp_path, [_src("https://a/LICENSE", "a" * 64, ["license"])],
+                               dims=("license", "core-gated"))
+    fake = lambda url, **kw: {"url": url, "http_status": 200, "content_sha256": "a" * 64}  # noqa: E731
+    result = reverify.reverify_product(root, "p", date(2026, 9, 3), axes=("openness",), fetch=fake)
+    assert result.stamped == []
+    assert ("openness", "core-gated has no digested establishing source") in result.skipped
+
+
+def test_apply_writes_accessed_status_and_last_verified_only(tmp_path):
+    root = _score_with_sources(tmp_path, [_src("https://a/LICENSE", "a" * 64, ["license"])], dims=("license",))
+    fake = lambda url, **kw: {"url": url, "http_status": 200, "content_sha256": "a" * 64}  # noqa: E731
+    result = reverify.reverify_product(root, "p", date(2026, 9, 3), axes=("openness",), fetch=fake)
+    before = (root / "sources/scores/p.yaml").read_text()
+    reverify.apply(root, "p", result, date(2026, 9, 3))
+    after = yaml.safe_load((root / "sources/scores/p.yaml").read_text())
+    assert after["openness"]["last_verified"] == "2026-09-03"
+    assert after["openness"]["sources"][0]["accessed"] == "2026-09-03"
+    assert after["openness"]["sources"][0]["content_sha256"] == "a" * 64
+    assert after["adoption"]["last_verified"] == "2026-08-13"
+    # Only the intended lines moved.
+    changed = [l for l in (root / "sources/scores/p.yaml").read_text().splitlines()
+               if l not in before.splitlines()]
+    assert all("2026-09-03" in l for l in changed), changed

--- a/tests/test_reverify.py
+++ b/tests/test_reverify.py
@@ -184,6 +184,18 @@ def test_placeholder_shows_never_confirms(tmp_path):
     assert result.drifted == [("openness", "https://a/LICENSE")]
 
 
+def test_apply_carries_the_fetched_http_status_for_a_byte_identical_source(tmp_path):
+    # A byte-identical re-fetch is still a real fetch, and its response is not always a
+    # bare 200 (a conditional GET can come back 304). `apply` used to hardcode 200 for
+    # every reconfirmed source regardless of what was actually returned.
+    root = _score_with_sources(tmp_path, [_src("https://a/LICENSE", "a" * 64, ["license"])], dims=("license",))
+    fake = lambda url, **kw: {"url": url, "http_status": 304, "content_sha256": "a" * 64}  # noqa: E731
+    result = reverify.reverify_product(root, "p", date(2026, 9, 3), axes=("openness",), fetch=fake)
+    reverify.apply(root, "p", result, date(2026, 9, 3))
+    src = yaml.safe_load((root / "sources/scores/p.yaml").read_text())["openness"]["sources"][0]
+    assert src["http_status"] == 304
+
+
 def test_apply_writes_the_fetched_http_status_and_new_digest_for_a_shows_confirmed_source(tmp_path):
     body_path = _body(tmp_path, "license.html", "<p>the license text, reflowed.</p>")
     root = _score_with_sources(tmp_path, [_src("https://a/LICENSE", "a" * 64, ["license"],

--- a/tests/test_reverify.py
+++ b/tests/test_reverify.py
@@ -1,9 +1,11 @@
+import json
 from datetime import date
 from pathlib import Path
 
 import yaml
 
 from build import reverify
+from build.check_verification import PLACEHOLDER_SHOWS
 
 
 def _corpus(tmp_path: Path, dates: dict[str, tuple[str, str, str]]) -> Path:
@@ -33,11 +35,25 @@ def test_oldest_products_ranks_by_min_axis_then_slug(tmp_path):
     assert ranked == [(date(2026, 8, 13), "alpha"), (date(2026, 8, 13), "zeta")]
 
 
-def _score_with_sources(tmp_path, sources, dims=("license", "source")):
+# Minimal recipes so a dimension other than `license` (which is always required by
+# default — see `build.check_rubric.license_read_keys`) is required too, matching what
+# `build.check_verification.recorded_dimensions` reads off a category's own recipe.
+_SOURCE_RECIPE = {"openness": {"dimensions": {"source": {"reads": ["source"]}}}}
+_CORE_GATED_RECIPE = {"openness": {"dimensions": {"core-gated": {"reads": ["core-gated"]}}}}
+
+
+def _score_with_sources(tmp_path, sources, dims=("license", "source"), recipe=None):
     root = _corpus(tmp_path, {"p": ("2026-08-13", "2026-08-13", "2026-08-13")})
+    if recipe is not None:
+        cat_path = root / "sources" / "categories" / "cat.yaml"
+        cat = yaml.safe_load(cat_path.read_text())
+        cat["scoring_recipe"] = recipe
+        cat_path.write_text(yaml.safe_dump(cat))
     path = root / "sources" / "scores" / "p.yaml"
     data = yaml.safe_load(path.read_text())
-    data["openness"]["components"] = {d: "x" for d in dims}
+    # Structured shape (`{value: ...}`), matching the real corpus — see
+    # sources/scores/accelerate.yaml — so `build.check_rubric.components_of` can read it.
+    data["openness"]["components"] = {d: {"value": "x"} for d in dims}
     # `sources:` is the last field of an axis block throughout the corpus (see
     # sources/scores/accelerate.yaml); drop and re-add it after `components` so this
     # fixture matches that convention instead of leaving `sources` ahead of `components`.
@@ -47,8 +63,8 @@ def _score_with_sources(tmp_path, sources, dims=("license", "source")):
     return root
 
 
-def _src(url, digest, establishes):
-    return {"url": url, "shows": "the license text", "accessed": "2026-08-13",
+def _src(url, digest, establishes, shows="the license text"):
+    return {"url": url, "shows": shows, "accessed": "2026-08-13",
             "http_status": 200, "content_sha256": digest, "establishes": establishes}
 
 
@@ -56,7 +72,7 @@ def test_stamps_when_every_dimension_reconfirms(tmp_path):
     root = _score_with_sources(tmp_path, [
         _src("https://a/LICENSE", "a" * 64, ["license"]),
         _src("https://a/README", "b" * 64, ["source"]),
-    ])
+    ], recipe=_SOURCE_RECIPE)
     fake = lambda url, **kw: {"url": url, "http_status": 200,  # noqa: E731
                               "content_sha256": "a" * 64 if url.endswith("LICENSE") else "b" * 64}
     result = reverify.reverify_product(root, "p", date(2026, 9, 3), axes=("openness",), fetch=fake)
@@ -68,7 +84,7 @@ def test_drift_on_one_source_leaves_the_axis_alone(tmp_path):
     root = _score_with_sources(tmp_path, [
         _src("https://a/LICENSE", "a" * 64, ["license"]),
         _src("https://a/README", "b" * 64, ["source"]),
-    ])
+    ], recipe=_SOURCE_RECIPE)
     fake = lambda url, **kw: {"url": url, "http_status": 200,  # noqa: E731
                               "content_sha256": "a" * 64 if url.endswith("LICENSE") else "c" * 64}
     result = reverify.reverify_product(root, "p", date(2026, 9, 3), axes=("openness",), fetch=fake)
@@ -85,7 +101,7 @@ def test_transient_is_not_evidence(tmp_path):
 
 def test_dimension_without_digested_source_is_skipped(tmp_path):
     root = _score_with_sources(tmp_path, [_src("https://a/LICENSE", "a" * 64, ["license"])],
-                               dims=("license", "core-gated"))
+                               dims=("license", "core-gated"), recipe=_CORE_GATED_RECIPE)
     fake = lambda url, **kw: {"url": url, "http_status": 200, "content_sha256": "a" * 64}  # noqa: E731
     result = reverify.reverify_product(root, "p", date(2026, 9, 3), axes=("openness",), fetch=fake)
     assert result.stamped == []
@@ -107,3 +123,113 @@ def test_apply_writes_accessed_status_and_last_verified_only(tmp_path):
     changed = [l for l in (root / "sources/scores/p.yaml").read_text().splitlines()
                if l not in before.splitlines()]
     assert all("2026-09-03" in l for l in changed), changed
+
+
+# --- Step 1: the dimension set is the gate's, not every `components` key ---------------
+
+
+def test_free_text_is_not_a_required_dimension(tmp_path):
+    root = _score_with_sources(tmp_path, [_src("https://a/LICENSE", "a" * 64, ["license"])],
+                               dims=("license", "free_text"))
+    fake = lambda url, **kw: {"url": url, "http_status": 200, "content_sha256": "a" * 64}  # noqa: E731
+    result = reverify.reverify_product(root, "p", date(2026, 9, 3), axes=("openness",), fetch=fake)
+    assert result.stamped == ["openness"]
+    assert result.skipped == []
+
+
+# --- Step 2: a `shows` match is a second confirmation path -----------------------------
+
+
+def _body(tmp_path, name, text):
+    body_dir = tmp_path / "bodies"
+    body_dir.mkdir(exist_ok=True)
+    path = body_dir / name
+    path.write_text(text)
+    return path
+
+
+def test_shows_present_in_changed_body_confirms(tmp_path):
+    body_path = _body(tmp_path, "license.html",
+                      "<p>Some preamble.</p><p>the license text, now reflowed as HTML.</p>")
+    root = _score_with_sources(tmp_path, [_src("https://a/LICENSE", "a" * 64, ["license"],
+                                                shows="the license text")], dims=("license",))
+    fake = lambda url, **kw: {"url": url, "http_status": 200, "content_sha256": "b" * 64,  # noqa: E731
+                              "body_path": str(body_path)}
+    result = reverify.reverify_product(root, "p", date(2026, 9, 3), axes=("openness",), fetch=fake)
+    assert result.stamped == ["openness"]
+    assert result.reconfirmed_by_shows == [("openness", "https://a/LICENSE")]
+    assert result.drifted == []
+
+
+def test_shows_absent_from_changed_body_is_drift(tmp_path):
+    body_path = _body(tmp_path, "license.html", "<p>Completely different content now.</p>")
+    root = _score_with_sources(tmp_path, [_src("https://a/LICENSE", "a" * 64, ["license"],
+                                                shows="the license text")], dims=("license",))
+    fake = lambda url, **kw: {"url": url, "http_status": 200, "content_sha256": "b" * 64,  # noqa: E731
+                              "body_path": str(body_path)}
+    result = reverify.reverify_product(root, "p", date(2026, 9, 3), axes=("openness",), fetch=fake)
+    assert result.stamped == []
+    assert result.drifted == [("openness", "https://a/LICENSE")]
+
+
+def test_placeholder_shows_never_confirms(tmp_path):
+    marker = next(iter(PLACEHOLDER_SHOWS))
+    body_path = _body(tmp_path, "license.html", f"<p>{marker} plus the rest of the page.</p>")
+    root = _score_with_sources(tmp_path, [_src("https://a/LICENSE", "a" * 64, ["license"],
+                                                shows=marker)], dims=("license",))
+    fake = lambda url, **kw: {"url": url, "http_status": 200, "content_sha256": "b" * 64,  # noqa: E731
+                              "body_path": str(body_path)}
+    result = reverify.reverify_product(root, "p", date(2026, 9, 3), axes=("openness",), fetch=fake)
+    assert result.stamped == []
+    assert result.drifted == [("openness", "https://a/LICENSE")]
+
+
+def test_apply_writes_the_fetched_http_status_and_new_digest_for_a_shows_confirmed_source(tmp_path):
+    body_path = _body(tmp_path, "license.html", "<p>the license text, reflowed.</p>")
+    root = _score_with_sources(tmp_path, [_src("https://a/LICENSE", "a" * 64, ["license"],
+                                                shows="the license text")], dims=("license",))
+    fake = lambda url, **kw: {"url": url, "http_status": 304, "content_sha256": "b" * 64,  # noqa: E731
+                              "body_path": str(body_path)}
+    result = reverify.reverify_product(root, "p", date(2026, 9, 3), axes=("openness",), fetch=fake)
+    reverify.apply(root, "p", result, date(2026, 9, 3))
+    src = yaml.safe_load((root / "sources/scores/p.yaml").read_text())["openness"]["sources"][0]
+    assert src["http_status"] == 304
+    assert src["content_sha256"] == "b" * 64
+
+
+# --- Step 3: SPDX comparison for license API sources ------------------------------------
+
+
+def _score_with_license(tmp_path, license_value, sources):
+    root = _corpus(tmp_path, {"p": ("2026-08-13", "2026-08-13", "2026-08-13")})
+    path = root / "sources" / "scores" / "p.yaml"
+    data = yaml.safe_load(path.read_text())
+    data["openness"]["components"] = {"license": {"value": license_value}}
+    data["openness"].pop("sources", None)
+    data["openness"]["sources"] = sources
+    path.write_text(yaml.safe_dump(data, sort_keys=False, width=100))
+    return root
+
+
+def test_matching_spdx_confirms_license(tmp_path):
+    body_path = _body(tmp_path, "license.json", json.dumps({"license": {"spdx_id": "Apache-2.0"}}))
+    root = _score_with_license(tmp_path, "Apache-2.0", [
+        _src("https://api.github.com/repos/o/r/license", "a" * 64, ["license"]),
+    ])
+    fake = lambda url, **kw: {"url": url, "http_status": 200, "content_sha256": "b" * 64,  # noqa: E731
+                              "body_path": str(body_path)}
+    result = reverify.reverify_product(root, "p", date(2026, 9, 3), axes=("openness",), fetch=fake)
+    assert result.stamped == ["openness"]
+    assert result.reconfirmed_by_spdx == [("openness", "https://api.github.com/repos/o/r/license")]
+
+
+def test_noassertion_spdx_does_not_confirm(tmp_path):
+    body_path = _body(tmp_path, "license.json", json.dumps({"license": {"spdx_id": "NOASSERTION"}}))
+    root = _score_with_license(tmp_path, "Apache-2.0", [
+        _src("https://api.github.com/repos/o/r/license", "a" * 64, ["license"]),
+    ])
+    fake = lambda url, **kw: {"url": url, "http_status": 200, "content_sha256": "b" * 64,  # noqa: E731
+                              "body_path": str(body_path)}
+    result = reverify.reverify_product(root, "p", date(2026, 9, 3), axes=("openness",), fetch=fake)
+    assert result.stamped == []
+    assert result.drifted == [("openness", "https://api.github.com/repos/o/r/license")]

--- a/tests/test_schedule_doc.py
+++ b/tests/test_schedule_doc.py
@@ -21,7 +21,7 @@ ROOT = Path(__file__).resolve().parent.parent
 DOC = ROOT / "docs/operations/deploy-models.md"
 # The gates whose times the doc's table quotes. Dataset crons live on the platform and
 # cannot be read from the repo, so they are out of scope here by construction.
-GATES = ("parity", "artifacts", "freshness", "channel-authority")
+GATES = ("parity", "artifacts", "freshness", "channel-authority", "reverify")
 
 _DAYS = {"1": "Monday", "2": "Tuesday", "3": "Wednesday", "4": "Thursday",
          "5": "Friday", "6": "Saturday", "0": "Sunday"}


### PR DESCRIPTION
## Summary

A deterministic weekly re-verifier for the oldest products, and the honest result of measuring it.

`build/reverify.py` ranks published products by their oldest axis date (ties by slug), re-fetches every digested openness source through `build.fetch_source`, and stamps `last_verified` on an axis only when every dimension the verification gate requires an establishing source for came back confirmed. A source confirms when the fetch is non-transient and either the body is byte-identical, or its recorded `shows` excerpt still appears in the body, or for a GitHub or Hugging Face license-API source the returned SPDX id normalizes to the recorded single-segment license. A confirmed source takes the fetch's real `accessed`, `http_status`, and `content_sha256`. Any drifted, transient, or unestablished dimension blocks the whole axis. Adoption and capability are excluded by default per the ruling on #445.

`reverify.yml` runs Tuesdays 10:00 UTC, gates the result, and opens one `freshness` PR with the per-product report. GitHub-hosted fetches authenticate when `GITHUB_TOKEN` is set.

**What the measurement says.** A 150-product dry run against the oldest cohort stamped 10. Almost every openness citation on this corpus points at a rendered GitHub or Hugging Face page whose bytes change on every load, and where a `shows` excerpt or SPDX id did re-confirm one source, another source on the same axis had drifted. So this is a drift reporter, not the thing that clears the freshness cliff. The per-product drift list it produces is the scope for the agent leg (`refresh-category`), and the 45-day window in #458 buys that time.

This branch is stacked on #458, which raised the window; merge that first and this PR retargets to `main` on its own.

Docs: the "Machine re-verification" contract in `docs/reference/evidence-and-freshness.md`, a schedule row in `deploy-models.md`, and the #445 ruling posted on the issue.

## Test plan

- Full suite green on the branch (1305 passed)
- `uv run pytest tests/test_reverify.py tests/test_check_verification.py tests/test_check_refetch.py -q` passes
- Real run on the 5 oldest products: `build.validate` 0 errors, `check_verification --verbose` and `check_capability` clean, diff touched only `accessed`, `http_status`, `content_sha256`, `last_verified` lines; discarded
- After merge: `gh workflow run reverify -f limit=150` and review the PR it opens
