### PR TITLE
Contract the identity dataset inputs and reserve the identity namespace

### DIFF
--- a/build/assets.py
+++ b/build/assets.py
@@ -25,7 +25,7 @@ import yaml
 
 ROOT = Path(__file__).resolve().parent.parent
 
-NAMESPACES = {"registry", "catalog", "observations", "evaluation", "releases"}
+NAMESPACES = {"registry", "catalog", "observations", "evaluation", "releases", "identity"}
 STATUSES = {"active", "staged", "deprecated", "historical", "compatibility", "dormant"}
 CHECK_STATES = {"checked", "unknown", "not_applicable"}
 AUTHORITIES = {"repo", "platform", "external"}


### PR DESCRIPTION
## What

Phase 1 identity graph, task 5a (steps 1-2 only; no deploy in this PR).

- Adds `identity` to `NAMESPACES` in `build/assets.py`, reserving the namespace for the
  identity dataset ahead of its deploy.
- Writes the seven identity SQL models (nodes, artifact-identity edges, candidates,
  membership edges, equivalence edges, org edges, digest) outside this repo, in the
  `udms/` directory alongside the other platform-deployed model sources. They are not
  part of this PR's diff since that directory isn't a git repo.

## The three contracts

The brief called for `dependencies.yaml` contracts on `currentai.signal_hfhub.model_universe`,
`currentai.signal_openrouter.models`, and `currentai.signal_goodailist.repo_catalog`, plus
staged `assets.yaml` entries for the seven identity models. Both are **blocked** by the
existing gates, not added here:

- `dependency_violations()` accepts only a `verified_revision` + in-repo mirror anchor for a
  `currentai.*` table; `content_contract_sha256` is structurally rejected for anything not
  `oso.*`. Creating the mirror is out of scope for this PR (that's a later step, once the
  models are deployed).
- Independently, the three tables are not reachable from any governed root: `needed_tables()`
  only walks files tracked inside this repo, and the identity SQL lives in `udms/`, outside it.
  Nothing in this repo reads those three tables today.
- The `assets.yaml` staged-entry fallback (`authority: platform`, `role: governed-data`) is
  also blocked: the role gate requires `authority: repo` for `role: governed-data`, and
  requires the producer to be a `build/`-rooted file or have a `files.data` entry, neither of
  which a `udms/*.sql` path satisfies.

Both routes were tried for real against the gates (added, verified the exact failure, then
reverted) rather than reasoned about abstractly. Full detail, including the exact gate
messages, is in the task notes.

## What the SQL does

Each of the seven files carries a header comment stating its grain, inputs, and design rule,
and cites `build/identity.py::fold_for_proposal` for the identity-folding logic. Every output
row keeps the declared artifact spelling and adds a folded `artifact_key` for joins and grain
uniqueness. Confidence is `GREATEST(0, LEAST(1, GREATEST(evidence...) - SUM(penalties)))`
throughout. Columns I could not verify live (two tables from an in-flight PR that isn't merged
yet, one invented normalization rule, one undefined `blast_radius` formula) are flagged
`-- TODO verify on deploy:` inline.

## Test plan

- [x] `uv run pytest tests/test_scope_gates.py tests/test_assets_inventory.py tests/test_docs_integrity.py -q -n 4` — 153 passed
- [x] `uv run python -m build.validate` — 0 errors
- [x] `uv run pytest -q -n 4 -m "not serial"` — 1358 passed
- [x] All seven SQL files parse clean under `sqlglot`'s Trino dialect
- [ ] Not run against the live warehouse (deploy is a later step)

Refs #365