### PR TITLE
feat(sources): agent_tools_protocols: add MCP Go

### DIFF
--- a/sources/categories/agent_tools_protocols.yaml
+++ b/sources/categories/agent_tools_protocols.yaml
@@ -44,6 +44,7 @@ products:
 - context7
 - marker
 - lightpanda
+- mcp-go
 scoring_recipe:
   version: 1
   extends: software

--- a/sources/organizations/mark3labs.yaml
+++ b/sources/organizations/mark3labs.yaml
@@ -1,0 +1,8 @@
+name: mark3labs
+display_name: Mark III Labs
+type: company
+homepage: https://mark3labs.com
+github:
+- url: https://github.com/mark3labs
+products:
+- mcp-go

--- a/sources/products/mcp-go.yaml
+++ b/sources/products/mcp-go.yaml
@@ -1,0 +1,11 @@
+name: mcp-go
+display_name: MCP Go
+type: software
+description: MCP Go is a Go implementation of the Model Context Protocol, letting developers build servers and
+  clients that expose resources, tools and prompts to LLM applications. It handles protocol compliance and
+  message routing, supports stdio, SSE and streamable HTTP transports plus OAuth-protected resources, and
+  implements the 2025-11-25 specification with backward compatibility to 2024-11-05. Maintained by Mark III
+  Labs.
+github:
+- url: https://github.com/mark3labs/mcp-go
+comments: Verified 2026-09-03 via GitHub and the LICENSE body.

--- a/sources/registry/agent_tools_protocols.yaml
+++ b/sources/registry/agent_tools_protocols.yaml
@@ -27,12 +27,6 @@ products:
     org: google
     github: google-labs-code/design.md
     homepage: https://stitch.withgoogle.com/docs/design-md/specification
-  - slug: mcp-go
-    display_name: MCP Go
-    type: software
-    org: mark3labs
-    github: mark3labs/mcp-go
-    homepage: https://mcp-go.dev
 
   # Tool servers and tool-calling platforms
   - slug: aws-mcp-servers

--- a/sources/scores/mcp-go.yaml
+++ b/sources/scores/mcp-go.yaml
@@ -51,8 +51,8 @@ adoption:
   signal_type: stars_fallback
   confidence: low
   note: 9,058 GitHub stars, which lands in the 1K-10K stars band of the stars scale, level 2. mcp-go ships
-    as a Go module rather than a PyPI or npm package, resolved via pkg.go.dev/go.dev rather than a registry
-    this map fetches download counts from, so the stars scale applies with its cap of 3.
+    as a Go module with no download-counting package registry, so the band rests on stars as the fallback
+    instrument, capped at 3.
   last_verified: '2026-09-03'
   sources:
   - url: https://api.github.com/repos/mark3labs/mcp-go
@@ -61,19 +61,21 @@ adoption:
     http_status: 200
     content_sha256: c316ac369f78a7563a74753d897ea9d8122fd971ba9597a1c07232d1f9d40e82
 capability:
-  score: 3
+  score: 4
   basis: feature_matrix
   basis_detail: 'category feature matrix: MCP server/client SDK feature breadth'
   value: Implements the full server, resource, tool and prompt primitives of the MCP specification
     (2025-11-25, backward compatible to 2024-11-05), including task-augmented (async, pollable) tools,
     stdio/SSE/streamable-HTTP transports, and OAuth Protected Resource Metadata for servers that require
     authorization.
-  relative_to: fastmcp
+  relative_to: mcp-typescript-sdk
   relation: one_below
   confidence: medium
-  note: Placed one band below fastmcp, the category's most feature-complete framework. mcp-go implements
-    the full protocol surface plus transports, task-augmented tools and OAuth, but is a lower-level SDK
-    without fastmcp's higher-level "Apps" layer, auth helpers and deployment tooling.
+  note: Placed one band below mcp-typescript-sdk, the official TypeScript MCP SDK and a fair same-shape
+    peer - another official, language-specific reference implementation of the same protocol. mcp-go covers
+    the full server, resource, tool and prompt surface plus transports, task-augmented tools and OAuth,
+    but has not grown mcp-typescript-sdk's multi-runtime targets (Node.js, Bun, Deno) or its optional framework
+    middleware packages (Express, Fastify, Hono, Node.js HTTP).
   last_verified: '2026-09-03'
   sources:
   - url: https://raw.githubusercontent.com/mark3labs/mcp-go/main/README.md
