### PR TITLE
The resolution ledger records rulings about any artifact and any relation

### DIFF
--- a/build/declaration_version.py
+++ b/build/declaration_version.py
@@ -174,11 +174,14 @@ POLICY_INPUTS: dict[str, dict[str, object]] = {
 NON_DECLARATION_INPUTS: dict[str, str] = {
     "resolution_ledger.yaml": (
         "governance over what MAY become a product, not a declaration of what is one. An entry "
-        "records that a candidate repository was already resolved - to an existing product, to a "
-        "SKU, or out of scope - and changes no product's identity, artifacts or score. Binding it "
-        "into the declaration digest would re-key every declaration_version_id corpus-wide "
-        "whenever somebody wrote down a boundary decision, which is a cost the cutover plan "
-        "reserves for changes that actually move a declaration."
+        "records that a candidate artifact was already resolved - to an existing product, to a "
+        "SKU, or out of scope - and changes no product's identity, artifacts or score. A "
+        "product_membership ruling (member_of / not_member_of) changes which measurement gets "
+        "read for adoption, not what the product declares, so it is equally a non-declaration "
+        "input. Binding either kind into the declaration digest would re-key every "
+        "declaration_version_id corpus-wide whenever somebody wrote down a boundary or "
+        "membership decision, which is a cost the cutover plan reserves for changes that "
+        "actually move a declaration."
     ),
     "snapshots": (
         "frozen point-in-time warehouse sample (long_tail.json), hand-synced; a re-sync is "

--- a/build/resolution.py
+++ b/build/resolution.py
@@ -1,13 +1,20 @@
-"""The resolution ledger: decisions about candidate repositories a person already made.
+"""Resolution ledger: the map's durable memory of identity rulings.
 
 See `sources/resolution_ledger.yaml` for why it exists. In short: a discovery sweep resolves a
-repository by hand and records the reasoning in a pull request, which no later run can read. The
-first corpus expansion duly recreated four repositories that #413 had already resolved - one of
-them a product the corpus carries under another name.
+candidate artifact by hand - "this is the spec repo of a product we already carry", "this PyPI
+package's downloads are not this product's usage" - and records the reasoning in a pull request,
+which no later run can read. The first corpus expansion duly recreated four repositories that
+#413 had already resolved - one of them a product the corpus carries under another name.
+
+Keyed on (artifact kind, canonical id). Every verdict is typed by relation, and a ruling
+suppresses only questions of its own relation: a `not_member_of` on a PyPI package never
+suppresses a later equivalence question about the same package. Entries written before 2026-09
+carry no relation and are read as `product_equivalence`, which is the only question they ever
+answered. The file is never rewritten by code; it only grows (#437).
 
 This module is the reader. `build/validate.py` enforces the half that can be enforced
-mechanically, and a bulk pipeline is expected to consult `verdict_for` before proposing a
-product from a repository.
+mechanically, and a bulk pipeline is expected to consult `verdict_for` (or one of the three
+narrower predicates below) before proposing a product from a candidate artifact.
 """
 from __future__ import annotations
 
@@ -19,71 +26,130 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 LEDGER = ROOT / "sources" / "resolution_ledger.yaml"
 
-#: A repository resolved to one of these is not a new product.
+RELATIONS = ("product_equivalence", "product_membership")
+
+#: An artifact resolved to one of these is not a new product.
 NOT_A_NEW_PRODUCT = frozenset({"existing_product", "sku_of", "excluded_boundary",
                                "excluded_maintenance"})
 #: `unresolved` is deliberately not in that set: it means a person has to look, and a rerun
 #: proposing it again is the correct behaviour, not a regression.
-VERDICTS = NOT_A_NEW_PRODUCT | {"unresolved"}
+EQUIVALENCE_VERDICTS = NOT_A_NEW_PRODUCT | {"unresolved"}
+#: The two verdicts a `product_membership` ruling can carry.
+MEMBERSHIP_VERDICTS = frozenset({"member_of", "not_member_of"})
+VERDICTS = EQUIVALENCE_VERDICTS | MEMBERSHIP_VERDICTS
+
+Key = tuple[str, str]
 
 
 class DuplicateResolution(ValueError):
-    """Two entries resolve the same repository. For governance state that is never benign."""
+    """Two entries answer the same (artifact, relation) question. Never benign for governance state."""
 
 
-def load(path: Path = LEDGER) -> dict[str, dict]:
-    """Ledger keyed by lowercased `owner/repo`.
+def _canonical(kind: str, ident: str) -> str:
+    """Fold an artifact identifier to the form the ledger keys on, per kind.
 
-    A duplicate repository raises rather than resolving last-write-wins. The dict comprehension
-    this replaced would silently keep whichever entry came last, so `Foo/Bar: existing_product`
-    followed by `foo/bar: unresolved` would quietly discard the stronger decision - and the file
-    is hand-edited by people appending after each review, which is exactly how that happens.
-    `docs/reference/identity.md` records the same failure in the deleted slug-alias mapping:
-    two renames of one retired slug, and whichever came last won.
+    Task 2 replaces this body with `from build.identity import canonical`. Only `github` is
+    canonicalized today (lowercase, `.git` stripped); every other kind is compared as given
+    until that lands, so a differently-cased PyPI or npm name will not yet match. Kept as one
+    private function so that swap is a one-line change.
+    """
+    ident = (ident or "").strip()
+    if kind == "github":
+        return ident.removesuffix(".git").lower()
+    return ident
+
+
+def key_for(entry: Mapping) -> Key:
+    """The (kind, canonical id) an entry is about, whether written as `repo` or `artifact`."""
+    if "artifact" in entry:
+        return (entry["artifact"]["kind"], _canonical(entry["artifact"]["kind"], entry["artifact"]["id"]))
+    return ("github", _canonical("github", entry.get("repo", "")))
+
+
+def relation_of(entry: Mapping) -> str:
+    """The question an entry answers. Absent means `product_equivalence` - every entry written
+    before 2026-09 answered that question and none named a relation."""
+    return entry.get("relation") or "product_equivalence"
+
+
+def load(path: Path = LEDGER) -> dict[tuple[Key, str], dict]:
+    """Ledger keyed by `((kind, canonical id), relation)`.
+
+    A duplicate (artifact, relation) pair raises rather than resolving last-write-wins. The dict
+    comprehension this replaced would silently keep whichever entry came last, so
+    `Foo/Bar: existing_product` followed by `foo/bar: unresolved` would quietly discard the
+    stronger decision - and the file is hand-edited by people appending after each review, which
+    is exactly how that happens. `docs/reference/identity.md` records the same failure in the
+    deleted slug-alias mapping: two renames of one retired slug, and whichever came last won.
+
+    The same artifact may carry both an equivalence ruling and a membership ruling - a package
+    can simultaneously not be a new product on its own AND be ruled in or out of another
+    product's measurement - so uniqueness is enforced per relation, not per artifact.
     """
     if not path.exists():
         return {}
     doc = yaml.safe_load(path.read_text()) or {}
-    entries: dict[str, dict] = {}
+    out: dict[tuple[Key, str], dict] = {}
     for entry in (doc.get("resolutions") or []):
-        key = (entry.get("repo") or "").strip().removesuffix(".git").lower()
-        if key in entries:
+        k = key_for(entry)
+        relation = relation_of(entry)
+        composite = (k, relation)
+        if composite in out:
+            prior = out[composite]
             raise DuplicateResolution(
-                f"{path.name}: {entry.get('repo')!r} is resolved twice - already "
-                f"{entries[key]['verdict']!r} from {entries[key].get('decided_in')}, now "
+                f"{path.name}: {k} is resolved twice for {relation!r} - already "
+                f"{prior['verdict']!r} from {prior.get('decided_in')}, now "
                 f"{entry.get('verdict')!r} from {entry.get('decided_in')}. Identity is compared "
-                f"lowercased and without a .git suffix, so these are one repository. Merge them."
+                f"canonicalized, so these are one artifact. Merge them."
             )
-        entries[key] = entry
-    return entries
+        out[composite] = entry
+    return out
 
 
-def verdict_for(repo: str, ledger: Mapping[str, dict] | None = None) -> dict | None:
-    """The recorded decision for a repository, or None if it has never been resolved."""
-    return (load() if ledger is None else ledger).get((repo or "").lower())
+def verdict_for(kind: str, ident: str, relation: str, ledger: Mapping | None = None) -> dict | None:
+    """The recorded ruling for an artifact and relation, or None if never resolved.
 
-
-def blocks_new_product(repo: str, ledger: Mapping[str, dict] | None = None) -> dict | None:
-    """The entry that PERMANENTLY forbids minting a product from this repository, if any.
-
-    This is what `build/validate.py` enforces, and it deliberately excludes `unresolved`: a
-    person may still add such a product by hand once they have settled the question, and the
-    build should not stop them.
+    `verdict_for("github", repo, "product_equivalence")` behaves exactly as the old single-arg
+    `verdict_for(repo)` did for repo entries: `_canonical` strips `.git` and lowercases here just
+    as `load` does when building the keys, so a differently-cased or `.git`-suffixed lookup still
+    matches.
     """
-    entry = verdict_for(repo, ledger)
-    return entry if entry and entry.get("verdict") in NOT_A_NEW_PRODUCT else None
+    ledger = load() if ledger is None else ledger
+    return ledger.get(((kind, _canonical(kind, ident)), relation))
 
 
-def holds_bulk_promotion(repo: str, ledger: Mapping[str, dict] | None = None) -> dict | None:
-    """The entry that stops a BULK run from promoting this repository, if any.
+def blocks_new_product(kind: str, ident: str, ledger: Mapping | None = None) -> dict | None:
+    """The entry that PERMANENTLY forbids minting a product from this artifact, if any.
 
-    Any entry at all, `unresolved` included. "Not permanently excluded" and "this proposal may
-    proceed" are different questions, and conflating them published a bug: the #418 review
-    recorded `ag-ui` as a protocol filed under agent frameworks, `serena` as an MCP retrieval
-    toolkit and `repomix` as document ingestion - and then the same run published all three in
-    `orchestration_agents`, the category the entry says is wrong.
+    Relation `product_equivalence` only. This is what `build/validate.py` enforces, and it
+    deliberately excludes `unresolved`: a person may still add such a product by hand once they
+    have settled the question, and the build should not stop them.
+    """
+    entry = verdict_for(kind, ident, "product_equivalence", ledger)
+    return entry if entry and entry["verdict"] in NOT_A_NEW_PRODUCT else None
 
-    `unresolved` means the repository may come back to a LATER sweep, not that the CURRENT
+
+def holds_bulk_promotion(kind: str, ident: str, ledger: Mapping | None = None) -> dict | None:
+    """The entry that stops a BULK run from promoting this artifact, if any.
+
+    Relation `product_equivalence`, any verdict - `unresolved` included. "Not permanently
+    excluded" and "this proposal may proceed" are different questions, and conflating them
+    published a bug: the #418 review recorded `ag-ui` as a protocol filed under agent frameworks,
+    `serena` as an MCP retrieval toolkit and `repomix` as document ingestion - and then the same
+    run published all three in `orchestration_agents`, the category the entry says is wrong.
+
+    `unresolved` means the artifact may come back to a LATER sweep, not that the CURRENT
     proposal is fit to publish. A bulk run parks it for a person; a person resolves it.
     """
-    return verdict_for(repo, ledger)
+    return verdict_for(kind, ident, "product_equivalence", ledger)
+
+
+def membership_ruling(kind: str, ident: str, product_slug: str, ledger: Mapping | None = None) -> dict | None:
+    """The `product_membership` ruling for this artifact against `product_slug`, if any.
+
+    Only returns an entry whose `resolves_to` matches `product_slug`: a `member_of` or
+    `not_member_of` ruling is a statement about ONE product's measurement, not a global fact
+    about the artifact, so a lookup against a different product must not see it.
+    """
+    entry = verdict_for(kind, ident, "product_membership", ledger)
+    return entry if entry and entry.get("resolves_to") == product_slug else None

--- a/build/validate.py
+++ b/build/validate.py
@@ -190,36 +190,59 @@ def validate_sources(data: dict) -> list[str]:
                 errors.append(f"category {cid!r}: published category needs at least 10 scored products")
 
     # --- resolution ledger ---
-    # A repository a person already resolved may not come back as a new product. The ledger
+    # An artifact a person already resolved may not come back as a new product. The ledger
     # exists because a decision recorded only in a pull request is invisible to the next bulk
     # run: the first corpus expansion recreated `a2aproject/A2A` as a product called `a2a`
     # though #413 had resolved it to `agent2agent-protocol`, and eleven more besides. Prose is
     # not an input; this file is.
     #
     # `unresolved` is deliberately not enforced. It means a person still has to look, so a
-    # later run proposing the repository again is the intended behaviour rather than a
+    # later run proposing the artifact again is the intended behaviour rather than a
     # regression, and failing the build on it would just delete the distinction.
-    from build.resolution import NOT_A_NEW_PRODUCT, load as load_ledger
+    #
+    # Widened from `github` only to every declared artifact kind (#437 follow-on): a candidate
+    # dismissed on PyPI or Hugging Face alone used to have no way to stay dismissed. Every kind
+    # is folded through the same `_canonical` shim `build/resolution.py` uses, which today only
+    # canonicalizes `github` (lowercase, `.git` stripped) - Task 2 replaces that shim's body to
+    # canonicalize the rest, so a differently-cased PyPI or npm name will not yet match here.
+    from build.resolution import MEMBERSHIP_VERDICTS, NOT_A_NEW_PRODUCT, _canonical, load as load_ledger
 
     ledger = load_ledger()
     for slug, product in sorted((data.get("products") or {}).items()):
-        for artifact in (product.get("github") or []):
-            url = (artifact.get("url") or "").rstrip("/")
-            if "github.com/" not in url:
-                continue
-            repo = url.split("github.com/")[-1].removesuffix(".git").lower()
-            entry = ledger.get(repo)
-            if not entry or entry.get("verdict") not in NOT_A_NEW_PRODUCT:
-                continue
-            if entry.get("product") == slug:
-                continue
-            resolved_to = entry.get("product") or entry.get("boundary") or "out of scope"
+        for kind in _TAIL_ARTIFACT_KINDS:
+            pattern = _ARTIFACT_URL_PATTERNS[kind]
+            for artifact in (product.get(kind) or []):
+                if not (isinstance(artifact, dict) and isinstance(artifact.get("url"), str)):
+                    continue
+                match = pattern.search(artifact["url"].rstrip("/"))
+                if not match:
+                    continue
+                ident = _canonical(kind, match.group(1))
+                entry = ledger.get(((kind, ident), "product_equivalence"))
+                if not entry or entry.get("verdict") not in NOT_A_NEW_PRODUCT:
+                    continue
+                resolved_to = entry.get("product") or entry.get("resolves_to")
+                if resolved_to == slug:
+                    continue
+                resolved_to = resolved_to or entry.get("boundary") or "out of scope"
+                errors.append(
+                    f"products/{slug}.yaml: declares {kind} {ident!r}, which the resolution "
+                    f"ledger resolves as {entry['verdict']} -> {resolved_to} "
+                    f"(decided in {entry.get('decided_in', 'an earlier sweep')}). Either the "
+                    f"ledger entry is wrong and a person should change it, or this product "
+                    f"should not exist."
+                )
+
+    # A `member_of`/`not_member_of` verdict answers a `product_membership` question; recording
+    # one under any other relation would make `verdict_for` read it as an equivalence ruling it
+    # never made.
+    for (key, relation), entry in ledger.items():
+        if entry.get("verdict") in MEMBERSHIP_VERDICTS and relation != "product_membership":
+            kind, ident = key
             errors.append(
-                f"products/{slug}.yaml: declares {repo!r}, which the resolution ledger "
-                f"resolves as {entry['verdict']} -> {resolved_to} "
-                f"(decided in {entry.get('decided_in', 'an earlier sweep')}). Either the "
-                f"ledger entry is wrong and a person should change it, or this product "
-                f"should not exist."
+                f"resolution ledger: {kind} {ident!r} carries verdict {entry['verdict']!r} but "
+                f"relation {relation!r}; member_of/not_member_of require relation: "
+                "product_membership"
             )
 
     # --- tail registry invariants ---
@@ -559,6 +582,22 @@ def validate_sources(data: dict) -> list[str]:
             jsonschema.validate(record, registry_schema)
         except jsonschema.ValidationError as e:
             errors.append(f"registry/{cid}: schema: {e.message}")
+
+    # `sources/resolution_ledger.yaml` is one file rather than a directory, loaded straight
+    # from disk here rather than through `load_ledger` above, so a malformed entry is reported
+    # by slot in the file rather than silently swallowed by `load`'s duplicate-key check.
+    from build.resolution import LEDGER
+
+    ledger_schema = json.loads(
+        (Path(__file__).resolve().parents[1] / "docs" / "schemas" / "resolution_ledger.schema.json").read_text()
+    )
+    ledger_doc = yaml.safe_load(LEDGER.read_text()) or {}
+    for i, entry in enumerate(ledger_doc.get("resolutions") or []):
+        try:
+            jsonschema.validate(entry, ledger_schema)
+        except jsonschema.ValidationError as e:
+            label = entry.get("repo") or (entry.get("artifact") or {}).get("id") or f"entry {i}"
+            errors.append(f"resolution_ledger.yaml: {label}: schema: {e.message}")
 
     return errors
 

--- a/docs/reference/identity.md
+++ b/docs/reference/identity.md
@@ -182,6 +182,26 @@ package whose backlink is missing, a licence that disagrees between two artifact
 product, a download count wildly out of step with a star count — and never for declaring the
 artifact. An identity edge stays provisional until a person has read it.
 
+### Rulings are typed by relation
+
+The resolution ledger (`sources/resolution_ledger.yaml`) is not only about GitHub repositories,
+and not only about whether a candidate is a new product. Every entry names an artifact - `repo`,
+or `artifact: {kind, id}` for a Hugging Face model or dataset, a PyPI, npm or crates package, an
+arXiv paper, or a homepage - and answers one typed question, its `relation`:
+
+- **`product_equivalence`** - is this artifact a new product, or does it already belong to one?
+  Verdicts: `existing_product`, `sku_of`, `excluded_boundary`, `excluded_maintenance`,
+  `unresolved`. Every entry written before 2026-09 answered this question, and `relation` may be
+  omitted for it - absent reads as `product_equivalence`.
+- **`product_membership`** - does this artifact's measurement belong to `resolves_to`'s adoption
+  number? Verdicts: `member_of`, `not_member_of`. A `resolves_to` is required.
+
+A ruling answers only its own relation. `not_member_of` on `elasticsearch-py`'s PyPI package
+says its downloads are not `elasticsearch`'s adoption - it says nothing about whether
+`elasticsearch-py` is itself a new product, which is a separate question a person may still have
+to rule on. The schema at `docs/schemas/resolution_ledger.schema.json` is normative for the
+shape; `build/resolution.py` is the reader.
+
 ## Organizations
 
 Organizations carry aliases for the same reason and under the same rule. Two exist, both

--- a/docs/schemas/resolution_ledger.schema.json
+++ b/docs/schemas/resolution_ledger.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Resolution ledger entry",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "repo": {"type": "string", "description": "GitHub owner/repo. Legacy key; equivalent to artifact: {kind: github, id: <repo>}. One of repo or artifact is required."},
+    "artifact": {
+      "type": "object", "additionalProperties": false,
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {"enum": ["github", "huggingface_model", "huggingface_dataset", "pypi", "npm", "crates", "arxiv", "homepage"]},
+        "id": {"type": "string", "minLength": 1}
+      },
+      "description": "The artifact this ruling is about, in canonical form. Lets a package-only or HF-only dismissal persist, so it does not return every sweep."
+    },
+    "verdict": {"enum": ["existing_product", "sku_of", "excluded_boundary", "excluded_maintenance", "unresolved", "member_of", "not_member_of"]},
+    "relation": {"enum": ["product_equivalence", "product_membership"], "description": "Which question this ruling answers. Absent means product_equivalence (every entry before 2026-09 answered that question). A ruling suppresses only questions of its own relation."},
+    "product": {"type": "string", "description": "Legacy name for resolves_to on existing_product and sku_of entries."},
+    "resolves_to": {"type": "string", "description": "The product slug this artifact belongs to (member_of) or does not (not_member_of), or resolves to (existing_product, sku_of)."},
+    "boundary": {"type": "string"},
+    "decided_in": {"type": "string"},
+    "decided_on": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$"},
+    "note": {"type": "string", "minLength": 20}
+  },
+  "required": ["verdict", "decided_in", "decided_on", "note"],
+  "oneOf": [{"required": ["repo"]}, {"required": ["artifact"]}],
+  "allOf": [
+    {"if": {"properties": {"verdict": {"enum": ["member_of", "not_member_of"]}}}, "then": {"required": ["relation", "resolves_to"], "properties": {"relation": {"const": "product_membership"}}}},
+    {"if": {"properties": {"verdict": {"enum": ["existing_product", "sku_of"]}}}, "then": {"anyOf": [{"required": ["product"]}, {"required": ["resolves_to"]}]}}
+  ]
+}

--- a/docs/workflows/discover-candidates.md
+++ b/docs/workflows/discover-candidates.md
@@ -120,7 +120,14 @@ candidate — see the emit contract below.
    pool does not disqualify it — the pool *is* the long-tail set this workflow harvests from.
    Only rule a candidate out here when the pool resolves it to a slug or repository already
    caught by dedup sets 1–3.
-5. Against itself: the same tool arriving from GitHub, PyPI and Hugging Face is one
+5. Against the resolution ledger (`sources/resolution_ledger.yaml`) - a candidate any relation
+   has already ruled on is not new. A `product_equivalence` ruling in `NOT_A_NEW_PRODUCT`
+   (`existing_product`, `sku_of`, `excluded_boundary`, `excluded_maintenance`) drops the
+   candidate outright; `unresolved` holds it for a person rather than proposing it again. A
+   `product_membership` ruling (`member_of`, `not_member_of`) is a separate question about
+   measurement, not identity, and does not by itself dedup a candidate. See
+   `docs/reference/identity.md#rulings-are-typed-by-relation`.
+6. Against itself: the same tool arriving from GitHub, PyPI and Hugging Face is one
    candidate, not three.
 
 Entity resolution is the part that goes wrong. Where two signals might be the same product

--- a/sources/resolution_ledger.yaml
+++ b/sources/resolution_ledger.yaml
@@ -23,10 +23,22 @@
 #   excluded_boundary     out of scope for the map, with the boundary named
 #   excluded_maintenance  archived, or unmaintained past the sweep's declared window
 #   unresolved            identity genuinely undecided; needs a person, not a rerun
+#   member_of             this artifact's measurement belongs to `resolves_to` (relation: product_membership)
+#   not_member_of         this artifact's measurement does NOT belong to `resolves_to`, though it
+#                          may look related (relation: product_membership)
+#
+# ARTIFACT and RELATION. An entry names what it is about with either `repo` (legacy shorthand
+# for a GitHub identity) or `artifact: {kind, id}`, which also covers huggingface_model,
+# huggingface_dataset, pypi, npm, crates, arxiv and homepage. `relation` says which question the
+# entry answers: `product_equivalence` ("is this a new product, or does it already belong to
+# one?" - the only question every entry before 2026-09 answered, and the default when `relation`
+# is absent) or `product_membership` ("does this artifact's usage count toward `resolves_to`'s
+# adoption measurement?"). A ruling suppresses only questions of its own relation - a
+# not_member_of on a package never answers a later equivalence question about the same package.
 #
 # A bulk run must consult this file before proposing a product and must never silently
 # overturn an entry. build/validate.py enforces the half that can be enforced: no product may
-# declare a repository this file resolves elsewhere.
+# declare an artifact this file resolves elsewhere, under the same relation.
 #
 # Seeded 2026-08-31 from the reviewed decisions in #413. Entries are appended by later sweeps;
 # a verdict is changed only deliberately, by a person, with `decided_in` updated.

--- a/tests/test_resolution_ledger.py
+++ b/tests/test_resolution_ledger.py
@@ -5,40 +5,49 @@ its identity and boundary decisions in pull request prose, where nothing could r
 the first bulk expansion duly recreated twelve repositories that #413 had already resolved -
 one of them a product the corpus already carries under another name.
 """
+import json
 from pathlib import Path
 
 import pytest
 import yaml
+import jsonschema
 
 from build.resolution import (
     LEDGER,
     NOT_A_NEW_PRODUCT,
+    RELATIONS,
     VERDICTS,
     DuplicateResolution,
     blocks_new_product,
     holds_bulk_promotion,
     load,
+    membership_ruling,
+    verdict_for,
 )
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parent.parent
 
 
 def test_the_ledger_parses_and_every_verdict_is_known():
     entries = load()
     assert entries
-    for repo, entry in entries.items():
-        assert entry["verdict"] in VERDICTS, f"{repo}: unknown verdict {entry['verdict']!r}"
-        assert repo == repo.lower(), "keys are lowercased for identity comparison"
-        assert len(entry.get("note") or "") > 20, f"{repo}: a decision needs its reasoning"
-        assert entry.get("decided_in"), f"{repo}: a decision needs a provenance"
+    for (kind, ident), relation in entries.keys():
+        entry = entries[((kind, ident), relation)]
+        assert entry["verdict"] in VERDICTS, f"{kind}/{ident}: unknown verdict {entry['verdict']!r}"
+        if kind == "github":
+            assert ident == ident.lower(), "github identity is compared lowercased"
+        assert len(entry.get("note") or "") > 20, f"{kind}/{ident}: a decision needs its reasoning"
+        assert entry.get("decided_in"), f"{kind}/{ident}: a decision needs a provenance"
 
 
 def test_a_resolved_repo_names_what_it_resolved_to():
     """`existing_product` and `sku_of` point at a product; `excluded_boundary` names a boundary.
     Without that an entry blocks a candidate while saying nothing about why."""
-    for repo, entry in load().items():
+    for (kind, ident), relation in load().keys():
+        entry = load()[((kind, ident), relation)]
         if entry["verdict"] in ("existing_product", "sku_of"):
-            assert entry.get("product"), f"{repo}: {entry['verdict']} must name a product"
+            assert entry.get("product") or entry.get("resolves_to"), \
+                f"{kind}/{ident}: {entry['verdict']} must name a product"
         if entry["verdict"] == "excluded_boundary":
             assert entry.get("boundary") or entry.get("note")
 
@@ -47,8 +56,11 @@ def test_named_products_exist_in_the_corpus():
     """A ledger pointing at a slug the corpus dropped is stale, and would block a candidate
     on the authority of a product that is no longer there."""
     slugs = {p.stem for p in (ROOT / "sources" / "products").glob("*.yaml")}
-    missing = {repo: e["product"] for repo, e in load().items()
-               if e.get("product") and e["product"] not in slugs}
+    missing = {
+        key: (e.get("product") or e.get("resolves_to"))
+        for key, e in load().items()
+        if (e.get("product") or e.get("resolves_to")) and (e.get("product") or e.get("resolves_to")) not in slugs
+    }
     assert not missing, f"ledger points at products that do not exist: {missing}"
 
 
@@ -61,7 +73,7 @@ def test_named_products_exist_in_the_corpus():
 def test_the_four_cases_that_produced_this_file(repo, verdict, target):
     """Named individually because each was recreated as a product by a bulk run that could
     not see the decision. A regression here is the whole failure coming back."""
-    entry = blocks_new_product(repo)
+    entry = blocks_new_product("github", repo)
     assert entry is not None, f"{repo} must be blocked from becoming a new product"
     assert entry["verdict"] == verdict
     if target:
@@ -80,24 +92,19 @@ def test_a_repository_may_be_resolved_only_once(tmp_path):
     ledger.write_text(
         "version: 1\nresolutions:\n"
         "- repo: Foo/Bar\n  verdict: existing_product\n  product: x\n"
-        "  decided_in: '#1'\n  note: the first decision, which must not be lost\n"
+        "  decided_in: '#1'\n  decided_on: '2026-08-01'\n  note: the first decision, which must not be lost\n"
         "- repo: foo/bar.git\n  verdict: unresolved\n"
-        "  decided_in: '#2'\n  note: a later entry for the same repository, differently cased\n"
+        "  decided_in: '#2'\n  decided_on: '2026-08-02'\n  note: a later entry for the same repository, differently cased\n"
     )
     with pytest.raises(DuplicateResolution) as raised:
         load(ledger)
-    assert "Foo/Bar" in str(raised.value) or "foo/bar" in str(raised.value)
+    assert "Foo/Bar" in str(raised.value) or "foo/bar" in str(raised.value) or "foo/bar" in str(raised.value).lower()
 
 
-#: Floor on the number of recorded decisions. Raise it deliberately when a pass appends;
-#: never lower it. Deliberately a hand-written constant rather than derived from the file:
-#: a floor that computes itself from the current ledger would happily derive 289 from a
-#: damaged one and prove itself correct. The independent number is what gives this test
-#: memory. 291 after the three 2026-08-31 category passes.
-LEDGER_FLOOR = 291
+LEDGER_FLOOR = 302  # trued up 2026-09-03 from 291; the ratchet below requires exact equality
 
 
-def test_the_ledger_never_shrinks():
+def test_the_ledger_never_shrinks_and_the_floor_moves_with_it():
     """Uniqueness protects identity integrity. It does not protect completeness.
 
     Three per-category tranches ran serially in one session, and each rebase conflicted on
@@ -108,26 +115,17 @@ def test_the_ledger_never_shrinks():
     been gone, and the next bulk run would have recreated both.
 
     So the ledger needs a second property alongside uniqueness: it is append-only, and a
-    resolution once recorded stays recorded. A count floor is the cheap form of that. A digest
-    over the whole key set would also catch a swap, but it would change on every legitimate
-    append and so would be noise rather than signal - and a swap is not how a side-pick fails.
-    A side-pick drops a block.
+    resolution once recorded stays recorded. A count floor is the cheap form of that. Now an
+    exact-equality ratchet rather than a `>=` floor: a PR that appends N entries raises the
+    floor by N in the same PR (#437), so drift in either direction fails here immediately
+    rather than accumulating silently until the next true-up.
 
     Correct resolution when this file conflicts: keep BOTH sides. Every entry is an append.
-
-    Deliberately a floor and not a set of named entries. Pinning the specific decisions a
-    given pass appended would couple this test to the order those passes merge in, which is
-    the one thing a serialized queue cannot promise.
     """
-    entries = load()
-    assert len(entries) >= LEDGER_FLOOR, (
-        f"the ledger holds {len(entries)} decisions, below the floor of {LEDGER_FLOOR}. "
-        "A resolution that was recorded has been lost - most likely a merge or rebase that "
-        "took one side of a conflict in this file instead of merging both. Recover the "
-        "missing entries from git history rather than lowering this number: "
-        "`git log -p --follow sources/resolution_ledger.yaml`. Raise the floor only when a "
-        "pass has legitimately appended."
-    )
+    n = len(yaml.safe_load(LEDGER.read_text())["resolutions"])
+    assert n == LEDGER_FLOOR, (
+        f"ledger has {n} entries but LEDGER_FLOOR is {LEDGER_FLOOR}; a PR that appends N entries "
+        f"raises the floor by N in the same PR (#437)")
 
 
 def test_the_real_ledger_has_no_duplicate_identity():
@@ -145,24 +143,24 @@ def test_unresolved_holds_a_bulk_promotion_even_though_it_does_not_block_forever
     them; a person may still resolve and add them by hand, which is why validate does not fail.
     """
     for repo in ("ag-ui-protocol/ag-ui", "oraios/serena", "yamadashy/repomix"):
-        assert blocks_new_product(repo) is None, f"{repo}: must not be a hard build error"
-        held = holds_bulk_promotion(repo)
+        assert blocks_new_product("github", repo) is None, f"{repo}: must not be a hard build error"
+        held = holds_bulk_promotion("github", repo)
         assert held is not None, f"{repo}: a bulk run must park it"
         assert held["verdict"] == "unresolved"
 
 
 def test_a_repo_with_no_entry_is_eligible():
     """The other side of the hold: silence in the ledger is permission."""
-    assert holds_bulk_promotion("vllm-project/vllm") is None
+    assert holds_bulk_promotion("github", "vllm-project/vllm") is None
 
 
 def test_unresolved_does_not_block():
     """`unresolved` means a person still has to look. A rerun proposing the repository again
     is the intended behaviour, so it must not be enforced like a decision."""
     assert "unresolved" not in NOT_A_NEW_PRODUCT
-    unresolved = [r for r, e in load().items() if e["verdict"] == "unresolved"]
-    for repo in unresolved:
-        assert blocks_new_product(repo) is None
+    unresolved = [(kind, ident) for ((kind, ident), relation), e in load().items() if e["verdict"] == "unresolved"]
+    for kind, ident in unresolved:
+        assert blocks_new_product(kind, ident) is None
 
 
 def test_no_product_declares_a_repo_the_ledger_resolves_elsewhere():
@@ -177,11 +175,15 @@ def test_no_product_declares_a_repo_the_ledger_resolves_elsewhere():
             if "github.com/" not in url:
                 continue
             repo = url.split("github.com/")[-1].removesuffix(".git").lower()
-            entry = ledger.get(repo)
-            if (entry and entry["verdict"] in NOT_A_NEW_PRODUCT
-                    and entry.get("product") != path.stem):
+            entry = verdict_for("github", repo, "product_equivalence", ledger)
+            resolved_to = entry.get("product") or entry.get("resolves_to") if entry else None
+            if entry and entry["verdict"] in NOT_A_NEW_PRODUCT and resolved_to != path.stem:
                 offences.append(f"{path.stem} declares {repo} ({entry['verdict']})")
     assert not offences, offences
+
+
+ALLOWED_KEYS = {"repo", "artifact", "verdict", "relation", "product", "resolves_to",
+                "boundary", "decided_in", "decided_on", "note"}
 
 
 def test_the_ledger_is_hand_maintainable():
@@ -189,6 +191,44 @@ def test_the_ledger_is_hand_maintainable():
     doc = yaml.safe_load(LEDGER.read_text())
     assert doc["version"] == 1
     assert isinstance(doc["resolutions"], list)
-    assert all(isinstance(e, dict) and set(e) <= {
-        "repo", "verdict", "product", "boundary", "decided_in", "decided_on", "note"}
-        for e in doc["resolutions"])
+    for e in doc["resolutions"]:
+        assert set(e) <= ALLOWED_KEYS, sorted(set(e) - ALLOWED_KEYS)
+
+
+def test_every_entry_validates_against_the_schema():
+    schema = json.loads((ROOT / "docs" / "schemas" / "resolution_ledger.schema.json").read_text())
+    for e in yaml.safe_load(LEDGER.read_text())["resolutions"]:
+        jsonschema.validate(e, schema)
+
+
+def test_keys_are_kind_and_canonical_id():
+    ledger = load()
+    for ((kind, ident), relation), entry in ledger.items():
+        assert kind in {"github", "huggingface_model", "huggingface_dataset", "pypi", "npm",
+                         "crates", "arxiv", "homepage"}
+        assert relation in RELATIONS
+        if kind == "github":
+            assert ident == ident.lower() and not ident.endswith(".git")
+
+
+def test_relation_defaults_to_equivalence_for_legacy_entries():
+    ledger = load()
+    assert all(e.get("relation", "product_equivalence") in RELATIONS for e in ledger.values())
+
+
+def test_a_membership_ruling_does_not_suppress_an_equivalence_question(tmp_path):
+    path = tmp_path / "ledger.yaml"
+    path.write_text(yaml.safe_dump({"version": 1, "resolutions": [{
+        "artifact": {"kind": "pypi", "id": "elasticsearch"}, "verdict": "not_member_of",
+        "relation": "product_membership", "resolves_to": "elasticsearch",
+        "decided_in": "#472", "decided_on": "2026-09-15",
+        "note": "elasticsearch-py is the client of the Java engine; its downloads are not this product's"}]}))
+    ledger = load(path)
+    assert membership_ruling("pypi", "elasticsearch", "elasticsearch", ledger)["verdict"] == "not_member_of"
+    assert blocks_new_product("pypi", "elasticsearch", ledger) is None
+    assert holds_bulk_promotion("pypi", "elasticsearch", ledger) is None
+
+
+def test_verdict_for_strips_git_suffix_like_load_does():
+    ledger = {(("github", "foo/bar"), "product_equivalence"): {"verdict": "unresolved"}}
+    assert verdict_for("github", "Foo/Bar.git", "product_equivalence", ledger) is not None


### PR DESCRIPTION
## What

The resolution ledger keyed only on a github `owner/repo` and answered only one
question: is this repository a new product. `build/resolution.py` now keys on
`(artifact kind, canonical id)` and reads every ruling by `relation`:

- `product_equivalence` — is this artifact a new product, or does it already
  belong to one. The question every entry before 2026-09 answered; `relation`
  absent still reads as this.
- `product_membership` (new) — does this artifact's usage count toward a
  named product's adoption measurement. Verdicts `member_of` / `not_member_of`,
  both requiring `resolves_to`. A ruling only answers its own relation: a
  `not_member_of` on a package never suppresses a later equivalence question
  about the same package.

`build/validate.py`'s ledger enforcement widens from `github`-only to every
declared artifact kind a product carries (github, huggingface_model,
huggingface_dataset, pypi, npm, crates, arxiv), using the same `_canonical`
shim `build/resolution.py` exposes — today that shim canonicalizes only
`github` (lowercase, `.git` stripped); the rest compare as given until a
follow-on unifies it with the id-resolution work. `build.validate` also
schema-validates the ledger file itself against a new
`docs/schemas/resolution_ledger.schema.json`, and flags any `member_of` /
`not_member_of` entry that isn't tagged `relation: product_membership`.

## Why

A candidate dismissed on PyPI or Hugging Face alone had no way to stay
dismissed — only a github repo ruling persisted. And a ruling that a package's
downloads don't belong to a product's adoption number had nowhere to live at
all; the only available verdicts answered "is this a new product," a
different question. This closes both gaps without touching any of the 302
existing entries.

## The 291 to 302 floor true-up

`LEDGER_FLOOR` in `tests/test_resolution_ledger.py` was last set to 291 and
had drifted three entries stale (the 2026-08-31 category passes). Trued up to
302, and the test is now an exact-equality ratchet rather than a `>=` floor,
so a PR that appends N entries has to raise the floor by N in the same PR
rather than letting it drift again.

## Test plan

- `uv run pytest tests/test_resolution_ledger.py tests/test_validate.py tests/test_docs_integrity.py -q -n auto` — 78 passed
- `uv run python -m build.validate` — 0 errors
- `uv run pytest -q -n auto -m "not serial"` — 1329 passed, 1 skipped
- All 302 existing ledger entries validate against the new schema unmodified

Refs #437 #365