### PR TITLE
Key membership rulings on the target product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,11 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
 
 - `registry.product_artifacts`'s `crates` `artifact_id` now serializes the bare crate name
   instead of the full crates.io URL (one row: `yomo`) (#472).
+- The resolution ledger now keys a `product_membership` ruling on the product it names
+  (`resolves_to`), not on the artifact alone. One package can legitimately be `member_of` one
+  product's measurement and `not_member_of` another's — the loader used to raise
+  `DuplicateResolution` on that legitimate case. `registry.resolution_ledger`'s grain moves to
+  one row per `(artifact_kind, artifact_id, relation, resolves_to)` to match (#365).
 
 ## [0.2.0] - 2026-08-16
 

--- a/build/resolution.py
+++ b/build/resolution.py
@@ -98,7 +98,7 @@ def key_for(entry: Mapping) -> LedgerKey:
     artifact = artifact_of(entry)
     relation = relation_of(entry)
     if relation == "product_membership":
-        return (artifact, relation, entry.get("resolves_to"))
+        return (artifact, relation, (entry.get("resolves_to") or "").strip())
     return (artifact, relation)
 
 
@@ -164,7 +164,7 @@ def verdict_for(
     if relation == "product_membership":
         if product_slug is None:
             raise ValueError("verdict_for(relation='product_membership') requires product_slug")
-        return ledger.get((artifact, relation, product_slug))
+        return ledger.get((artifact, relation, product_slug.strip()))
     return ledger.get((artifact, relation))
 
 

--- a/build/resolution.py
+++ b/build/resolution.py
@@ -6,11 +6,14 @@ package's downloads are not this product's usage" - and records the reasoning in
 which no later run can read. The first corpus expansion duly recreated four repositories that
 #413 had already resolved - one of them a product the corpus carries under another name.
 
-Keyed on (artifact kind, canonical id). Every verdict is typed by relation, and a ruling
-suppresses only questions of its own relation: a `not_member_of` on a PyPI package never
-suppresses a later equivalence question about the same package. Entries written before 2026-09
-carry no relation and are read as `product_equivalence`, which is the only question they ever
-answered. The file is never rewritten by code; it only grows (#437).
+Keyed on (artifact kind, canonical id) plus relation - and, for `product_membership`, plus the
+product the ruling names (`resolves_to`), because membership is a relation between an artifact
+and a PRODUCT, not a fact about the artifact alone. One PyPI package can legitimately be
+`member_of` product-a's measurement and `not_member_of` product-b's; those are different keys,
+not a duplicate. A ruling suppresses only questions of its own relation: a `not_member_of` on a
+PyPI package never suppresses a later equivalence question about the same package. Entries
+written before 2026-09 carry no relation and are read as `product_equivalence`, which is the
+only question they ever answered. The file is never rewritten by code; it only grows (#437).
 
 This module is the reader. `build/validate.py` enforces the half that can be enforced
 mechanically, and a bulk pipeline is expected to consult `verdict_for` (or one of the three
@@ -42,10 +45,17 @@ MEMBERSHIP_VERDICTS = frozenset({"member_of", "not_member_of"})
 VERDICTS = EQUIVALENCE_VERDICTS | MEMBERSHIP_VERDICTS
 
 Key = tuple[str, str]
+#: The full ledger key: `(artifact, relation)` for `product_equivalence`, `(artifact, relation,
+#: resolves_to)` for `product_membership`. Membership is a relation between an artifact and a
+#: PRODUCT, so the product it names is part of the key -- one PyPI package may legitimately be
+#: `member_of` product-a and `not_member_of` product-b, and those are two different keys, not a
+#: duplicate.
+LedgerKey = tuple
 
 
 class DuplicateResolution(ValueError):
-    """Two entries answer the same (artifact, relation) question. Never benign for governance state."""
+    """Two entries answer the same (artifact, relation[, resolves_to]) question. Never benign for
+    governance state."""
 
 
 def _canonical(kind: str, ident: str) -> str:
@@ -63,7 +73,7 @@ def _canonical(kind: str, ident: str) -> str:
     return _identity_fold(kind, ident)
 
 
-def key_for(entry: Mapping) -> Key:
+def artifact_of(entry: Mapping) -> Key:
     """The (kind, canonical id) an entry is about, whether written as `repo` or `artifact`."""
     if "artifact" in entry:
         return (entry["artifact"]["kind"], _canonical(entry["artifact"]["kind"], entry["artifact"]["id"]))
@@ -76,50 +86,86 @@ def relation_of(entry: Mapping) -> str:
     return entry.get("relation") or "product_equivalence"
 
 
-def load(path: Path = LEDGER) -> dict[tuple[Key, str], dict]:
-    """Ledger keyed by `((kind, canonical id), relation)`.
+def key_for(entry: Mapping) -> LedgerKey:
+    """The full ledger key this entry occupies: `(artifact, relation)` for `product_equivalence`,
+    `(artifact, relation, resolves_to)` for `product_membership`.
 
-    A duplicate (artifact, relation) pair raises rather than resolving last-write-wins. The dict
-    comprehension this replaced would silently keep whichever entry came last, so
-    `Foo/Bar: existing_product` followed by `foo/bar: unresolved` would quietly discard the
-    stronger decision - and the file is hand-edited by people appending after each review, which
-    is exactly how that happens. `docs/reference/identity.md` records the same failure in the
-    deleted slug-alias mapping: two renames of one retired slug, and whichever came last won.
+    Membership is a relation between an artifact and a PRODUCT, not a global fact about the
+    artifact, so its key carries the product it names. Without the third element, a `member_of`
+    ruling for product-a and a `not_member_of` ruling for product-b on the SAME package would
+    collide as if they were the same question -- and one legitimately is not the other.
+    """
+    artifact = artifact_of(entry)
+    relation = relation_of(entry)
+    if relation == "product_membership":
+        return (artifact, relation, entry.get("resolves_to"))
+    return (artifact, relation)
 
-    The same artifact may carry both an equivalence ruling and a membership ruling - a package
-    can simultaneously not be a new product on its own AND be ruled in or out of another
-    product's measurement - so uniqueness is enforced per relation, not per artifact.
+
+def load(path: Path = LEDGER) -> dict[LedgerKey, dict]:
+    """Ledger keyed by `key_for`: `(artifact, relation)` for `product_equivalence`, `(artifact,
+    relation, resolves_to)` for `product_membership`.
+
+    A duplicate key raises rather than resolving last-write-wins. The dict comprehension this
+    replaced would silently keep whichever entry came last, so `Foo/Bar: existing_product`
+    followed by `foo/bar: unresolved` would quietly discard the stronger decision - and the file
+    is hand-edited by people appending after each review, which is exactly how that happens.
+    `docs/reference/identity.md` records the same failure in the deleted slug-alias mapping: two
+    renames of one retired slug, and whichever came last won.
+
+    The same artifact may carry an equivalence ruling AND one membership ruling per product it is
+    weighed against - a package can simultaneously not be a new product on its own, be ruled a
+    member of one product's measurement, and ruled out of another's - so uniqueness is enforced
+    per full key, not per artifact.
     """
     if not path.exists():
         return {}
     doc = yaml.safe_load(path.read_text()) or {}
-    out: dict[tuple[Key, str], dict] = {}
+    out: dict[LedgerKey, dict] = {}
     for entry in (doc.get("resolutions") or []):
         k = key_for(entry)
-        relation = relation_of(entry)
-        composite = (k, relation)
-        if composite in out:
-            prior = out[composite]
+        if k in out:
+            prior = out[k]
+            kind, ident = k[0]
+            relation = k[1]
+            target = f", resolves_to {k[2]!r}" if len(k) == 3 else ""
             raise DuplicateResolution(
-                f"{path.name}: {k} is resolved twice for {relation!r} - already "
-                f"{prior['verdict']!r} from {prior.get('decided_in')}, now "
+                f"{path.name}: {kind} {ident!r} is resolved twice for {relation!r}{target} - "
+                f"already {prior['verdict']!r} from {prior.get('decided_in')}, now "
                 f"{entry.get('verdict')!r} from {entry.get('decided_in')}. Identity is compared "
                 f"canonicalized, so these are one artifact. Merge them."
             )
-        out[composite] = entry
+        out[k] = entry
     return out
 
 
-def verdict_for(kind: str, ident: str, relation: str, ledger: Mapping | None = None) -> dict | None:
+def verdict_for(
+    kind: str,
+    ident: str,
+    relation: str,
+    ledger: Mapping | None = None,
+    *,
+    product_slug: str | None = None,
+) -> dict | None:
     """The recorded ruling for an artifact and relation, or None if never resolved.
 
     `verdict_for("github", repo, "product_equivalence")` behaves exactly as the old single-arg
     `verdict_for(repo)` did for repo entries: `_canonical` strips `.git` and lowercases here just
     as `load` does when building the keys, so a differently-cased or `.git`-suffixed lookup still
     matches.
+
+    `relation="product_membership"` requires `product_slug`: membership is a statement about ONE
+    product's measurement, not a global fact about the artifact, so a lookup that does not name
+    the product cannot be answered. The `relation="product_equivalence"` path ignores
+    `product_slug`.
     """
     ledger = load() if ledger is None else ledger
-    return ledger.get(((kind, _canonical(kind, ident)), relation))
+    artifact = (kind, _canonical(kind, ident))
+    if relation == "product_membership":
+        if product_slug is None:
+            raise ValueError("verdict_for(relation='product_membership') requires product_slug")
+        return ledger.get((artifact, relation, product_slug))
+    return ledger.get((artifact, relation))
 
 
 def blocks_new_product(kind: str, ident: str, ledger: Mapping | None = None) -> dict | None:
@@ -151,9 +197,8 @@ def holds_bulk_promotion(kind: str, ident: str, ledger: Mapping | None = None) -
 def membership_ruling(kind: str, ident: str, product_slug: str, ledger: Mapping | None = None) -> dict | None:
     """The `product_membership` ruling for this artifact against `product_slug`, if any.
 
-    Only returns an entry whose `resolves_to` matches `product_slug`: a `member_of` or
-    `not_member_of` ruling is a statement about ONE product's measurement, not a global fact
-    about the artifact, so a lookup against a different product must not see it.
+    A `member_of` or `not_member_of` ruling is a statement about ONE product's measurement, not
+    a global fact about the artifact, so `product_slug` is part of the key `verdict_for` looks
+    up here - a lookup against a different product simply misses.
     """
-    entry = verdict_for(kind, ident, "product_membership", ledger)
-    return entry if entry and entry.get("resolves_to") == product_slug else None
+    return verdict_for(kind, ident, "product_membership", ledger, product_slug=product_slug)

--- a/build/serialize_registry.py
+++ b/build/serialize_registry.py
@@ -23,6 +23,10 @@ Emitted tables (one CSV each, written to build/registry/):
   product_lineage       product_slug, relation, target
   resolution_ledger     artifact_kind, artifact_id, relation, verdict, resolves_to,
                         boundary, decided_in, decided_on, note
+                        (grain: one row per (artifact_kind, artifact_id, relation,
+                         resolves_to) -- a product_membership ruling names the product
+                         it is about, so the same artifact may carry a separate row per
+                         product it has been weighed against)
   product_aliases       alias, product_slug
 
 `arxiv` exists so citation lookups join on an exact identifier. Matching papers
@@ -51,7 +55,9 @@ import sys
 from pathlib import Path
 
 from build.identity import ARXIV_ID, canonical, homepage_canonical_url, id_from_url
+from build.resolution import artifact_of as _ledger_artifact_of
 from build.resolution import load as load_resolution_ledger
+from build.resolution import relation_of as _ledger_relation_of
 from build.serialize import _aliases
 from build.taxonomy import arc_categories, category_statuses
 from build.validate import load_sources, published_products
@@ -350,12 +356,18 @@ def build_registry(sources: dict) -> tuple[dict[str, list[dict]], list[str], lis
                     }
                 )
 
-    # The decision memory: one row per (artifact, relation) ruling, exactly the grain
-    # `build.resolution.load` keys on. Sorted for determinism, since this feeds the same
-    # daily automated PR the other tables do.
+    # The decision memory: one row per (artifact, relation, resolves_to) ruling, exactly the
+    # grain `build.resolution.load` keys on -- a `product_membership` ruling is a statement
+    # about ONE product, so the same artifact may carry a separate `member_of`/`not_member_of`
+    # row per product it has been weighed against. Sorted for determinism, since this feeds the
+    # same daily automated PR the other tables do.
     ledger = load_resolution_ledger()
-    for (kind, canonical_id), relation in sorted(ledger):
-        entry = ledger[((kind, canonical_id), relation)]
+    for entry in sorted(
+        ledger.values(),
+        key=lambda e: (*_ledger_artifact_of(e), _ledger_relation_of(e), e.get("resolves_to") or ""),
+    ):
+        kind, canonical_id = _ledger_artifact_of(entry)
+        relation = _ledger_relation_of(entry)
         tables["resolution_ledger"].append(
             {
                 "artifact_kind": kind,

--- a/build/validate.py
+++ b/build/validate.py
@@ -178,7 +178,13 @@ def validate_sources(data: dict) -> list[str]:
     # is folded through `build.identity.fold_for_proposal`, the same function
     # `build/resolution.py`'s ledger key now delegates to, so a differently-cased PyPI or npm
     # name matches here too.
-    from build.resolution import MEMBERSHIP_VERDICTS, NOT_A_NEW_PRODUCT, load as load_ledger
+    from build.resolution import (
+        MEMBERSHIP_VERDICTS,
+        NOT_A_NEW_PRODUCT,
+        artifact_of,
+        relation_of,
+        load as load_ledger,
+    )
 
     ledger = load_ledger()
     for slug, product in sorted((data.get("products") or {}).items()):
@@ -208,9 +214,10 @@ def validate_sources(data: dict) -> list[str]:
     # A `member_of`/`not_member_of` verdict answers a `product_membership` question; recording
     # one under any other relation would make `verdict_for` read it as an equivalence ruling it
     # never made.
-    for (key, relation), entry in ledger.items():
+    for entry in ledger.values():
+        relation = relation_of(entry)
         if entry.get("verdict") in MEMBERSHIP_VERDICTS and relation != "product_membership":
-            kind, ident = key
+            kind, ident = artifact_of(entry)
             errors.append(
                 f"resolution ledger: {kind} {ident!r} carries verdict {entry['verdict']!r} but "
                 f"relation {relation!r}; member_of/not_member_of require relation: "

--- a/build/validate.py
+++ b/build/validate.py
@@ -8,6 +8,7 @@ import jsonschema
 import yaml
 
 from build.identity import fold_for_proposal, id_from_url
+from build.resolution import LEDGER
 from build.vocabulary import axes, SIGNAL_TYPES
 
 from build.rubrics import dimension_vocabulary
@@ -104,7 +105,10 @@ def published_products(taxonomy: dict, cats: dict) -> set[str]:
     }
 
 
-def validate_sources(data: dict) -> list[str]:
+def validate_sources(data: dict, *, ledger_path: Path = LEDGER) -> list[str]:
+    """`ledger_path` is a seam for tests: it lets a test point every resolution-ledger check at
+    a temp file instead of the real `sources/resolution_ledger.yaml`, which this function
+    otherwise reads unconditionally."""
     errors: list[str] = []
     orgs, cats, prods, scores = (data["organizations"], data["categories"],
                                  data["products"], data["scores"])
@@ -186,7 +190,7 @@ def validate_sources(data: dict) -> list[str]:
         load as load_ledger,
     )
 
-    ledger = load_ledger()
+    ledger = load_ledger(ledger_path)
     for slug, product in sorted((data.get("products") or {}).items()):
         for kind in _TAIL_ARTIFACT_KINDS:
             for artifact in (product.get(kind) or []):
@@ -222,6 +226,28 @@ def validate_sources(data: dict) -> list[str]:
                 f"resolution ledger: {kind} {ident!r} carries verdict {entry['verdict']!r} but "
                 f"relation {relation!r}; member_of/not_member_of require relation: "
                 "product_membership"
+            )
+
+    # `resolves_to` is part of the ledger key for `product_membership` (`build/resolution.py`
+    # keys on artifact + relation + resolves_to), so a slug that does not exist -- retired,
+    # renamed, or simply mistyped -- silently forks the key rather than raising: a ruling meant
+    # to match an existing `member_of`/`not_member_of` entry for the same product would instead
+    # be treated as a ruling about a different (nonexistent) product and pass `load` clean. An
+    # exact match, because product slugs are kebab-case and a casing slip is exactly the kind of
+    # drift that must never fork a key silently.
+    product_slugs = set((data.get("products") or {}).keys())
+    for entry in ledger.values():
+        if relation_of(entry) != "product_membership":
+            continue
+        resolves_to = (entry.get("resolves_to") or "").strip()
+        if resolves_to not in product_slugs:
+            kind, ident = artifact_of(entry)
+            errors.append(
+                f"resolution ledger: {kind} {ident!r} carries a product_membership ruling for "
+                f"resolves_to {resolves_to!r}, which is not a product slug in the corpus "
+                f"(decided in {entry.get('decided_in', 'an earlier sweep')}). resolves_to is "
+                f"part of the ledger key, so an unknown or mistyped slug never matches the "
+                f"product it was meant to name."
             )
 
     # --- tail registry invariants ---
@@ -564,12 +590,10 @@ def validate_sources(data: dict) -> list[str]:
     # `sources/resolution_ledger.yaml` is one file rather than a directory, loaded straight
     # from disk here rather than through `load_ledger` above, so a malformed entry is reported
     # by slot in the file rather than silently swallowed by `load`'s duplicate-key check.
-    from build.resolution import LEDGER
-
     ledger_schema = json.loads(
         (Path(__file__).resolve().parents[1] / "docs" / "schemas" / "resolution_ledger.schema.json").read_text()
     )
-    ledger_doc = yaml.safe_load(LEDGER.read_text()) or {}
+    ledger_doc = yaml.safe_load(ledger_path.read_text()) or {}
     for i, entry in enumerate(ledger_doc.get("resolutions") or []):
         try:
             jsonschema.validate(entry, ledger_schema)

--- a/docs/reference/identity.md
+++ b/docs/reference/identity.md
@@ -214,6 +214,12 @@ says its downloads are not `elasticsearch`'s adoption - it says nothing about wh
 to rule on. The schema at `docs/schemas/resolution_ledger.schema.json` is normative for the
 shape; `build/resolution.py` is the reader.
 
+Membership is a relation between an artifact and a *product*, not a fact about the artifact
+alone, so `resolves_to` is part of the ledger key for `product_membership` rulings - one PyPI
+package may legitimately be `member_of` one product's measurement and `not_member_of` another's.
+`product_equivalence` has no such second axis: an artifact either is a new product or belongs to
+exactly one, so its key stays `(artifact, relation)`.
+
 ## Organizations
 
 Organizations carry aliases for the same reason and under the same rule. Two exist, both

--- a/docs/schemas/resolution_ledger.schema.json
+++ b/docs/schemas/resolution_ledger.schema.json
@@ -17,7 +17,7 @@
     "verdict": {"enum": ["existing_product", "sku_of", "excluded_boundary", "excluded_maintenance", "unresolved", "member_of", "not_member_of"]},
     "relation": {"enum": ["product_equivalence", "product_membership"], "description": "Which question this ruling answers. Absent means product_equivalence (every entry before 2026-09 answered that question). A ruling suppresses only questions of its own relation."},
     "product": {"type": "string", "description": "Legacy name for resolves_to on existing_product and sku_of entries."},
-    "resolves_to": {"type": "string", "description": "The product slug this artifact belongs to (member_of) or does not (not_member_of), or resolves to (existing_product, sku_of)."},
+    "resolves_to": {"type": "string", "description": "The product slug this artifact belongs to (member_of) or does not (not_member_of), or resolves to (existing_product, sku_of). For relation: product_membership, resolves_to is part of the ledger key alongside artifact and relation - the same artifact may carry a separate member_of/not_member_of ruling for a different product."},
     "boundary": {"type": "string"},
     "decided_in": {"type": "string"},
     "decided_on": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$"},

--- a/tests/test_resolution_ledger.py
+++ b/tests/test_resolution_ledger.py
@@ -18,10 +18,12 @@ from build.resolution import (
     RELATIONS,
     VERDICTS,
     DuplicateResolution,
+    artifact_of,
     blocks_new_product,
     holds_bulk_promotion,
     load,
     membership_ruling,
+    relation_of,
     verdict_for,
 )
 
@@ -31,8 +33,8 @@ ROOT = Path(__file__).resolve().parent.parent
 def test_the_ledger_parses_and_every_verdict_is_known():
     entries = load()
     assert entries
-    for (kind, ident), relation in entries.keys():
-        entry = entries[((kind, ident), relation)]
+    for entry in entries.values():
+        kind, ident = artifact_of(entry)
         assert entry["verdict"] in VERDICTS, f"{kind}/{ident}: unknown verdict {entry['verdict']!r}"
         if kind == "github":
             assert ident == ident.lower(), "github identity is compared lowercased"
@@ -43,8 +45,8 @@ def test_the_ledger_parses_and_every_verdict_is_known():
 def test_a_resolved_repo_names_what_it_resolved_to():
     """`existing_product` and `sku_of` point at a product; `excluded_boundary` names a boundary.
     Without that an entry blocks a candidate while saying nothing about why."""
-    for (kind, ident), relation in load().keys():
-        entry = load()[((kind, ident), relation)]
+    for entry in load().values():
+        kind, ident = artifact_of(entry)
         if entry["verdict"] in ("existing_product", "sku_of"):
             assert entry.get("product") or entry.get("resolves_to"), \
                 f"{kind}/{ident}: {entry['verdict']} must name a product"
@@ -99,6 +101,44 @@ def test_a_repository_may_be_resolved_only_once(tmp_path):
     with pytest.raises(DuplicateResolution) as raised:
         load(ledger)
     assert "Foo/Bar" in str(raised.value) or "foo/bar" in str(raised.value) or "foo/bar" in str(raised.value).lower()
+
+
+def _membership_entry(product_slug, verdict, decided_in, note):
+    return {
+        "artifact": {"kind": "pypi", "id": "widget"}, "verdict": verdict,
+        "relation": "product_membership", "resolves_to": product_slug,
+        "decided_in": decided_in, "decided_on": "2026-09-03", "note": note,
+    }
+
+
+def test_one_artifact_may_carry_a_membership_ruling_for_two_products(tmp_path):
+    """Membership is a relation between an artifact and a PRODUCT, not a global fact about the
+    artifact. One PyPI package can legitimately be `member_of` product-a's measurement and
+    `not_member_of` product-b's - that is two different keys, not a duplicate."""
+    path = tmp_path / "resolution_ledger.yaml"
+    path.write_text(yaml.safe_dump({"version": 1, "resolutions": [
+        _membership_entry("product-a", "member_of", "#1", "widget's downloads are product-a's own"),
+        _membership_entry("product-b", "not_member_of", "#2", "widget looks related but is not product-b's"),
+    ]}))
+    ledger = load(path)  # must not raise
+    assert membership_ruling("pypi", "widget", "product-a", ledger)["verdict"] == "member_of"
+    assert membership_ruling("pypi", "widget", "product-b", ledger)["verdict"] == "not_member_of"
+    # a lookup against a third product sees neither ruling
+    assert membership_ruling("pypi", "widget", "product-c", ledger) is None
+
+
+def test_two_membership_rulings_for_the_same_artifact_and_product_is_a_duplicate(tmp_path):
+    """The other side of the fix: `resolves_to` is part of the key, but the key is still
+    enforced - a `member_of` and a `not_member_of` for the SAME artifact and SAME product is
+    the same question answered twice, and that stays an error."""
+    path = tmp_path / "resolution_ledger.yaml"
+    path.write_text(yaml.safe_dump({"version": 1, "resolutions": [
+        _membership_entry("product-a", "member_of", "#1", "widget's downloads are product-a's own"),
+        _membership_entry("product-a", "not_member_of", "#2", "reversed on reconsideration, later sweep"),
+    ]}))
+    with pytest.raises(DuplicateResolution) as raised:
+        load(path)
+    assert "widget" in str(raised.value)
 
 
 LEDGER_FLOOR = 302  # trued up 2026-09-03 from 291; the ratchet below requires exact equality
@@ -158,7 +198,7 @@ def test_unresolved_does_not_block():
     """`unresolved` means a person still has to look. A rerun proposing the repository again
     is the intended behaviour, so it must not be enforced like a decision."""
     assert "unresolved" not in NOT_A_NEW_PRODUCT
-    unresolved = [(kind, ident) for ((kind, ident), relation), e in load().items() if e["verdict"] == "unresolved"]
+    unresolved = [artifact_of(e) for e in load().values() if e["verdict"] == "unresolved"]
     for kind, ident in unresolved:
         assert blocks_new_product(kind, ident) is None
 
@@ -203,7 +243,9 @@ def test_every_entry_validates_against_the_schema():
 
 def test_keys_are_kind_and_canonical_id():
     ledger = load()
-    for ((kind, ident), relation), entry in ledger.items():
+    for entry in ledger.values():
+        kind, ident = artifact_of(entry)
+        relation = relation_of(entry)
         assert kind in {"github", "huggingface_model", "huggingface_dataset", "pypi", "npm",
                          "crates", "arxiv", "homepage"}
         assert relation in RELATIONS

--- a/tests/test_serialize_registry.py
+++ b/tests/test_serialize_registry.py
@@ -314,7 +314,7 @@ def test_resolution_ledger_table_has_one_row_per_ruling():
     tables, errors, _ = build_registry(_sources())
     rows = tables["resolution_ledger"]
     assert not errors
-    keys = [(r["artifact_kind"], r["artifact_id"], r["relation"]) for r in rows]
+    keys = [(r["artifact_kind"], r["artifact_id"], r["relation"], r["resolves_to"]) for r in rows]
     assert len(keys) == len(set(keys))
     assert all(r["relation"] in ("product_equivalence", "product_membership") for r in rows)
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,3 +1,7 @@
+import pytest
+import yaml
+
+from build.resolution import DuplicateResolution
 from build.validate import validate_sources
 
 # `llama` is the product the tests reach for; the other nine exist because a PUBLISHED
@@ -633,3 +637,43 @@ def test_a_fetched_source_with_status_and_digest_validates():
         {"http_status": 200, "content_sha256": "a" * 64}
     )
     assert validate_sources(d) == []
+
+
+def _membership_entry(product_slug, verdict, decided_in, note):
+    return {
+        "artifact": {"kind": "pypi", "id": "widget"}, "verdict": verdict,
+        "relation": "product_membership", "resolves_to": product_slug,
+        "decided_in": decided_in, "decided_on": "2026-09-03", "note": note,
+    }
+
+
+def _write_ledger(tmp_path, resolutions):
+    path = tmp_path / "resolution_ledger.yaml"
+    path.write_text(yaml.safe_dump({"version": 1, "resolutions": resolutions}))
+    return path
+
+
+def test_a_member_of_and_not_member_of_for_the_same_artifact_and_product_is_a_duplicate(tmp_path):
+    """`resolves_to` is part of the ledger key `build/resolution.py` enforces uniqueness on, but
+    the key is still enforced: a member_of and a not_member_of naming the SAME product are the
+    same question answered twice, not two legitimate rulings."""
+    path = _write_ledger(tmp_path, [
+        _membership_entry("llama", "member_of", "#1", "widget's downloads are llama's own usage"),
+        _membership_entry("llama", "not_member_of", "#2", "reversed on reconsideration, later sweep"),
+    ])
+    with pytest.raises(DuplicateResolution):
+        validate_sources(_fixture(), ledger_path=path)
+
+
+def test_a_membership_ruling_naming_an_unknown_product_is_a_hard_error(tmp_path):
+    """resolves_to is part of the ledger key, so a retired, renamed, or mistyped slug never
+    matches the product the ruling was meant to name - it silently forks the key instead of
+    raising, which is worse than a build failure."""
+    path = _write_ledger(tmp_path, [
+        _membership_entry(
+            "not-a-real-product", "not_member_of", "#1",
+            "widget looks related to this product but its downloads are not its own",
+        ),
+    ])
+    errs = validate_sources(_fixture(), ledger_path=path)
+    assert any("not-a-real-product" in e and "not a product slug" in e for e in errs)

--- a/warehouse/assets.yaml
+++ b/warehouse/assets.yaml
@@ -952,7 +952,7 @@ assets:
     platform_models: checked
     external: unknown
   external_consumers: none_confirmed
-  grain: one row per (artifact_kind, artifact_id, relation)
+  grain: one row per (artifact_kind, artifact_id, relation, resolves_to)
   producer: build/serialize_registry.py + build/publish_registry.py
   publication_role: identity_input
   refresh: CI push on merge to main


### PR DESCRIPTION
## Summary

A reviewer found a design bug in the resolution ledger: `product_membership` is a relation between an artifact and a *product*, so one PyPI package can legitimately be `member_of` product-a's adoption measurement and `not_member_of` product-b's. The loader keyed rulings on `(artifact, relation)` only, so a second membership ruling for the same artifact against a different product looked like a duplicate and raised `DuplicateResolution` instead of being recorded.

- Ledger key: `product_equivalence` stays `(artifact, relation)`; `product_membership` becomes `(artifact, relation, resolves_to)`, with `resolves_to` stripped the same way the artifact id is folded. `key_for(entry)` builds the full key; `load()` uses it directly for the duplicate check, so a `member_of`/`not_member_of` pair for the same artifact and same product is still correctly rejected as a duplicate.
- `verdict_for` takes an optional `product_slug`, required when `relation="product_membership"`. `membership_ruling` now just delegates to it instead of post-filtering on `resolves_to`.
- `registry.resolution_ledger`'s grain moves to one row per `(artifact_kind, artifact_id, relation, resolves_to)` — columns are unchanged. `assets.yaml`, the table builder's docstring, and `docs/reference/identity.md` updated to match.
- `validate_sources` gains a hard error for a `product_membership` ruling whose `resolves_to` does not match an existing product slug exactly: since `resolves_to` is part of the key, an unknown or mistyped slug would otherwise fork the key silently instead of colliding with the ruling it was meant to match.
- `validate_sources` now takes an optional `ledger_path` (default the real `sources/resolution_ledger.yaml`), a seam so tests can point every resolution-ledger check at a temp file instead of the real one.
- Schema: `resolves_to`'s description now notes it is part of the key for membership rulings.
- No ledger entries added; `LEDGER_FLOOR` stays 302.

## Test plan

- `uv run pytest tests/test_resolution_ledger.py tests/test_validate.py tests/test_serialize_registry.py tests/test_assets_inventory.py -q -n 4` — 174 passed, including: one artifact carrying membership rulings for two different products (legal), a `member_of`/`not_member_of` pair for the same artifact and same product (still a duplicate), and a `product_membership` ruling naming an unknown product (hard error).
- `uv run python -m build.validate` — 0 errors.
- `uv run python -m build.serialize_registry --check` — no row-count changes (`resolution_ledger` still 302 rows).
- `uv run pytest -q -n 4 -m "not serial"` — 1362 passed.

Refs #365