### PR TITLE
Treat a homepage as evidence, not identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
 
 ## [Unreleased]
 
+### Fixed
+
+- `homepage` artifact identity now keys on the full canonical URL (host and path), not the bare
+  domain — two products sharing one company's domain at different paths are no longer treated as
+  a collision. A shared domain is corroborating evidence of ownership, never proof of identity;
+  it never establishes equivalence between two candidates and never suppresses a second one.
+  `registry.tail_products` homepage rows now carry that full URL in `artifact_id` (#365).
+
 ### Added
 
 - Per-product `overall_score` and `tier` (`leading` for score ≥ 4.5, `strong` for

--- a/build/identity.py
+++ b/build/identity.py
@@ -18,15 +18,23 @@ case or punctuation for `github` or `pypi`, because `registry.product_artifacts`
 joined against externally sourced signal tables (GitHub's own API casing, PyPI's own
 package name) on raw equality; rewriting the declared spelling there breaks that
 join until every signal re-runs. `npm` and `crates` publish under a single
-registry-enforced casing, so folding those in `canonical` costs nothing; `arxiv` and
-`homepage` are never case-sensitive identifiers to begin with; Hugging Face ids are
-also kept as served.
+registry-enforced casing, so folding those in `canonical` costs nothing; `arxiv` is
+never a case-sensitive identifier to begin with; Hugging Face ids are also kept as
+served. `homepage` keeps its host lowercased in `canonical` (hosts are never
+case-sensitive) but its path as declared, because paths can be case-sensitive.
 
 `fold_for_proposal(kind, ident)` is the **comparison form** -- github and Hugging
 Face casefolded, PyPI folded per PEP 503 (lowercase, runs of `-`/`_`/`.` collapsed to
-`-`), crates' `-`/`_` collapsed. Every equality question -- "is this artifact already
-declared", a resolution-ledger lookup, a proposer's dedup -- goes through this, never
-through raw `canonical` values compared to each other.
+`-`), crates' `-`/`_` collapsed, homepage lowercased in full. Every equality question
+-- "is this artifact already declared", a resolution-ledger lookup, a proposer's
+dedup -- goes through this, never through raw `canonical` values compared to each
+other.
+
+A homepage is weak corroborating evidence, never identity: two distinct products
+routinely share one company's `homepage_domain` (`acme.com`), so `canonical`/
+`fold_for_proposal` key on the full URL (host + path), and a shared domain alone must
+never establish equivalence or suppress a second candidate. See the "Homepage is
+evidence, not identity" note in docs/reference/identity.md.
 """
 from __future__ import annotations
 
@@ -96,7 +104,7 @@ def id_from_url(kind: str, url: str) -> str | None:
     """
     raw = (url or "").strip()
     if kind == "homepage":
-        return homepage_domain(raw) if "." in raw else None
+        return _homepage_canonical(raw) if "." in raw else None
     pattern = _URL.get(kind)
     if pattern is None:
         raise ValueError(kind)
@@ -141,7 +149,7 @@ def canonical(kind: str, ident_or_url: str) -> str:
     if kind in ("huggingface_model", "huggingface_dataset"):
         return ident.strip("/")
     if kind == "homepage":
-        return homepage_domain(raw)
+        return _homepage_canonical(raw)
     raise ValueError(kind)
 
 
@@ -165,11 +173,31 @@ def fold_for_proposal(kind: str, ident: str) -> str:
         return c.replace("_", "-")
     if kind in ("huggingface_model", "huggingface_dataset"):
         return c.casefold()
+    if kind == "homepage":
+        return c.lower()
     return c
+
+
+def _homepage_canonical(url: str) -> str:
+    """Scheme-less canonical form: lowercased host minus `www.`, plus the path as
+    declared (case kept -- paths can be case-sensitive), minus query/fragment and any
+    trailing slash. `canonical("homepage", ...)`'s implementation; see that docstring
+    and the "Homepage is evidence, not identity" note in docs/reference/identity.md.
+    """
+    parts = urlsplit(url if "://" in url else f"https://{url}")
+    host = (parts.hostname or "").lower().removeprefix("www.")
+    path = parts.path.rstrip("/")
+    return f"{host}{path}"
 
 
 def homepage_domain(url: str) -> str:
     """The comparison host: hostname, lowercased, minus a leading `www.`.
+
+    Evidence only -- a shared host is corroborating evidence of common ownership, never
+    identity. Two distinct products at `acme.com/a` and `acme.com/b` are legitimately
+    different homepage artifacts (`canonical`/`fold_for_proposal` key on the full URL,
+    not this); use this only where the question really is "same registrable-ish host",
+    such as an org-ownership signal, not "same artifact".
 
     Not a registrable domain -- `awslabs.github.io`'s registrable domain is
     `github.io`, and this returns the full hostname regardless. The brief chose this
@@ -181,8 +209,8 @@ def homepage_domain(url: str) -> str:
 
 
 def homepage_canonical_url(url: str) -> str:
-    """The canonical evidence URL: https, comparison host, path kept, no query/fragment."""
-    parts = urlsplit(url if "://" in url else f"https://{url}")
-    host = (parts.hostname or "").lower().removeprefix("www.")
-    path = parts.path.rstrip("/")
-    return f"https://{host}{path}"
+    """The canonical evidence URL, with an explicit scheme -- an alias of
+    `canonical("homepage", url)` with `https://` prepended, for callers that need a
+    dereferenceable link rather than the bare comparison form.
+    """
+    return f"https://{canonical('homepage', url)}"

--- a/build/serialize_registry.py
+++ b/build/serialize_registry.py
@@ -50,7 +50,7 @@ import csv
 import sys
 from pathlib import Path
 
-from build.identity import ARXIV_ID, canonical, homepage_canonical_url, homepage_domain, id_from_url
+from build.identity import ARXIV_ID, canonical, homepage_canonical_url, id_from_url
 from build.resolution import load as load_resolution_ledger
 from build.serialize import _aliases
 from build.taxonomy import arc_categories, category_statuses
@@ -300,8 +300,14 @@ def build_registry(sources: dict) -> tuple[dict[str, list[dict]], list[str], lis
     # bug: a homepage-only tail row satisfies the `anyOf` in the schema and validates, but
     # emitted zero `tail_products` rows because this list never carried it. Unlike the other
     # kinds, a tail row's `homepage` field is already a full URI (see
-    # docs/schemas/registry.schema.json), so it is reduced with `homepage_domain`/
+    # docs/schemas/registry.schema.json), so it is reduced with `canonical`/
     # `homepage_canonical_url` directly rather than through the URL-templating below.
+    # `artifact_id` carries the full canonical URL (host + path), not the bare domain --
+    # a homepage is evidence, not identity, and two products sharing a company's domain
+    # at different paths are not a collision (see docs/reference/identity.md). SQL that
+    # wants the domain alone derives it from this URL rather than reading a separate
+    # column; `homepage_domain` stays available for that derivation but is not stored
+    # here.
     tail_artifact_kinds = (
         "github", "pypi", "npm", "huggingface_model", "huggingface_dataset",
         "crates", "arxiv", "homepage",
@@ -313,7 +319,7 @@ def build_registry(sources: dict) -> tuple[dict[str, list[dict]], list[str], lis
                 if not identifier:
                     continue
                 if kind == "homepage":
-                    row_artifact_id = homepage_domain(identifier)
+                    row_artifact_id = canonical("homepage", identifier)
                     url = homepage_canonical_url(identifier)
                 else:
                     row_artifact_id = identifier

--- a/docs/reference/identity.md
+++ b/docs/reference/identity.md
@@ -138,6 +138,18 @@ recorded values reproduce the recorded score; none can verify that the artifact 
 product. That makes it the one identity question a reviewer has to settle by reading, and the
 three shapes below are how it has actually gone wrong.
 
+### Homepage is evidence, not identity
+
+`homepage` is on the artifact-kind list, but it is not a measurement identity like the others -
+nothing bands adoption or routes license/weights off it. It is corroborating evidence: mainly
+who owns a product, sometimes that two records are the same thing when other evidence already
+points that way. The artifact id is the full canonical URL (host and path; see
+`build/identity.py`'s `canonical("homepage", ...)`), not the bare domain, because one company's
+domain routinely hosts several distinct products at different paths - `acme.com/widgets` and
+`acme.com/gadgets` are two products, not a collision. A shared `homepage_domain` alone must never
+establish equivalence between two candidates or suppress a second one from being proposed; it is
+a fact to weigh alongside the rest, never a verdict by itself.
+
 ### An open satellite around a closed core
 
 A vendor ships an open repository *for* a closed product: a recipe library, a client, a

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -18,7 +18,9 @@ from build import identity as I
     ("arxiv", "https://arxiv.org/abs/2401.12345v3", "2401.12345"),
     ("arxiv", "arxiv:cs/0112017v1", "cs/0112017"),
     ("huggingface_model", "https://huggingface.co/Meta-Llama/Llama-3", "Meta-Llama/Llama-3"),
-    ("homepage", "http://www.Example.com/products/foo/?utm=1#x", "example.com"),
+    ("homepage", "http://www.Example.com/products/foo/?utm=1#x", "example.com/products/foo"),
+    ("homepage", "https://www.Example.com/Product/", "example.com/Product"),
+    ("homepage", "example.com", "example.com"),
 ])
 def test_canonical(kind, raw, want):
     assert I.canonical(kind, raw) == want
@@ -46,6 +48,30 @@ def test_hf_compares_casefolded_but_keeps_case():
 
 def test_homepage_canonical_url_keeps_the_path_as_evidence():
     assert I.homepage_canonical_url("http://www.example.com/products/foo/?a=1") == "https://example.com/products/foo"
+
+
+def test_homepage_canonical_url_is_a_canonical_alias_with_a_scheme():
+    assert I.homepage_canonical_url("www.Example.com/Product/") == f"https://{I.canonical('homepage', 'www.Example.com/Product/')}"
+
+
+def test_homepage_fold_for_proposal_lowercases_the_full_url_but_canonical_keeps_path_case():
+    a, b = "https://www.Example.com/Product", "https://example.com/product"
+    assert I.canonical("homepage", a) != I.canonical("homepage", b)
+    assert I.fold_for_proposal("homepage", a) == I.fold_for_proposal("homepage", b)
+
+
+def test_homepage_different_paths_on_one_domain_are_distinct_identities():
+    """A homepage is evidence, not identity -- one company's domain routinely hosts more
+    than one product, so two different paths on it must not collapse to one artifact id."""
+    a = I.fold_for_proposal("homepage", "https://acme.com/widgets")
+    b = I.fold_for_proposal("homepage", "https://acme.com/gadgets")
+    assert a != b
+
+
+def test_homepage_same_url_folds_equal_regardless_of_scheme_www_or_query():
+    a = I.fold_for_proposal("homepage", "https://www.Acme.com/Widgets/")
+    b = I.fold_for_proposal("homepage", "http://acme.com/Widgets?utm=1")
+    assert a == b
 
 
 def test_every_kind_has_a_url_pattern():

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -313,11 +313,11 @@ def test_tail_row_with_only_homepage_validates():
     assert validate_sources(d) == []
 
 
-def test_tail_rows_sharing_a_homepage_domain_fail():
+def test_tail_rows_sharing_a_homepage_url_fail():
     """`homepage` is a dedup-gated identity key, not just an addressability check (#472
-    review): two tail rows declaring the same comparison host are the same duplicate
-    identity a github or pypi collision would be, even across categories and even when
-    the URLs differ by scheme, `www.`, path or query."""
+    review, corrected in #365): two tail rows declaring the same comparison URL are the
+    same duplicate identity a github or pypi collision would be, even across categories
+    and even when the URLs differ by scheme, `www.`, trailing slash or query."""
     d = _fixture()
     d["registry"] = {
         "base_pretrained": {
@@ -340,7 +340,7 @@ def test_tail_rows_sharing_a_homepage_domain_fail():
                     "display_name": "Site Two",
                     "type": "software",
                     "org": "meta",
-                    "homepage": "http://example.com/pricing?utm=1",
+                    "homepage": "http://example.com?utm=1",
                 },
             ],
         },