@@ -87,10 +89,10 @@ capability:
   comparison:
     last_attested: '2026-09-03'
     sources:
-    - url: https://github.com/PrefectHQ/fastmcp
-      shows: README still opens "FastMCP is the standard framework for working with MCP," describing three
-        pillars - servers, apps, clients - plus auth and deployment tooling that mcp-go's lower-level SDK
-        does not provide.
+    - url: https://raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/main/README.md
+      shows: README documents multi-runtime support (Node.js, Bun, Deno) and optional middleware packages
+        wiring MCP into Express, Fastify, Hono and Node.js HTTP - a layer mcp-go's lower-level SDK does
+        not provide.
       accessed: '2026-09-03'
       http_status: 200
-      content_sha256: b804be94976ce4e8d16712f8965bbf222a126466ebba35641673609a79c4a518
+      content_sha256: ecda9a1a30f74de6f843078d5b61bb3b4b63459987ab6c1ec55748f8154d43ae

--- a/sources/scores/mcp-go.yaml
+++ b/sources/scores/mcp-go.yaml
@@ -1,0 +1,96 @@
+product: mcp-go
+openness:
+  score: 5
+  class: open_source
+  components:
+    license:
+    - name: MIT
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+  confidence: high
+  note: The LICENSE body is the standard MIT License text; GitHub's classifier resolves it correctly to MIT
+    even though the copyright line names Anthropic, PBC rather than mark3labs, so no NOASSERTION handling
+    was needed here. The repository is public and unarchived and ships the whole SDK - server, client,
+    transports and OAuth support - with no separate paid tier or license-gated build described anywhere in
+    the README, so source is public and the core ungated.
+  raw: license:MIT(OSI);source:public;core-gated:ungated
+  last_verified: '2026-09-03'
+  sources:
+  - url: https://raw.githubusercontent.com/mark3labs/mcp-go/main/LICENSE
+    shows: MIT License text, copyright (c) 2024 Anthropic, PBC.
+    accessed: '2026-09-03'
+    http_status: 200
+    content_sha256: 5e13dbbc1d120fc2a03cecde7c91424ae2d7de11b63d58ded2f4431e261ee50d
+    establishes:
+    - license
+  - url: https://api.github.com/repos/mark3labs/mcp-go
+    shows: Repo metadata - license spdx_id MIT, private false, archived false, default branch main - for
+      mark3labs/mcp-go.
+    accessed: '2026-09-03'
+    http_status: 200
+    content_sha256: c316ac369f78a7563a74753d897ea9d8122fd971ba9597a1c07232d1f9d40e82
+    establishes:
+    - license
+    - source
+  - url: https://raw.githubusercontent.com/mark3labs/mcp-go/main/README.md
+    shows: README describes the whole SDK - server, resources, tools, prompts, task-augmented tools,
+      transports (stdio, SSE, streamable HTTP) and OAuth Protected Resource Metadata - with no paid tier
+      or license-gated build mentioned anywhere.
+    accessed: '2026-09-03'
+    http_status: 200
+    content_sha256: f30204e0f9820d993ea8779c09478472f187e908c75bef40f69fe3244a4d3f68
+    establishes:
+    - source
+    - core-gated
+adoption:
+  level: 2
+  reach: 1K-10K stars
+  signal_type: stars_fallback
+  confidence: low
+  note: 9,058 GitHub stars, which lands in the 1K-10K stars band of the stars scale, level 2. mcp-go ships
+    as a Go module rather than a PyPI or npm package, resolved via pkg.go.dev/go.dev rather than a registry
+    this map fetches download counts from, so the stars scale applies with its cap of 3.
+  last_verified: '2026-09-03'
+  sources:
+  - url: https://api.github.com/repos/mark3labs/mcp-go
+    shows: Repo metadata - stargazers_count = 9,058 - for mark3labs/mcp-go.
+    accessed: '2026-09-03'
+    http_status: 200
+    content_sha256: c316ac369f78a7563a74753d897ea9d8122fd971ba9597a1c07232d1f9d40e82
+capability:
+  score: 3
+  basis: feature_matrix
+  basis_detail: 'category feature matrix: MCP server/client SDK feature breadth'
+  value: Implements the full server, resource, tool and prompt primitives of the MCP specification
+    (2025-11-25, backward compatible to 2024-11-05), including task-augmented (async, pollable) tools,
+    stdio/SSE/streamable-HTTP transports, and OAuth Protected Resource Metadata for servers that require
+    authorization.
+  relative_to: fastmcp
+  relation: one_below
+  confidence: medium
+  note: Placed one band below fastmcp, the category's most feature-complete framework. mcp-go implements
+    the full protocol surface plus transports, task-augmented tools and OAuth, but is a lower-level SDK
+    without fastmcp's higher-level "Apps" layer, auth helpers and deployment tooling.
+  last_verified: '2026-09-03'
+  sources:
+  - url: https://raw.githubusercontent.com/mark3labs/mcp-go/main/README.md
+    shows: README documents server, resource, tool and prompt primitives, task-augmented tools with
+      TaskSupportRequired/TaskSupportOptional modes, multiple transports, and OAuth Protected Resource
+      Metadata; also states the project "is under active development... some advanced capabilities are
+      still in progress."
+    accessed: '2026-09-03'
+    http_status: 200
+    content_sha256: f30204e0f9820d993ea8779c09478472f187e908c75bef40f69fe3244a4d3f68
+  comparison:
+    last_attested: '2026-09-03'
+    sources:
+    - url: https://github.com/PrefectHQ/fastmcp
+      shows: README still opens "FastMCP is the standard framework for working with MCP," describing three
+        pillars - servers, apps, clients - plus auth and deployment tooling that mcp-go's lower-level SDK
+        does not provide.
+      accessed: '2026-09-03'
+      http_status: 200
+      content_sha256: b804be94976ce4e8d16712f8965bbf222a126466ebba35641673609a79c4a518


