### PR TITLE
A tail registry row needs any addressable artifact, not GitHub

### DIFF
--- a/build/serialize_registry.py
+++ b/build/serialize_registry.py
@@ -283,8 +283,13 @@ def build_registry(sources: dict) -> tuple[dict[str, list[dict]], list[str], lis
                 {"product_slug": product_slug, "category_slug": slug}
             )
 
+    # Appended (crates, arxiv) rather than inserted, so existing per-kind ordering in any
+    # downstream diff or fixture is undisturbed -- #365 added these as tail row fields but
+    # they were still absent here, so a crates- or arxiv-only tail row validated and then
+    # silently produced no `tail_products` row at all.
     tail_artifact_kinds = (
-        "github", "pypi", "npm", "huggingface_model", "huggingface_dataset"
+        "github", "pypi", "npm", "huggingface_model", "huggingface_dataset",
+        "crates", "arxiv",
     )
     for category_slug, record in sorted(registry.items()):
         for product in record.get("products") or []:
@@ -300,8 +305,12 @@ def build_registry(sources: dict) -> tuple[dict[str, list[dict]], list[str], lis
                     url = f"https://www.npmjs.com/package/{identifier}"
                 elif kind == "huggingface_model":
                     url = f"https://huggingface.co/{identifier}"
-                else:
+                elif kind == "huggingface_dataset":
                     url = f"https://huggingface.co/datasets/{identifier}"
+                elif kind == "crates":
+                    url = f"https://crates.io/crates/{identifier}"
+                else:
+                    url = f"https://arxiv.org/abs/{identifier}"
                 tables["tail_products"].append(
                     {
                         "slug": product.get("slug", ""),

--- a/build/validate.py
+++ b/build/validate.py
@@ -79,9 +79,9 @@ _ARTIFACT_URL_PATTERNS = {
 def _canonicalize(kind: str, value: str) -> str:
     """Fold an artifact identifier to the form dedup compares on, per kind.
 
-    Matches the canonical forms in `plans/2026-09-03-identity-graph-design.md` §2: PyPI
-    folds separator runs per PEP 503, crates lowercases without folding (`-` and `_` are
-    distinct there), an arXiv id drops its version suffix, everything else casefolds.
+    Canonical forms: GitHub owner/repo lowercased with any .git suffix removed; PyPI names
+    normalized per PEP 503 (lowercase, runs of -, _ and . collapsed to -); arXiv ids
+    without the version suffix; crates and npm names lowercased; Hugging Face ids as given.
     """
     value = value.strip().lower()
     if kind == "github":

--- a/build/validate.py
+++ b/build/validate.py
@@ -46,6 +46,53 @@ OPENNESS_CLASSES = {
 # and imported above so this gate and serialize_routing cannot disagree about the set.
 LAYERS = {"product_ux", "model_components", "infrastructure"}
 
+# The artifact kinds a tail row can dedup on. `homepage` is deliberately excluded: it is
+# addressable (counts toward "at least one artifact") but carries no adoption signal and
+# is not treated as an identity-bearing artifact -- see the identity graph design doc §2.
+_TAIL_ARTIFACT_KINDS = (
+    "github",
+    "huggingface_model",
+    "huggingface_dataset",
+    "pypi",
+    "npm",
+    "crates",
+    "arxiv",
+)
+
+# Reduce a declared head-product artifact URL to the bare identifier a tail row would
+# store directly. Deliberately a local, small duplicate of build/serialize_registry.py's
+# `_ID_PATTERNS` rather than an import: that module imports `load_sources` from this one,
+# so importing it back here would be circular. `head_repos`'s own github regex predates
+# this and already diverged from serialize_registry's; kept as one family here instead of
+# two.
+_ARTIFACT_URL_PATTERNS = {
+    "github": re.compile(r"github\.com/([^/]+/[^/]+?)(?:\.git)?/?$", re.I),
+    "huggingface_model": re.compile(r"huggingface\.co/(?!datasets/)([^/]+/[^/]+?)/?$", re.I),
+    "huggingface_dataset": re.compile(r"huggingface\.co/datasets/([^/]+/[^/]+?)/?$", re.I),
+    "pypi": re.compile(r"pypi\.org/project/([^/]+)", re.I),
+    "npm": re.compile(r"npmjs\.com/package/([^/]+(?:/[^/]+)?)/?$", re.I),
+    "crates": re.compile(r"crates\.io/crates/([^/]+)", re.I),
+    "arxiv": re.compile(r"(?:arxiv\.org/(?:abs|pdf)/)?([a-z\-.]*\d{4}\.\d{4,5}|[a-z\-.]+/\d{7})", re.I),
+}
+
+
+def _canonicalize(kind: str, value: str) -> str:
+    """Fold an artifact identifier to the form dedup compares on, per kind.
+
+    Matches the canonical forms in `plans/2026-09-03-identity-graph-design.md` §2: PyPI
+    folds separator runs per PEP 503, crates lowercases without folding (`-` and `_` are
+    distinct there), an arXiv id drops its version suffix, everything else casefolds.
+    """
+    value = value.strip().lower()
+    if kind == "github":
+        return value.removesuffix(".git")
+    if kind == "pypi":
+        return re.sub(r"[-_.]+", "-", value)
+    if kind == "arxiv":
+        value = value.removeprefix("arxiv:")
+        return re.sub(r"v\d+$", "", value)
+    return value
+
 
 def load_sources(root: Path) -> dict:
     def _dir(name):
@@ -177,10 +224,17 @@ def validate_sources(data: dict) -> list[str]:
 
     # --- tail registry invariants ---
     # Tail rows are deliberately lighter than head product records, but identity is
-    # not: a slug and a GitHub artifact may appear in only one tier and category.
+    # not: a slug and an addressable artifact may appear in only one tier and category.
+    # #365 widened "addressable" past GitHub -- a candidate discovered on Hugging Face, a
+    # package registry, or in a paper is now storable too -- so dedup has to run per
+    # artifact kind rather than assuming `github` is the only one worth checking. A
+    # GitHub-only check let an HF-only or package-only candidate be added twice under two
+    # kinds with nothing noticing.
     tail_slugs: dict[str, str] = {}
-    tail_repos: dict[str, str] = {}
-    head_repos: dict[str, str] = {}
+    # Keyed (kind, canonical id) -> owning slug, shared across every registry file so a
+    # collision is caught regardless of which category first claimed the artifact.
+    tail_artifacts: dict[tuple[str, str], str] = {}
+    head_artifacts: dict[tuple[str, str], str] = {}
     # A retired slug is a settled decision, so it disqualifies a candidate exactly as a live
     # slug does: re-adding it re-opens the consolidation that retired it. Checking only
     # `slug in prods` missed that entirely -- amazon-nova-pro, an alias of amazon-nova, passed
@@ -194,11 +248,15 @@ def validate_sources(data: dict) -> list[str]:
         if isinstance(alias, str)
     }
     for slug, product in prods.items():
-        for artifact in product.get("github") or []:
-            if isinstance(artifact, dict) and isinstance(artifact.get("url"), str):
-                match = re.search(r"github\.com/([^/]+/[^/]+?)(?:\.git)?/?$", artifact["url"])
-                if match:
-                    head_repos[match.group(1).lower()] = slug
+        for kind in _TAIL_ARTIFACT_KINDS:
+            pattern = _ARTIFACT_URL_PATTERNS[kind]
+            for artifact in product.get(kind) or []:
+                if not (isinstance(artifact, dict) and isinstance(artifact.get("url"), str)):
+                    continue
+                match = pattern.search(artifact["url"].rstrip("/"))
+                if not match:
+                    continue
+                head_artifacts[(kind, _canonicalize(kind, match.group(1)))] = slug
     for cid, record in registry.items():
         if not isinstance(record, dict):
             errors.append(f"registry/{cid}.yaml: record must be a mapping")
@@ -214,8 +272,7 @@ def validate_sources(data: dict) -> list[str]:
             if not isinstance(row, dict):
                 continue
             slug = row.get("slug")
-            repo = row.get("github")
-            if not isinstance(slug, str) or not isinstance(repo, str):
+            if not isinstance(slug, str):
                 continue
             if slug in prods:
                 errors.append(f"registry/{cid}.yaml: tail slug {slug!r} already exists as a head product")
@@ -231,18 +288,31 @@ def validate_sources(data: dict) -> list[str]:
                     f"registry/{tail_slugs[slug]}.yaml"
                 )
             tail_slugs[slug] = cid
-            repo_key = repo.lower()
-            if repo_key in head_repos:
+
+            has_artifact = False
+            for kind in _TAIL_ARTIFACT_KINDS:
+                value = row.get(kind)
+                if not isinstance(value, str) or not value:
+                    continue
+                has_artifact = True
+                key = (kind, _canonicalize(kind, value))
+                if key in head_artifacts:
+                    errors.append(
+                        f"registry/{cid}.yaml: {kind} artifact {value!r} already belongs to "
+                        f"head product {head_artifacts[key]!r}"
+                    )
+                if key in tail_artifacts:
+                    errors.append(
+                        f"registry/{cid}.yaml: {kind} artifact {value!r} already belongs to "
+                        f"tail product {tail_artifacts[key]!r}"
+                    )
+                tail_artifacts[key] = slug
+            if not has_artifact and not row.get("homepage"):
                 errors.append(
-                    f"registry/{cid}.yaml: GitHub artifact {repo!r} already belongs to "
-                    f"head product {head_repos[repo_key]!r}"
+                    f"registry/{cid}.yaml: tail slug {slug!r} has no addressable artifact "
+                    "(one of github, huggingface_model, huggingface_dataset, pypi, npm, "
+                    "crates, arxiv, or homepage)"
                 )
-            if repo_key in tail_repos:
-                errors.append(
-                    f"registry/{cid}.yaml: GitHub artifact {repo!r} already belongs to "
-                    f"tail product {tail_repos[repo_key]!r}"
-                )
-            tail_repos[repo_key] = slug
 
     # --- roster <-> product invariants ---
     roster_count: dict[str, int] = {}

--- a/docs/schemas/registry.schema.json
+++ b/docs/schemas/registry.schema.json
@@ -15,7 +15,17 @@
       "description": "Signal-only tail products. They carry identity and addressable artifacts but no editorial scores, and are excluded from the public scored map until promoted.",
       "items": {
         "type": "object",
-        "required": ["slug", "display_name", "type", "org", "github"],
+        "required": ["slug", "display_name", "type", "org"],
+        "anyOf": [
+          {"required": ["github"]},
+          {"required": ["huggingface_model"]},
+          {"required": ["huggingface_dataset"]},
+          {"required": ["pypi"]},
+          {"required": ["npm"]},
+          {"required": ["crates"]},
+          {"required": ["arxiv"]},
+          {"required": ["homepage"]}
+        ],
         "additionalProperties": false,
         "properties": {
           "slug": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
@@ -25,6 +35,8 @@
           "github": {"type": "string", "pattern": "^[^/]+/[^/]+$"},
           "pypi": {"type": "string", "minLength": 1},
           "npm": {"type": "string", "minLength": 1},
+          "crates": {"type": "string", "minLength": 1},
+          "arxiv": {"type": "string", "minLength": 1},
           "huggingface_model": {"type": "string", "pattern": "^[^/]+/[^/]+$"},
           "huggingface_dataset": {"type": "string", "pattern": "^[^/]+/[^/]+$"},
           "homepage": {"type": "string", "format": "uri"}

--- a/docs/workflows/discover-candidates.md
+++ b/docs/workflows/discover-candidates.md
@@ -5,12 +5,15 @@
 A sweep of the outside world should turn into candidate rows the map can act on: new
 products from GitHub, Hugging Face, package registries, papers, or launch venues.
 
-**Sweep every source; emit only GitHub-backed candidates.** The tail registry requires a
-`github` identifier on every row, so a candidate whose only handle is a Hugging Face repo, a
-package name, a paper or a product page cannot be stored yet. Those are still worth
-surveying — a HF release is often how you find a repo — but one that resolves to no
-repository is parked in the batch summary, against issue #365, rather than emitted. Do not
-work around this by inventing a plausible repo for a candidate that has none.
+**Sweep every source; emit any candidate with at least one addressable artifact.** The tail
+registry requires one of `github`, `huggingface_model`, `huggingface_dataset`, `pypi`, `npm`,
+`crates`, `arxiv` or `homepage` on every row (#365) — not `github` specifically, so a candidate
+whose only handle is a Hugging Face repo, a package name, or a paper can now be stored. A
+candidate that resolves to none of these — no repo, no package, no Hub entry, no paper, no
+homepage — is still parked in the batch summary rather than emitted; do not work around that by
+inventing a plausible artifact for a candidate that has none. Hardware remains a case to think
+about: `homepage` satisfies the schema, but it carries no adoption signal, so treat a
+hardware-only candidate as weaker evidence than any other artifact kind.
 
 This is the step *before* the map changes. It decides what should exist. For a single
 product you already know about use `add-product`; to turn a seeded roster into researched
@@ -84,10 +87,11 @@ preliminary alike. Then load the existing corpus:
   `sources/slug_aliases.yaml`; the single alias mapping was deleted in #157 because two
   renames of the same retired slug silently kept whichever came last. Aliases now live on
   the record that replaced the slug, so the retired set is derived, not read from a file.
-- **existing registry slugs and artifacts** — the `slug` and `github` of every row already in
-  `sources/registry/*.yaml`. These are candidates a previous sweep already found; without this
-  set a repeated sweep rediscovers and re-triages them every time, only failing at final
-  `validate` if a slug or repository collides. Loading them here is what makes a sweep
+- **existing registry slugs and artifacts** — the `slug` and every declared artifact (`github`,
+  `huggingface_model`, `huggingface_dataset`, `pypi`, `npm`, `crates`, `arxiv`) of every row
+  already in `sources/registry/*.yaml`. These are candidates a previous sweep already found;
+  without this set a repeated sweep rediscovers and re-triages them every time, only failing at
+  final `validate` if a slug or artifact collides. Loading them here is what makes a sweep
   incremental rather than a full re-triage.
 
 A candidate matching any of these sets is already known and is not a new candidate.
@@ -105,11 +109,11 @@ candidate — see the emit contract below.
    `sources/products/*.yaml`. A retired slug means the thing was deliberately consolidated or
    dropped, and re-adding it re-opens a settled decision. `amazon-nova-pro` is the shape to
    watch for: a SKU that was folded into `amazon-nova` and reads like a new product.
-3. Against the existing registry rows loaded in step 1 — every `slug` and `github` already in
-   `sources/registry/*.yaml`. A match here is a candidate a previous sweep already emitted;
-   drop it and, if the earlier decision was to park it, do not re-triage it. This set is
-   deduped *before* the warehouse pool because a match here is a settled outcome, while a match
-   in the pool is only a signal.
+3. Against the existing registry rows loaded in step 1 — every `slug` and every declared
+   artifact already in `sources/registry/*.yaml`. A match here is a candidate a previous sweep
+   already emitted; drop it and, if the earlier decision was to park it, do not re-triage it.
+   This set is deduped *before* the warehouse pool because a match here is a settled outcome,
+   while a match in the pool is only a signal.
 4. Against the warehouse discovery pool, if reachable. This step is enrichment and
    consolidation, **not rejection**: use the pool to fold several signals into one entity,
    recover the canonical `owner/repo`, and fill in artifacts. A repository being present in the
@@ -133,9 +137,15 @@ a governance event, not a data event.
 ### 5. Emit rows, not prose
 
 Each accepted candidate becomes a row in `sources/registry/<category>.yaml` satisfying
-`docs/schemas/registry.schema.json`: `slug`, `display_name`, `type`, `org` and `github` are
-required, with `pypi`, `npm`, `huggingface_model`, `huggingface_dataset` and `homepage` where
-they apply. The row rejects any other key (`additionalProperties: false`).
+`docs/schemas/registry.schema.json`: `slug`, `display_name`, `type` and `org` are required, plus
+at least one of `github`, `huggingface_model`, `huggingface_dataset`, `pypi`, `npm`, `crates`,
+`arxiv` or `homepage` (#365) — not `github` specifically. Write every artifact you have evidence
+for, not just one; the row rejects any other key (`additionalProperties: false`).
+
+A paper alone is weaker evidence of a *product* than a repo, a package, or a Hub entry: an
+`arxiv`-only row is a legitimate candidate but carries no adoption signal and no code to
+inspect, so treat it as a lower-confidence emit and say so in the batch summary rather than
+promoting it with the same confidence as a repo-backed row.
 
 **When the category has no registry file yet, create it.** Only `compilers` and `storage` have
 registry files today, so a sweep over any other category is creating the file, not appending to
@@ -168,6 +178,8 @@ identifier, so a stored URL would serialize to `https://github.com/https://githu
 | `huggingface_dataset` | `owner/name` | `https://huggingface.co/datasets/owner/name` |
 | `pypi` | `package-name` | `https://pypi.org/project/package-name/` |
 | `npm` | `package-name` | `https://www.npmjs.com/package/package-name` |
+| `crates` | `crate-name` | `https://crates.io/crates/crate-name` |
+| `arxiv` | `2401.12345` | `https://arxiv.org/abs/2401.12345` |
 | `homepage` | a full URL | — the one field that *is* a URL |
 
 Head product records are the opposite convention — `sources/products/<slug>.yaml` stores typed
@@ -182,8 +194,8 @@ and keeps neither the identifiers nor the source URLs has produced nothing the r
 ### 6. Park what you did not accept, with its reason
 
 Anything surveyed and not accepted is recorded **in the batch summary** with the reason:
-already mapped, a retired alias, a new SKU of an existing product, superseded, unmaintained,
-no public artifact, GitHub-backed storage not yet available (#365), or a boundary rejection.
+already mapped, a retired alias, a new SKU of an existing product, superseded, unmaintained, no
+addressable artifact at all, or a boundary rejection.
 Record the source URL and fetch date for a parked candidate too, not only for an accepted one:
 the sweep earlier promised provenance for *every* raw signal, and a parked candidate with no
 source URL cannot be re-checked next week — it just comes back and is triaged again from
@@ -237,15 +249,17 @@ uv run pytest tests/ -q                  # full suite
 ```
 
 `build.validate` catches a malformed registry row (including a URL where an identifier
-belongs), a candidate assigned to a category that does not exist, a slug that collides with a
-live product, a retired alias or another registry file, and a GitHub artifact already claimed
-by a head or tail product.
+belongs, or a row with no addressable artifact at all), a candidate assigned to a category that
+does not exist, a slug that collides with a live product, a retired alias or another registry
+file, and any of `github`, `huggingface_model`, `huggingface_dataset`, `pypi`, `npm`, `crates`
+or `arxiv` already claimed by a head or tail product — dedup runs per artifact kind, so a
+package-only or HF-only candidate is checked exactly as a GitHub-backed one is (#365).
 
-Two limits worth knowing, so the gate is not trusted past its reach. Artifact-level dedup is
-keyed on `github` only: two rows carrying the same `pypi` or `huggingface_model` and different
-repos both pass, so the self-dedup in step 3 is yours to get right (#365). And validation
-cannot tell a genuinely new product from one you failed to recognize — it checks identity
-collisions, not judgment.
+One limit worth knowing, so the gate is not trusted past its reach: validation cannot tell a
+genuinely new product from one you failed to recognize — it checks identity collisions, not
+judgment. `homepage` is not part of that dedup — it is addressable (satisfies the "at least one
+artifact" rule) but carries no identity-bearing signal, so two rows sharing a homepage still
+pass; catching that is on the self-dedup in step 3.
 
 ## Expected PR contents
 

--- a/skills/discover-candidates/SKILL.md
+++ b/skills/discover-candidates/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: discover-candidates
-description: Use when sweeping the outside world for products the map does not yet have — GitHub, Hugging Face, package registries, papers, launch venues — and turning the result into candidate rows in sources/registry/. Every source is swept, but only GitHub-backed candidates can be emitted today. This is the step before the map changes. For one product you already know about use add-product; to turn a seeded roster into published products use promote-category; to re-verify what is published use refresh-category.
+description: Use when sweeping the outside world for products the map does not yet have — GitHub, Hugging Face, package registries, papers, launch venues — and turning the result into candidate rows in sources/registry/. Every source is swept, and any candidate with at least one addressable artifact (github, huggingface, a package, arxiv, or homepage) can be emitted. This is the step before the map changes. For one product you already know about use add-product; to turn a seeded roster into published products use promote-category; to re-verify what is published use refresh-category.
 ---
 
 # Discover candidates for the map
@@ -34,13 +34,16 @@ sweep that had to be thrown away.
    candidate belonging to a category added since — and parsing `sources/taxonomy.yaml` by hand
    drops the `{name, status}` entries, which is the failure that broke `build_stack_map`.
 2. **Artifacts are identifiers, not URLs.** `github: owner/repo`, not
-   `https://github.com/owner/repo`; same for `huggingface_*`, and bare package names for
-   `pypi` / `npm`. `homepage` is the only URL on the row. Serialization builds the public URL
-   *from* the identifier, so a URL there serializes to a doubled link. Source URLs and fetch
-   dates go in the batch summary, not on the row.
-3. **Only GitHub-backed candidates can be emitted.** `github` is required on every row, so an
-   HF-only, package-only, paper-only or hardware candidate is parked in the summary against
-   issue #365. Never invent a repo to satisfy the schema.
+   `https://github.com/owner/repo`; same for `huggingface_*`, `crates`, `arxiv`, and bare
+   package names for `pypi` / `npm`. `homepage` is the only URL on the row. Serialization builds
+   the public URL *from* the identifier, so a URL there serializes to a doubled link. Source
+   URLs and fetch dates go in the batch summary, not on the row.
+3. **A row needs at least one addressable artifact, not `github` specifically (#365).** Any of
+   `github`, `huggingface_model`, `huggingface_dataset`, `pypi`, `npm`, `crates`, `arxiv` or
+   `homepage` satisfies the schema, so an HF-only or package-only candidate can now be emitted.
+   A candidate with none of these is still parked in the summary. Never invent an artifact to
+   satisfy the schema, and treat an arxiv-only or homepage-only row as weaker evidence than a
+   repo- or package-backed one.
 4. **Do not invent a legitimacy rule mid-sweep.** Park the candidate and say why in the
    summary. A threshold that exists only in one run's output cannot be reproduced or appealed.
 5. **A 429 is not a measured absence.** Retry or leave the field out; never record

--- a/tests/test_serialize_registry.py
+++ b/tests/test_serialize_registry.py
@@ -210,6 +210,50 @@ def test_tail_products_serialize_without_becoming_head_products():
     assert tables["categories"][0]["status"] == "preliminary"
 
 
+def test_tail_row_with_only_crates_serializes_with_the_crate_id():
+    """#365 let a crates-only tail row validate; it must not then vanish from tail_products."""
+    sources = _sources(
+        categories={"storage": {"display_name": "Storage", "weights": {}, "products": []}},
+        taxonomy={
+            "arcs": [
+                {
+                    "name": "Infrastructure",
+                    "layer": "infrastructure",
+                    "categories": [{"name": "storage", "status": "preliminary"}],
+                }
+            ]
+        },
+    )
+    sources["registry"] = {
+        "storage": {
+            "category": "storage",
+            "products": [
+                {
+                    "slug": "some-crate",
+                    "display_name": "Some Crate",
+                    "type": "software",
+                    "org": "acme",
+                    "crates": "some-crate",
+                }
+            ],
+        }
+    }
+    tables, errors, _ = build_registry(sources)
+    assert errors == []
+    assert tables["tail_products"] == [
+        {
+            "slug": "some-crate",
+            "display_name": "Some Crate",
+            "product_type": "software",
+            "org_slug": "acme",
+            "category_slug": "storage",
+            "artifact_kind": "crates",
+            "artifact_id": "some-crate",
+            "artifact_url": "https://crates.io/crates/some-crate",
+        }
+    ]
+
+
 def test_real_sources_serialize_without_structural_errors():
     from pathlib import Path
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -254,6 +254,113 @@ def test_a_tail_slug_that_is_no_alias_passes():
     assert not any("retired alias" in e for e in validate_sources(d))
 
 
+def test_tail_row_with_only_huggingface_validates():
+    """#365: a row needs at least one addressable artifact, not `github` specifically."""
+    d = _fixture()
+    d["registry"] = {
+        "base_pretrained": {
+            "category": "base_pretrained",
+            "products": [
+                {
+                    "slug": "some-hf-thing",
+                    "display_name": "Some HF Thing",
+                    "type": "model",
+                    "org": "meta",
+                    "huggingface_model": "acme/some-hf-thing",
+                }
+            ],
+        }
+    }
+    assert validate_sources(d) == []
+
+
+def test_tail_row_with_only_arxiv_validates():
+    d = _fixture()
+    d["registry"] = {
+        "base_pretrained": {
+            "category": "base_pretrained",
+            "products": [
+                {
+                    "slug": "some-paper-thing",
+                    "display_name": "Some Paper Thing",
+                    "type": "software",
+                    "org": "meta",
+                    "arxiv": "2401.12345",
+                }
+            ],
+        }
+    }
+    assert validate_sources(d) == []
+
+
+def test_tail_row_with_no_artifact_fails_with_a_clear_message():
+    d = _fixture()
+    d["registry"] = {
+        "storage": {
+            "category": "storage",
+            "products": [
+                {
+                    "slug": "no-artifact-thing",
+                    "display_name": "No Artifact Thing",
+                    "type": "software",
+                    "org": "meta",
+                }
+            ],
+        }
+    }
+    errs = validate_sources(d)
+    assert any("no addressable artifact" in e for e in errs), errs
+
+
+def test_tail_rows_sharing_a_normalized_pypi_name_fail():
+    """PEP 503: runs of -, _, . fold to -, and comparison is case-insensitive."""
+    d = _fixture()
+    d["registry"] = {
+        "storage": {
+            "category": "storage",
+            "products": [
+                {
+                    "slug": "pkg-one",
+                    "display_name": "Pkg One",
+                    "type": "software",
+                    "org": "meta",
+                    "pypi": "My-Cool_Package",
+                },
+                {
+                    "slug": "pkg-two",
+                    "display_name": "Pkg Two",
+                    "type": "software",
+                    "org": "meta",
+                    "pypi": "my.cool.package",
+                },
+            ],
+        }
+    }
+    errs = validate_sources(d)
+    assert any("pypi artifact" in e and "already belongs to tail product 'pkg-one'" in e for e in errs), errs
+
+
+def test_tail_row_github_matching_head_product_fails_case_insensitively():
+    """Existing behavior, extended: the tail/head collision check must not care about case."""
+    d = _fixture()
+    d["registry"] = {
+        "storage": {
+            "category": "storage",
+            "products": [
+                {
+                    "slug": "duplicate-of-llama",
+                    "display_name": "Duplicate",
+                    "type": "software",
+                    "org": "meta",
+                    "github": "Meta-Llama/LLAMA",
+                }
+            ],
+        }
+    }
+    errs = validate_sources(d)
+    assert any("already belongs to head product" in e for e in errs), errs
+
+
 def test_roster_pointing_at_missing_product_fails():
     d = _fixture()
     d["categories"]["base_pretrained"]["products"].append("does-not-exist")


### PR DESCRIPTION
## Summary

- `docs/schemas/registry.schema.json`: tail rows no longer require `github`. `required` drops to `slug`, `display_name`, `type`, `org`, and an `anyOf` requires at least one of `github`, `huggingface_model`, `huggingface_dataset`, `pypi`, `npm`, `crates`, `arxiv`, or `homepage`. Added `crates` and `arxiv` as row fields (`additionalProperties: false` kept).
- `build/validate.py`: artifact-level dedup, previously keyed on `github` only (`tail_repos` / `head_repos`), now runs per artifact kind (`github`, `huggingface_model`, `huggingface_dataset`, `pypi`, `npm`, `crates`, `arxiv`) across both the tail registry and head products' declared artifacts. Canonicalization follows the identity graph design doc: PEP 503 folding for pypi, lowercase-only (no separator folding) for crates, version-suffix stripping for arxiv, casefold for github/huggingface/npm. A row with no addressable artifact at all now fails validate with a clear message, ahead of the schema check.
- `docs/workflows/discover-candidates.md` and `skills/discover-candidates/SKILL.md`: replaced every "only GitHub-backed candidates can be emitted" statement with the new rule, and updated the dedup-limits note, the artifact-identifier table, and the parking reasons to match.

## What stays for the identity-graph ruling

Per the identity graph design doc (`plans/2026-09-03-identity-graph-design.md` §4), this PR deliberately does **not** add `identity_confidence` or `identity_method` to the schema. Those wait on review of that design.

Hardware also stays a decision rather than a schema edit, per issue #365's third sub-problem: `type: hardware` with only `homepage` satisfies the new `anyOf` (homepage is addressable) but is not treated as identity-bearing for dedup purposes, and nothing here proposes a machine-readable artifact for hardware.

## Test plan

- [x] `uv run python -m build.validate` on the real corpus — `0 error(s)`
- [x] `uv run python -m build.serialize_registry --check` — unchanged output (39 tail_products rows, same 2 pre-existing warnings)
- [x] `uv run pytest -q -n auto -m "not serial"` — 1319 passed
- [x] New cases in `tests/test_validate.py`: a row with only `huggingface_model` validates; a row with only `arxiv` validates; a row with no artifact fails with a clear message; two rows sharing a PEP-503-normalized `pypi` name fail; a tail `github` matching a head product's repo fails case-insensitively

Refs #365