@@ -349,6 +349,41 @@ def test_tail_rows_sharing_a_homepage_domain_fail():
     assert any(
         "homepage artifact" in e and "already belongs to tail product 'site-one'" in e for e in errs
     ), errs
+
+
+def test_tail_rows_sharing_a_homepage_domain_at_different_paths_do_not_collide():
+    """A homepage is evidence, not identity (#365): one company's domain routinely hosts
+    more than one distinct product, so two tail rows at different paths on the same
+    domain are legitimately different artifacts, not a duplicate-identity collision."""
+    d = _fixture()
+    d["registry"] = {
+        "base_pretrained": {
+            "category": "base_pretrained",
+            "products": [
+                {
+                    "slug": "acme-widgets",
+                    "display_name": "Acme Widgets",
+                    "type": "software",
+                    "org": "meta",
+                    "homepage": "https://acme.com/widgets",
+                },
+            ],
+        },
+        "storage": {
+            "category": "storage",
+            "products": [
+                {
+                    "slug": "acme-gadgets",
+                    "display_name": "Acme Gadgets",
+                    "type": "software",
+                    "org": "meta",
+                    "homepage": "https://acme.com/gadgets",
+                },
+            ],
+        },
+    }
+    errs = validate_sources(d)
+    assert not any("homepage artifact" in e for e in errs), errs
 
 
 def test_tail_row_with_no_artifact_fails_with_a_clear_message():