### PR DESCRIPTION
## What

Adds MCP Go (`mark3labs/mcp-go`) to `agent_tools_protocols`. It's a Go implementation of the
Model Context Protocol, letting developers build servers and clients that expose resources,
tools and prompts to LLM applications. It handles protocol compliance and message routing,
supports stdio, SSE and streamable HTTP transports plus OAuth-protected resources, and
implements the 2025-11-25 specification with backward compatibility to 2024-11-05. Maintained
by Mark III Labs.

## Scores

- **Openness: 5/open_source.** MIT license (OSI), public source, no gated core. GitHub's
  classifier resolves the license correctly to MIT even though the repository's copyright line
  names Anthropic, PBC rather than mark3labs.
- **Adoption: level 2 (stars_fallback).** 9,058 GitHub stars. mcp-go ships as a Go module with
  no download-counting package registry, so the band rests on stars as the fallback instrument,
  capped at 3.
- **Capability: 4, one band below `mcp-typescript-sdk`.** mcp-typescript-sdk is the official
  TypeScript MCP SDK and the nearer same-shape peer — another official, language-specific
  reference implementation of the same protocol — rather than fastmcp, a higher-level, more
  distant framework. mcp-go covers the full server, resource, tool and prompt surface plus
  transports, task-augmented tools and OAuth, but has not grown mcp-typescript-sdk's
  multi-runtime targets (Node.js, Bun, Deno) or its optional framework middleware packages
  (Express, Fastify, Hono, Node.js HTTP).

## Evidence

- https://raw.githubusercontent.com/mark3labs/mcp-go/main/LICENSE — MIT License text, copyright
  (c) 2024 Anthropic, PBC.
- https://api.github.com/repos/mark3labs/mcp-go — repo metadata: license spdx_id MIT, private
  false, archived false, stargazers_count 9,058.
- https://raw.githubusercontent.com/mark3labs/mcp-go/main/README.md — describes the whole SDK
  (server, resources, tools, prompts, task-augmented tools, transports, OAuth Protected Resource
  Metadata) with no paid tier or license-gated build.
- https://raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/main/README.md — the
  capability comparison peer: documents multi-runtime support (Node.js, Bun, Deno) and optional
  middleware packages wiring MCP into Express, Fastify, Hono and Node.js HTTP, a layer mcp-go's
  lower-level SDK does not provide.

## Review sheet

```
| category | stage | gaps | products | tier changes |
|---|---|---|---|---|
| agent_tools_protocols | 5 | [] | +1 / -0 | none |

stage moves: none
untouched-product row changes: none
```

## Test plan

- [x] `build.validate` — 0 errors
- [x] `check_verification --verbose`, `check_capability`, `check_components`, `check_rubric`
      (`agent_tools_protocols: 35/35 reproduced`), `check_adoption --strict` — all green
- [x] `pytest -q -n auto -m "not serial"` — 1324 passed, 1 skipped
- [x] `build.serialize` + `build.check_corpus_diff` — single-category +1, no stage move, no
      untouched-product drift
