### PR TITLE
Publish the resolution ledger and product aliases as registry tables

### DIFF
--- a/build/serialize_registry.py
+++ b/build/serialize_registry.py
@@ -21,6 +21,9 @@ Emitted tables (one CSV each, written to build/registry/):
   product_categories    product_slug, category_slug
   product_organizations product_slug, org_slug
   product_lineage       product_slug, relation, target
+  resolution_ledger     artifact_kind, artifact_id, relation, verdict, resolves_to,
+                        boundary, decided_in, decided_on, note
+  product_aliases       alias, product_slug
 
 `arxiv` exists so citation lookups join on an exact identifier. Matching papers
 by product name was measured at 2 correct out of 10 — APPS resolved to a medical
@@ -48,8 +51,10 @@ import re
 import sys
 from pathlib import Path
 
+from build.resolution import load as load_resolution_ledger
+from build.serialize import _aliases
 from build.taxonomy import arc_categories, category_statuses
-from build.validate import load_sources
+from build.validate import load_sources, published_products
 
 ROOT = Path(__file__).resolve().parents[1]
 OUT_DIR = ROOT / "build" / "registry"
@@ -99,6 +104,18 @@ TABLES: dict[str, tuple[str, ...]] = {
     "product_categories": ("product_slug", "category_slug"),
     "product_organizations": ("product_slug", "org_slug"),
     "product_lineage": ("product_slug", "relation", "target"),
+    "resolution_ledger": (
+        "artifact_kind",
+        "artifact_id",
+        "relation",
+        "verdict",
+        "resolves_to",
+        "boundary",
+        "decided_in",
+        "decided_on",
+        "note",
+    ),
+    "product_aliases": ("alias", "product_slug"),
 }
 
 _ID_PATTERNS = {
@@ -323,6 +340,34 @@ def build_registry(sources: dict) -> tuple[dict[str, list[dict]], list[str], lis
                         "artifact_url": url,
                     }
                 )
+
+    # The decision memory: one row per (artifact, relation) ruling, exactly the grain
+    # `build.resolution.load` keys on. Sorted for determinism, since this feeds the same
+    # daily automated PR the other tables do.
+    ledger = load_resolution_ledger()
+    for (kind, canonical_id), relation in sorted(ledger):
+        entry = ledger[((kind, canonical_id), relation)]
+        tables["resolution_ledger"].append(
+            {
+                "artifact_kind": kind,
+                "artifact_id": canonical_id,
+                "relation": relation,
+                "verdict": entry.get("verdict", ""),
+                "resolves_to": entry.get("resolves_to") or entry.get("product") or "",
+                "boundary": entry.get("boundary") or "",
+                "decided_in": entry.get("decided_in") or "",
+                "decided_on": entry.get("decided_on") or "",
+                "note": entry.get("note") or "",
+            }
+        )
+
+    # Aliases, published products only -- must match build.serialize._aliases exactly
+    # (same helper, same "published" set) so the table and the notebook payload can never
+    # disagree about which redirects exist.
+    published = published_products(sources.get("taxonomy") or {}, categories)
+    product_aliases = _aliases(products, organizations, published, set())["products"]
+    for alias, product_slug in sorted(product_aliases.items()):
+        tables["product_aliases"].append({"alias": alias, "product_slug": product_slug})
 
     placed = {row["product_slug"] for row in tables["product_categories"]}
     owned = {row["product_slug"] for row in tables["product_organizations"]}

--- a/docs/architecture/current-state-dag.md
+++ b/docs/architecture/current-state-dag.md
@@ -5,7 +5,7 @@ fails if this file drifts from the renderer. Regenerate with
 `uv run python -c "import sys;sys.path.insert(0,'.');from build import assets;print(assets.render_dag())"`.
 
 This graph is **root-scoped** (ADR-003): it is the Open Source AI Gap Map's own data system,