### PR DESCRIPTION
## Summary

A homepage is corroborating evidence of ownership, not a measurement identity. #472 keyed `registry.tail_products` homepage rows and the tail-registry dedup on the bare domain (`homepage_domain`), which meant two products from one company at different paths on that domain — a routine shape — were treated as the same duplicate artifact and would collide in `build/validate.py`'s per-kind dedup.

## Changes

- `canonical("homepage", url)` now returns the full scheme-less canonical URL: host lowercased with a leading `www.` stripped, path preserved with its declared case (paths can be case-sensitive), query and fragment dropped, trailing slash stripped. A bare domain still canonicalizes to just the domain. `fold_for_proposal("homepage", ...)` is that same form lowercased in full, for comparison.
- `homepage_domain` is unchanged and now documented as evidence-only — a fact about common ownership, never proof of identity.
- `homepage_canonical_url` is now a thin alias of `canonical("homepage", ...)` with `https://` prepended, for callers that need a dereferenceable link.
- `build/validate.py`'s tail-registry dedup (unchanged code, new behavior via `identity.py`) now compares the full folded URL: `acme.com/a` and `acme.com/b` on two different tail products is legal; the same URL declared twice, even differing by scheme/`www.`/trailing slash/query, is still a collision.
- `registry.tail_products` homepage rows now carry the full canonical URL in `artifact_id` rather than the bare domain. Of the 27 existing homepage tail rows, 9 changed (every one that has a path); the other 18 are bare-domain homepages and are unaffected. No new schema column was added — SQL that wants the domain alone derives it from the URL.
- Added a "Homepage is evidence, not identity" section to `docs/reference/identity.md`.
- CHANGELOG entry under `Fixed`.

Does not touch GitHub/PyPI/HF/npm/crates canonicalization or any `sources/*.yaml`.

## Test plan

- [x] `uv run pytest tests/test_identity.py tests/test_validate.py tests/test_serialize_registry.py tests/test_check_artifacts.py -q -n 4` — 108 passed
- [x] `uv run python -m build.validate` — 0 errors
- [x] `uv run python -m build.serialize_registry --check` — passes, 2 pre-existing unrelated warnings
- [x] `uv run pytest -q -n 4 -m "not serial"` — 1365 passed

Refs #365