### PR TITLE
feat(sources): storage: add pgvectorscale

### DIFF
--- a/sources/categories/storage.yaml
+++ b/sources/categories/storage.yaml
@@ -53,6 +53,7 @@ products:
 - pixeltable
 - lamindb
 - redisearch
+- pgvectorscale
 scoring_recipe:
   version: 1
   extends: software

--- a/sources/organizations/tiger-data.yaml
+++ b/sources/organizations/tiger-data.yaml
@@ -1,0 +1,8 @@
+name: tiger-data
+display_name: Tiger Data
+type: company
+homepage: https://www.tigerdata.com
+github:
+- url: https://github.com/timescale
+products:
+- pgvectorscale

--- a/sources/products/pgvectorscale.yaml
+++ b/sources/products/pgvectorscale.yaml
@@ -1,0 +1,11 @@
+name: pgvectorscale
+display_name: pgvectorscale
+type: software
+description: pgvectorscale is a Postgres extension that complements pgvector with a StreamingDiskANN index,
+  inspired by Microsoft's DiskANN research, and a statistical binary quantization scheme for cost-efficient
+  storage at scale. It also adds label-based filtered vector search, combining similarity search with
+  metadata filtering in a single index. Written in Rust using the PGRX framework and developed by Tiger
+  Data (formerly Timescale).
+github:
+- url: https://github.com/timescale/pgvectorscale
+comments: Verified 2026-09-03 via GitHub and the LICENSE body.

--- a/sources/scores/pgvectorscale.yaml
+++ b/sources/scores/pgvectorscale.yaml
@@ -1,0 +1,101 @@
+product: pgvectorscale
+openness:
+  score: 5
+  class: open_source
+  components:
+    license:
+    - name: PostgreSQL
+      detail: OSI
+    source:
+      value: public
+    core-gated:
+      value: ungated
+  confidence: high
+  note: The LICENSE body is the PostgreSQL License, the same OSI-approved terms pgvector records, here
+    carrying a Tiger Data disclaimer rather than the Postgres project's own notices. GitHub's classifier
+    resolves it to `postgresql`, not NOASSERTION. The repository is public and unarchived and builds the
+    whole extension - the StreamingDiskANN index, statistical binary quantization and label-based filtered
+    search - with no separate paid tier or license-gated build in the tree; Tiger Data's hosted Timescale
+    Cloud service sits beside the extension rather than withholding any part of it. So source is public and
+    the core ungated.
+  raw: license:PostgreSQL(OSI);source:public;core-gated:ungated
+  last_verified: '2026-09-03'
+  sources:
+  - url: https://raw.githubusercontent.com/timescale/pgvectorscale/main/LICENSE
+    shows: The PostgreSQL License - permissive terms carrying a Tiger Data disclaimer of warranty and
+      liability, structurally identical to the license pgvector records.
+    accessed: '2026-09-03'
+    http_status: 200
+    content_sha256: 1fb31b095ba8b0188bc2c7eaff8d69028c2f4cfb19aaf8bd463121e7008f1e83
+    establishes:
+    - license
+  - url: https://api.github.com/repos/timescale/pgvectorscale
+    shows: Repo metadata - license spdx_id PostgreSQL, private false, archived false, default branch main -
+      for timescale/pgvectorscale.
+    accessed: '2026-09-03'
+    http_status: 200
+    content_sha256: 738307b4defbd220d8f6628df2061e1b5987bef6b9b5485932e3d6732fe1d7e2
+    establishes:
+    - license
+    - source
+  - url: https://raw.githubusercontent.com/timescale/pgvectorscale/main/README.md
+    shows: README describes StreamingDiskANN indexing, statistical binary quantization and label-based
+      filtered vector search shipped in the one repository, installed via `CREATE EXTENSION vectorscale`,
+      with a separate paid "private beta" Timescale Cloud signup offered alongside the extension rather
+      than gating any part of what is in the tree.
+    accessed: '2026-09-03'
+    http_status: 200
+    content_sha256: 796d2a4b84b8be04ea9dcba5afe3bacba9117a1a48617dc1404b32e4285a0466
+    establishes:
+    - source
+    - core-gated
+adoption:
+  level: 2
+  reach: 1K-10K stars
+  signal_type: stars_fallback
+  confidence: low
+  note: 3,119 GitHub stars, which lands in the 1K-10K stars band of the stars scale, level 2. The extension
+    installs as a Postgres extension via Docker or from source rather than a PyPI or npm package, and no
+    distribution channel publishes a comparable download count, so the stars scale applies with its cap of
+    3.
+  last_verified: '2026-09-03'
+  sources:
+  - url: https://api.github.com/repos/timescale/pgvectorscale
+    shows: Repo metadata - stargazers_count = 3,119 - for timescale/pgvectorscale.
+    accessed: '2026-09-03'
+    http_status: 200
+    content_sha256: 738307b4defbd220d8f6628df2061e1b5987bef6b9b5485932e3d6732fe1d7e2
+capability:
+  score: 2
+  basis: feature_matrix
+  basis_detail: 'category feature matrix: single index family shipped as a library with no storage of its own'
+  value: Adds a StreamingDiskANN index type, statistical binary quantization and label-based filtered search
+    on top of pgvector's existing vector columns; it indexes vectors pgvector already stores rather than
+    persisting or serving data on its own.
+  relative_to: pgvector
+  relation: one_below
+  confidence: medium
+  note: Banded one rung below pgvector on the storage category's feature matrix. pgvector is rung 3, a
+    working single-purpose store or index; pgvectorscale ships only a faster index type and quantization
+    scheme over columns pgvector already defines and stores, which is rung 2, a single index family shipped
+    as a library with no storage of its own.
+  last_verified: '2026-09-03'
+  sources:
+  - url: https://raw.githubusercontent.com/timescale/pgvectorscale/main/README.md
+    shows: README states pgvectorscale "complements pgvector... and introduces the following key
+      innovations for pgvector data", requires `CREATE EXTENSION vectorscale CASCADE` to automatically
+      install pgvector, and indexes the vector columns pgvector defines rather than defining or storing
+      data itself.
+    accessed: '2026-09-03'
+    http_status: 200
+    content_sha256: 796d2a4b84b8be04ea9dcba5afe3bacba9117a1a48617dc1404b32e4285a0466
+  comparison:
+    last_attested: '2026-09-03'
+    sources:
+    - url: https://github.com/pgvector/pgvector
+      shows: Repo page still documents "nearest neighbor" search over vector types stored directly in
+        Postgres tables with joins, transactions and point-in-time recovery, the single-purpose store-and-
+        index surface pgvectorscale's own rung is measured one below.
+      accessed: '2026-09-03'
+      http_status: 200
+      content_sha256: caa9a3a699c0bb749a36098b578b104a92dac5cd69752e226dc97811fe598e28