-not the OSO organization's warehouse. Nodes are the <!-- count:governed_assets -->38 governed
+not the OSO organization's warehouse. Nodes are the <!-- count:governed_assets -->40 governed
 assets in `warehouse/assets.yaml` (every one carries a `role`) plus the <!-- count:dependencies -->8
 external contracts in `warehouse/dependencies.yaml`. The peripheral OSO pipelines are out of scope:
 they were removed and **frozen** under platform ownership (disposition `frozen-without-producer`,
@@ -59,6 +59,7 @@ graph LR
     registry__evidence_abstentions[evidence_abstentions]
     registry__license_aliases[license_aliases]
     registry__organizations[organizations]
+    registry__product_aliases[product_aliases]
     registry__product_artifacts[product_artifacts]
     registry__product_categories[product_categories]
     registry__product_lineage[product_lineage]
@@ -67,6 +68,7 @@ graph LR
     registry__product_score_sources[product_score_sources]
     registry__product_scores[product_scores]
     registry__products[products]
+    registry__resolution_ledger[resolution_ledger]
     registry__tail_products[tail_products]
   end
   subgraph signal_packages
@@ -87,6 +89,7 @@ graph LR
   SRC --> registry__evidence_abstentions
   SRC --> registry__license_aliases
   SRC --> registry__organizations
+  SRC --> registry__product_aliases
   SRC --> registry__product_artifacts
   SRC --> registry__product_categories
   SRC --> registry__product_lineage
@@ -95,6 +98,7 @@ graph LR
   SRC --> registry__product_score_sources
   SRC --> registry__product_scores
   SRC --> registry__products
+  SRC --> registry__resolution_ledger
   SRC --> registry__tail_products
   observations__product_adoption_current --> evaluation__product_adoption_measurements
   registry__adoption_bands --> signal_packages__product_adoption
@@ -106,6 +110,8 @@ graph LR
   class observations__product_adoption_baseline staged;
   class observations__source_runs staged;
   class registry__axis_assessments staged;
+  class registry__product_aliases staged;
+  class registry__resolution_ledger staged;
   class registry__tail_products dormant;
   class signal_packages__downloads staged;
   class signal_packages__downloads_daily staged;

--- a/docs/architecture/data-architecture.md
+++ b/docs/architecture/data-architecture.md
@@ -1651,16 +1651,17 @@ Three numbers that must not be conflated:
 
 ```text
 deployed tables in the in-scope datasets    <!-- count:deployed_tables -->31
-staged, not deployed                         <!-- count:staged_assets -->6
+staged, not deployed                         <!-- count:staged_assets -->8
 dormant, no platform table yet              <!-- count:dormant_assets -->1
                                             ------
-logical assets in warehouse/assets.yaml     <!-- count:assets -->38
+logical assets in warehouse/assets.yaml     <!-- count:assets -->40
 ```
 
-The staged six are the three `signal_packages` models from issue #314,
-`observations.source_runs` and `observations.product_adoption_baseline` (both Phase 2), and the
-Phase-3 `registry.axis_assessments` candidate: tracked assets whose tables do not exist on the
-platform yet. The two Phase-3 evaluation candidates that were staged here,
+The staged eight are the three `signal_packages` models from issue #314,
+`observations.source_runs` and `observations.product_adoption_baseline` (both Phase 2), the
+Phase-3 `registry.axis_assessments` candidate, and the Phase-1 identity outputs
+`registry.resolution_ledger` and `registry.product_aliases`: tracked assets whose tables do not
+exist on the platform yet. The two Phase-3 evaluation candidates that were staged here,
 `evaluation.product_adoption_measurements` and `evaluation.adoption_reconciliation`, are now
 **deployed** (#368, 2026-08-25) and count among the deployed tables. (`registry.foundation_model_repos`
 was later **externalized** under ADR-003 — frozen under platform ownership and removed from this

--- a/docs/reference/where-scores-live.md
+++ b/docs/reference/where-scores-live.md
@@ -13,6 +13,12 @@ looks like a score is frozen, external, or keyed to something other than a gap-m
 Recorded, mirrored, recomputed and measured are four different things here, and a query is only
 as good as knowing which one it hit.
 
+Two more `registry` tables carry no axis at all and are easy to mistake for one because they sit
+next to `product_scores`: `currentai.registry.resolution_ledger` (the identity rulings a discovery
+sweep has already made, one row per artifact and relation) and `currentai.registry.product_aliases`
+(retired slug → live slug, published products only). Both are identity bookkeeping, not
+measurements — see `build/serialize_registry.py`.
+
 ## The one table — `currentai.registry.product_scores`
 
 522 rows, one per product per category, all three axes with their own confidence and

--- a/tests/test_serialize_registry.py
+++ b/tests/test_serialize_registry.py
@@ -5,7 +5,8 @@ the two things that would silently corrupt downstream joins: identifier parsing
 and reference integrity.
 """
 
-from build.serialize_registry import TABLES, artifact_id, build_registry, category_layers
+from build.serialize_registry import ROOT, TABLES, artifact_id, build_registry, category_layers
+from build.validate import load_sources
 
 
 def _sources(products=None, organizations=None, categories=None, taxonomy=None):
@@ -304,3 +305,28 @@ def test_arxiv_artifacts_serialize_like_any_other_kind():
             "artifact_url": "https://arxiv.org/abs/2110.14168",
         }
     ]
+
+
+def test_resolution_ledger_table_has_one_row_per_ruling():
+    tables, errors, _ = build_registry(_sources())
+    rows = tables["resolution_ledger"]
+    assert not errors
+    keys = [(r["artifact_kind"], r["artifact_id"], r["relation"]) for r in rows]
+    assert len(keys) == len(set(keys))
+    assert all(r["relation"] in ("product_equivalence", "product_membership") for r in rows)
+
+
+def test_product_aliases_table_matches_the_payload_alias_map():
+    sources = load_sources(ROOT)
+    tables, _, _ = build_registry(sources)
+    from build.serialize import _aliases
+
+    from build.validate import published_products
+
+    published = published_products(sources.get("taxonomy") or {}, sources["categories"])
+    payload_aliases = _aliases(
+        sources["products"], sources["organizations"], published=published, org_slugs=set()
+    )["products"]
+    assert {(r["alias"], r["product_slug"]) for r in tables["product_aliases"]} == set(
+        payload_aliases.items()
+    )

--- a/warehouse/assets.yaml
+++ b/warehouse/assets.yaml
@@ -718,6 +718,27 @@ assets:
   status: active
   materialized: true
   verified_at: '2026-08-20'
+- id: registry.product_aliases
+  table: currentai.registry.product_aliases
+  kind: registry
+  authority: repo
+  population: gap_map
+  release_path: true
+  role: governed-output
+  consumer_checks:
+    repository: checked
+    platform_notebooks: checked
+    platform_models: checked
+    external: unknown
+  external_consumers: none_confirmed
+  grain: one row per alias, published products only
+  producer: build/serialize_registry.py + build/publish_registry.py
+  publication_role: identity_input
+  refresh: CI push on merge to main
+  dataset_id: 6b735d7b-e38e-41e8-a951-d4d7f3fbf331
+  status: staged
+  materialized: false
+  verified_at: '2026-09-03'
 - id: registry.product_artifacts
   table: currentai.registry.product_artifacts
   kind: registry
@@ -918,6 +939,27 @@ assets:
   status: active
   materialized: true
   verified_at: '2026-08-20'
+- id: registry.resolution_ledger
+  table: currentai.registry.resolution_ledger
+  kind: registry
+  authority: repo
+  population: gap_map
+  release_path: true
+  role: governed-output
+  consumer_checks:
+    repository: checked
+    platform_notebooks: checked
+    platform_models: checked
+    external: unknown
+  external_consumers: none_confirmed
+  grain: one row per (artifact_kind, artifact_id, relation)
+  producer: build/serialize_registry.py + build/publish_registry.py
+  publication_role: identity_input
+  refresh: CI push on merge to main
+  dataset_id: 6b735d7b-e38e-41e8-a951-d4d7f3fbf331
+  status: staged
+  materialized: false
+  verified_at: '2026-09-03'
 - id: registry.tail_products
   table: currentai.registry.tail_products
   kind: registry


### PR DESCRIPTION
## What

Adds two new registry tables to `build/serialize_registry.py`:

- `registry.resolution_ledger` — one row per `(artifact_kind, artifact_id, relation)` ruling, read straight from `build.resolution.load()`'s composite-keyed ledger. Carries `verdict`, `resolves_to`, `boundary`, `decided_in`, `decided_on` and `note`, so the identity models (Task 5) can join against past decisions instead of a bulk sweep silently re-deriving what a person already resolved.
- `registry.product_aliases` — one row per alias, published products only.

Both grains and the row ordering come straight from the task-3 brief in the phase-1 identity implementation plan.

## Two grains

- `resolution_ledger`: `(artifact_kind, artifact_id, relation)`. `resolves_to` is `entry.get("resolves_to") or entry.get("product") or ""`; the four optional fields are emitted as strings, empty when absent.
- `product_aliases`: `(alias, product_slug)`.

## Keeping aliases identical to the payload

`product_aliases` is built with the same `build.serialize._aliases` helper and the same `published_products` set the notebook payload uses, so the table and the payload can never disagree about which redirects exist — a test enforces the two stay byte-identical.

Both tables are declared in `warehouse/assets.yaml` (`status: staged`, `materialized: false`) until the first publish, and `docs/reference/where-scores-live.md` and the architecture docs' governed-asset counts were updated to match.

## Test plan

- `uv run pytest tests/test_serialize_registry.py tests/test_assets_inventory.py tests/test_scope_gates.py tests/test_serialize.py tests/test_registry_triggers.py -q -n auto` — 219 passed
- `uv run python -m build.validate` — 0 errors
- `uv run python -m build.serialize_registry --check` — `resolution_ledger` 302 rows, `product_aliases` 63 rows
- `uv run pytest -q -n auto -m "not serial"` — 1332 passed

Refs #365