### PR DESCRIPTION
## What

Adds pgvectorscale (`timescale/pgvectorscale`) to `storage`. It's a Postgres extension that
complements pgvector with a StreamingDiskANN index, inspired by Microsoft's DiskANN research,
and a statistical binary quantization scheme for cost-efficient storage at scale. It also adds
label-based filtered vector search, combining similarity search with metadata filtering in a
single index. Written in Rust using the PGRX framework and developed by Tiger Data (formerly
Timescale).

## Scores

- **Openness: 5/open_source.** PostgreSQL License (OSI) — the same license pgvector already
  carries in this category. Public source, no gated core: Tiger Data's hosted Timescale Cloud
  service sits beside the extension rather than withholding any part of it.
- **Adoption: level 2 (stars_fallback).** 3,119 GitHub stars. The extension installs via Docker
  or from source rather than a package registry, and no distribution channel publishes a
  comparable download count, so the stars scale applies with its cap of 3.
- **Capability: 2, one band below `pgvector`.** pgvector is rung 3 on the storage category's
  feature matrix, a working single-purpose store or index. pgvectorscale ships only a faster
  index type and quantization scheme over columns pgvector already defines and stores, which is
  rung 2, a single index family shipped as a library with no storage of its own.

## Evidence

- https://raw.githubusercontent.com/timescale/pgvectorscale/main/LICENSE — the PostgreSQL
  License, structurally identical to the license pgvector records.
- https://api.github.com/repos/timescale/pgvectorscale — repo metadata: license spdx_id
  PostgreSQL, private false, archived false, stargazers_count 3,119.
- https://raw.githubusercontent.com/timescale/pgvectorscale/main/README.md — describes
  StreamingDiskANN indexing, statistical binary quantization and label-based filtered vector
  search shipped in one repository, installed via `CREATE EXTENSION vectorscale`, with a
  separate paid "private beta" Timescale Cloud signup offered alongside rather than gating any
  part of what is in the tree.
- https://github.com/pgvector/pgvector — the capability comparison peer: still documents
  nearest-neighbor search over vector types stored directly in Postgres tables with joins,
  transactions and point-in-time recovery, the single-purpose store-and-index surface
  pgvectorscale's own rung is measured one below.

## Review sheet

```
| category | stage | gaps | products | tier changes |
|---|---|---|---|---|
| storage | 4 | ['resiliency'] | +1 / -0 | none |

stage moves: none
untouched-product row changes: none
```

## Test plan

- [x] `build.validate` — 0 errors
- [x] `pytest -q -n auto -m "not serial"` — 1324 passed, 1 skipped
- [x] `build.serialize` + `build.check_corpus_diff` — single-category +1, no stage move, no
      untouched-product drift
