### PR TITLE
Mirror and contract the identity dataset models

### DIFF
--- a/.github/workflows/identity-digest.yml
+++ b/.github/workflows/identity-digest.yml
@@ -7,12 +7,10 @@ name: identity-digest
 # Scheduled Monday 09:00 UTC, after `identity-eval` (Monday 07:30 UTC) has had time to run
 # and after the identity dataset's Sunday 05:30 UTC materialization has had a day to land.
 #
-# --allow-unprovisioned: the currentai.identity.digest model has not deployed yet, so a live
-# run would otherwise be red every week for a failure that is not drift -- see
-# build.identity_digest.main. A missing table renders "skipped: ..." to stdout instead of a
-# digest body, and the issue step is skipped entirely in that case. Remove this flag from the
-# schedule/dispatch step once the model is deployed -- from that point on, a missing table is
-# a real failure again and should be reported as one.
+# The render step passes no --allow-unprovisioned: currentai.identity.digest is deployed and
+# carries a mirror-bound dependency contract in warehouse/dependencies.yaml, so a missing
+# table is a real failure again and is reported as one (exit 2). The flag would be refused
+# anyway -- build.identity_digest.main rejects it once that contract exists.
 
 on:
   schedule:
@@ -43,7 +41,7 @@ jobs:
           OSO_API_KEY: ${{ secrets.OSO_API_KEY }}
         run: |
           set +e
-          OUTPUT=$(uv run python -m build.identity_digest --week "${{ steps.week.outputs.week }}" --out digest.md --allow-unprovisioned)
+          OUTPUT=$(uv run python -m build.identity_digest --week "${{ steps.week.outputs.week }}" --out digest.md)
           STATUS=$?
           echo "$OUTPUT"
           if [ $STATUS -ne 0 ]; then

--- a/.github/workflows/identity-eval.yml
+++ b/.github/workflows/identity-eval.yml
@@ -10,14 +10,11 @@ name: identity-eval
 # Scheduled Monday 07:30 UTC, after the identity dataset's Sunday run has had a day to land,
 # and offset from `artifacts` (also Monday 07:00) to keep the two gates' logs apart.
 #
-# --allow-unprovisioned: the currentai.identity.* dataset has not deployed yet, so a live run
-# would otherwise be red every week for a failure that is not drift -- see
-# build.identity_eval.main and _identity_dataset_deployed. The flag makes a missing table exit
-# 0 ("not provisioned") instead of 2, and REFUSES to run at all if warehouse/assets.yaml ever
-# marks an identity.* asset materialized: true, so the skip cannot outlive the deploy it is
-# covering for. Remove this flag from the schedule/dispatch step in the PR that adds the
-# identity.* assets to warehouse/assets.yaml -- from that point on, a missing table is a real
-# failure again and should be reported as one.
+# The live step passes no --allow-unprovisioned: all seven currentai.identity.* models are
+# deployed and carry mirror-bound dependency contracts in warehouse/dependencies.yaml, so a
+# missing table is a real failure again and is reported as one (exit 2). The flag would be
+# refused anyway -- build.identity_eval.main rejects it once a contract with a mirror block
+# exists, the platform-owned equivalent of an asset marked materialized: true.
 #
 # push/pull_request runs the FIXTURE eval, never --from-warehouse: a PR cannot reach the
 # warehouse tables (they may not exist, and a fork PR has no OSO_API_KEY regardless). The
@@ -74,4 +71,4 @@ jobs:
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         env:
           OSO_API_KEY: ${{ secrets.OSO_API_KEY }}
-        run: uv run python -m build.identity_eval --from-warehouse --floors --allow-unprovisioned
+        run: uv run python -m build.identity_eval --from-warehouse --floors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
 
 ### Changed
 
+- Dropped `--allow-unprovisioned` from the `identity-eval` and `identity-digest` workflows now
+  that the identity dataset is deployed and contracted. Both modules refuse the flag once a
+  `currentai.identity.*` contract with a `mirror` block exists, so a missing table is a real
+  failure again rather than a green skip (#365).
 - Split the labour between stage and gap text: a stage says where a category stands, a gap says
   what it needs. They render together in the category drawer, and written in one mood they
   restated each other — `depth` fires if and only if the stage is 4, so both sentences carried
@@ -91,6 +95,17 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
   another artifact kind, none homepage-only) (#472).
 - Consolidated GitHub/PyPI/npm/crates/arXiv/Hugging Face artifact-identity canonicalization,
   previously duplicated and drifted across three modules, into one (#472).
+- Brought all seven deployed `currentai.identity.*` models under repo governance (ADR-003):
+  read-only mirrors under `warehouse/models/identity/`, plus dependency contracts pinning each
+  model id, released revision and file hash, so `build/identity_eval.py`'s and
+  `build/identity_digest.py`'s inputs are versioned, hashed and reviewable. Mirrored the three
+  pool feeds (`signal_hfhub.model_universe`, `signal_openrouter.models`,
+  `signal_goodailist.repo_catalog`) the same way, since the dependency gate requires a mirror
+  for every `currentai.*` input a governed reader reaches (#365).
+- Recorded `currentai.signal_goodailist.repo_catalog`'s return to the dependency graph as a
+  `reclaimed-as-dependency` event in `warehouse/audits/externalization.json`: the identity
+  graph's `artifact_nodes` model reads it, so it is contracted again while the original
+  externalization entry stays byte-identical as history (#365).
 
 ### Deprecated
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ that merely exists on OSO, or is read only by a standalone notebook or another p
 externalization (the 28 backlog assets removed from this repo's inventory + publisher and frozen under
 platform ownership — disposition `frozen-without-producer`, no OSO deletion; see
 `warehouse/audits/externalization.json`) have both landed. The governed inventory is the Gap Map's own
-data system — 38 governed assets + 8 dependency contracts; `population: long_tail` is retired and the
+data system — 42 governed assets + 18 dependency contracts; `population: long_tail` is retired and the
 gates keep peripheral OSO tables out. The old Phase-5 namespace-move runbooks stay **superseded**.
 
 ## Conventions

--- a/build/assets.py
+++ b/build/assets.py
@@ -53,6 +53,8 @@ AUDIT_ROOTS = (
     "build/check_parity.py",     # protects the openness dual-run
     "build/apply_scores.py",     # applies the recorded score corpus
     "build/check_artifacts.py",  # audits declared-artifact coverage of the signals
+    "build/identity_eval.py",    # replays the identity dataset's edges against human rulings
+    "build/identity_digest.py",  # renders the weekly review digest from identity.digest
 )
 
 # Explicitly declared publication workflows that read tables directly (none today). The root

--- a/build/identity_digest.py
+++ b/build/identity_digest.py
@@ -83,6 +83,7 @@ from build.vocabulary import parse_date, parse_timestamp
 
 ROOT = Path(__file__).resolve().parents[1]
 TABLE = "currentai.identity.digest"
+DEPENDENCIES_PATH = ROOT / "warehouse" / "dependencies.yaml"
 
 #: Section order -- equivalence first, per the design's digest contract, then the rest in
 #: the order the brief names them.
@@ -464,6 +465,24 @@ def load_rows_from_file(path: Path) -> list[dict]:
     return json.loads(path.read_text())
 
 
+def _digest_is_contracted(path: Path = DEPENDENCIES_PATH) -> bool:
+    """Does `warehouse/dependencies.yaml` carry a mirror-bound contract for `TABLE`?
+
+    `identity.digest` is platform-authored, so under ADR-003 it is a dependency contract and
+    never a governed asset. A contract with a `mirror` block pins a model id, a released
+    revision and the hash of the mirrored code -- none of which can be written for a table that
+    does not exist -- so it is the repo's record that the model is deployed, and it refuses
+    `--allow-unprovisioned`.
+    """
+    if not path.exists():
+        return False
+    doc = yaml.safe_load(path.read_text()) or {}
+    return any(
+        d.get("table") == TABLE and (d.get("mirror") or {})
+        for d in (doc.get("dependencies") or [])
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--week", required=True, help='ISO week, e.g. "2026-36"')
@@ -476,7 +495,8 @@ def main(argv: list[str] | None = None) -> int:
         "--allow-unprovisioned", action="store_true",
         help=(
             "a missing currentai.identity.digest table exits 0 (\"skipped\") instead of 2. "
-            "Ignored when --rows is given."
+            "Ignored when --rows is given. Refused -- exit 2, no query attempted -- once "
+            "warehouse/dependencies.yaml contracts the table with a mirror block."
         ),
     )
     args = parser.parse_args(argv)
@@ -484,6 +504,14 @@ def main(argv: list[str] | None = None) -> int:
     if args.rows:
         rows = load_rows_from_file(args.rows)
     else:
+        if args.allow_unprovisioned and _digest_is_contracted(DEPENDENCIES_PATH):
+            print(
+                f"[FAIL] --allow-unprovisioned refused: warehouse/dependencies.yaml already "
+                f"contracts {TABLE} with a mirror block. The model is deployed, so a missing "
+                f"table is a real failure, not an unprovisioned skip -- remove "
+                f"--allow-unprovisioned from the caller."
+            )
+            return 2
         try:
             rows = load_rows_from_warehouse()
         except WarehouseTableMissing as exc:

--- a/build/identity_eval.py
+++ b/build/identity_eval.py
@@ -149,8 +149,11 @@ edges dict keyed by anything outside `EDGE_RELATIONS` -- a renamed or misspelled
 `--allow-unprovisioned` (`--from-warehouse` only): treats a genuine missing-table error as
 "not deployed yet" and exits 0 instead of 2, so the scheduled workflow is not red for months
 while the identity dataset ships. It refuses to run at all -- exit 2, before touching the
-warehouse -- if `warehouse/assets.yaml` already marks any `identity.*` asset
-`materialized: true`, so the skip cannot outlive the deploy it is meant to wait for.
+warehouse -- once the repo records the dataset as deployed: either `warehouse/assets.yaml`
+marks an `identity.*` asset `materialized: true`, or `warehouse/dependencies.yaml` carries an
+`identity.*` contract with a `mirror` block. So the skip cannot outlive the deploy it is meant
+to wait for. All seven models deployed on 2026-09-04 and are contracted, so the flag is refused
+today and the workflow no longer passes it.
 
 ## Insufficient truth, not a floor that can never be met
 
@@ -201,6 +204,7 @@ from build.validate import _load_optional_yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 ASSETS_PATH = ROOT / "warehouse" / "assets.yaml"
+DEPENDENCIES_PATH = ROOT / "warehouse" / "dependencies.yaml"
 
 Key = tuple[str, str]
 
@@ -916,6 +920,27 @@ def _identity_dataset_deployed(path: Path = ASSETS_PATH) -> list[str]:
     )
 
 
+def _identity_dataset_contracted(path: Path = DEPENDENCIES_PATH) -> list[str]:
+    """`currentai.identity.*` tables `warehouse/dependencies.yaml` contracts with a mirror block.
+
+    The identity models are platform-authored, so under ADR-003 they are dependency contracts and
+    never governed assets -- `warehouse/assets.yaml` will not carry them, and
+    `_identity_dataset_deployed` will keep returning `[]` however deployed the dataset is. A
+    contract with a `mirror` block is the equivalent record: it pins a model id, a released
+    revision and the hash of the mirrored code, none of which can be written for a table that
+    does not exist. So it refuses `--allow-unprovisioned` for the same reason a materialized
+    asset does.
+    """
+    if not path.exists():
+        return []
+    doc = yaml.safe_load(path.read_text()) or {}
+    return sorted(
+        str(d.get("table"))
+        for d in (doc.get("dependencies") or [])
+        if str(d.get("table", "")).startswith("currentai.identity.") and (d.get("mirror") or {})
+    )
+
+
 def load_edges_from_warehouse() -> dict[str, list[dict]]:
     """The four edge tables, read live with an explicit column list per table.
 
@@ -1043,7 +1068,8 @@ def main(argv: list[str] | None = None) -> int:
         help=(
             "--from-warehouse only: a missing currentai.identity.* table exits 0 (\"not "
             "provisioned yet\") instead of 2. Refused -- exit 2, no query attempted -- if "
-            "warehouse/assets.yaml already marks any identity.* asset materialized: true."
+            "warehouse/assets.yaml already marks any identity.* asset materialized: true, or "
+            "warehouse/dependencies.yaml contracts any identity.* table with a mirror block."
         ),
     )
     args = parser.parse_args(argv)
@@ -1058,12 +1084,23 @@ def main(argv: list[str] | None = None) -> int:
             # function-definition time, so a test that monkeypatches the module-level
             # ASSETS_PATH would otherwise be silently ignored here.
             deployed = _identity_dataset_deployed(ASSETS_PATH)
-            if deployed:
+            contracted = _identity_dataset_contracted(DEPENDENCIES_PATH)
+            if deployed or contracted:
+                where = []
+                if deployed:
+                    where.append(
+                        f"warehouse/assets.yaml already marks {', '.join(deployed)} "
+                        f"materialized: true"
+                    )
+                if contracted:
+                    where.append(
+                        f"warehouse/dependencies.yaml already contracts "
+                        f"{', '.join(contracted)} with a mirror block"
+                    )
                 print(
-                    f"[FAIL] --allow-unprovisioned refused: warehouse/assets.yaml already marks "
-                    f"{', '.join(deployed)} materialized: true. The identity dataset is deployed, "
-                    f"so a missing table is a real failure, not an unprovisioned skip -- remove "
-                    f"--allow-unprovisioned from the caller."
+                    f"[FAIL] --allow-unprovisioned refused: {'; '.join(where)}. The identity "
+                    f"dataset is deployed, so a missing table is a real failure, not an "
+                    f"unprovisioned skip -- remove --allow-unprovisioned from the caller."
                 )
                 return 2
         try:

--- a/docs/architecture/adr-003-repository-scope-boundary.md
+++ b/docs/architecture/adr-003-repository-scope-boundary.md
@@ -9,8 +9,8 @@ pipelines + 4 questionable gap_map tables) were removed from this repo's invento
 `warehouse/audits/externalization.json` (archived source hashes, platform IDs, consumers at removal).
 That is the no-orphan disposition, **not** a verified ownership transfer to a named destination repo:
 **no OSO table was deleted** — each deployed table is retained and frozen at its last publish, its
-repo producer removed, and its consumers still resolve against it. The governed inventory is now 38
-governed assets + 8 dependency contracts; the `long_tail` population is retired and the backlog is
+repo producer removed, and its consumers still resolve against it. The governed inventory is now 42
+governed assets + 18 dependency contracts; the `long_tail` population is retired and the backlog is
 empty, kept so by the gates.
 **Supersedes:** the scope *basis* of ADR-002 and `data-architecture.md` §11.3 (the transitive-closure
 membership rule). ADR-002's provenance test (`registry` vs `catalog`) stands; its assumption that every

--- a/docs/architecture/current-state-dag.md
+++ b/docs/architecture/current-state-dag.md
@@ -6,7 +6,7 @@ fails if this file drifts from the renderer. Regenerate with
 
 This graph is **root-scoped** (ADR-003): it is the Open Source AI Gap Map's own data system,
 not the OSO organization's warehouse. Nodes are the <!-- count:governed_assets -->42 governed
-assets in `warehouse/assets.yaml` (every one carries a `role`) plus the <!-- count:dependencies -->8
+assets in `warehouse/assets.yaml` (every one carries a `role`) plus the <!-- count:dependencies -->18
 external contracts in `warehouse/dependencies.yaml`. The peripheral OSO pipelines are out of scope:
 they were removed and **frozen** under platform ownership (disposition `frozen-without-producer`,
 recorded in the reproducible receipt `warehouse/audits/externalization.json`; not an ownership
@@ -132,16 +132,35 @@ graph LR
 ```mermaid
 graph LR
   currentai__evidence__product_evidence[currentai.evidence.product_evidence]:::dep --> currentai__scores__openness_facts[currentai.scores.openness_facts]:::dep
+  currentai__identity__artifact_identity_edges[currentai.identity.artifact_identity_edges]:::dep --> build/identity_eval__py[build/identity_eval.py]:::audit
+  currentai__identity__artifact_nodes[currentai.identity.artifact_nodes]:::dep --> currentai__identity__artifact_identity_edges[currentai.identity.artifact_identity_edges]:::dep
+  currentai__identity__artifact_nodes[currentai.identity.artifact_nodes]:::dep --> currentai__identity__candidates[currentai.identity.candidates]:::dep
+  currentai__identity__artifact_nodes[currentai.identity.artifact_nodes]:::dep --> currentai__identity__digest[currentai.identity.digest]:::dep
+  currentai__identity__artifact_nodes[currentai.identity.artifact_nodes]:::dep --> currentai__identity__equivalence_edges[currentai.identity.equivalence_edges]:::dep
+  currentai__identity__artifact_nodes[currentai.identity.artifact_nodes]:::dep --> currentai__identity__org_edges[currentai.identity.org_edges]:::dep
+  currentai__identity__candidates[currentai.identity.candidates]:::dep --> currentai__identity__digest[currentai.identity.digest]:::dep
+  currentai__identity__candidates[currentai.identity.candidates]:::dep --> currentai__identity__membership_edges[currentai.identity.membership_edges]:::dep
+  currentai__identity__digest[currentai.identity.digest]:::dep --> build/identity_digest__py[build/identity_digest.py]:::audit
+  currentai__identity__equivalence_edges[currentai.identity.equivalence_edges]:::dep --> build/identity_eval__py[build/identity_eval.py]:::audit
+  currentai__identity__equivalence_edges[currentai.identity.equivalence_edges]:::dep --> currentai__identity__digest[currentai.identity.digest]:::dep
+  currentai__identity__membership_edges[currentai.identity.membership_edges]:::dep --> build/identity_eval__py[build/identity_eval.py]:::audit
+  currentai__identity__membership_edges[currentai.identity.membership_edges]:::dep --> currentai__identity__digest[currentai.identity.digest]:::dep
+  currentai__identity__org_edges[currentai.identity.org_edges]:::dep --> build/identity_eval__py[build/identity_eval.py]:::audit
+  currentai__identity__org_edges[currentai.identity.org_edges]:::dep --> currentai__identity__digest[currentai.identity.digest]:::dep
   currentai__scores__openness_computed[currentai.scores.openness_computed]:::dep --> build/apply_scores__py[build/apply_scores.py]:::audit
   currentai__scores__openness_computed[currentai.scores.openness_computed]:::dep --> build/check_parity__py[build/check_parity.py]:::audit
   currentai__scores__openness_facts[currentai.scores.openness_facts]:::dep --> currentai__scores__openness_computed[currentai.scores.openness_computed]:::dep
   currentai__signal_github__artifact_state[currentai.signal_github.artifact_state]:::dep --> build/check_artifacts__py[build/check_artifacts.py]:::audit
   currentai__signal_github__artifact_state[currentai.signal_github.artifact_state]:::dep --> currentai__evidence__product_evidence[currentai.evidence.product_evidence]:::dep
+  currentai__signal_github__artifact_state[currentai.signal_github.artifact_state]:::dep --> currentai__identity__artifact_identity_edges[currentai.identity.artifact_identity_edges]:::dep
   currentai__signal_github__artifact_state[currentai.signal_github.artifact_state]:::dep --> currentai__observations__product_adoption_current[currentai.observations.product_adoption_current]
   currentai__signal_github__artifact_state[currentai.signal_github.artifact_state]:::dep --> currentai__signal_github__product_adoption[currentai.signal_github.product_adoption]
+  currentai__signal_goodailist__repo_catalog[currentai.signal_goodailist.repo_catalog]:::dep --> currentai__identity__artifact_nodes[currentai.identity.artifact_nodes]:::dep
+  currentai__signal_hfhub__model_universe[currentai.signal_hfhub.model_universe]:::dep --> currentai__identity__artifact_nodes[currentai.identity.artifact_nodes]:::dep
   currentai__signal_huggingface__artifact_state[currentai.signal_huggingface.artifact_state]:::dep --> currentai__evidence__product_evidence[currentai.evidence.product_evidence]:::dep
   currentai__signal_huggingface__artifact_state[currentai.signal_huggingface.artifact_state]:::dep --> currentai__observations__product_adoption_current[currentai.observations.product_adoption_current]
   currentai__signal_huggingface__artifact_state[currentai.signal_huggingface.artifact_state]:::dep --> currentai__signal_huggingface__product_adoption[currentai.signal_huggingface.product_adoption]
+  currentai__signal_openrouter__models[currentai.signal_openrouter.models]:::dep --> currentai__identity__candidates[currentai.identity.candidates]:::dep
   currentai__signal_pypi__package_downloads[currentai.signal_pypi.package_downloads]:::dep --> build/check_artifacts__py[build/check_artifacts.py]:::audit
   currentai__signal_pypi__package_downloads[currentai.signal_pypi.package_downloads]:::dep --> currentai__observations__product_adoption_current[currentai.observations.product_adoption_current]
   currentai__signal_pypi__package_downloads[currentai.signal_pypi.package_downloads]:::dep --> currentai__signal_github__product_adoption[currentai.signal_github.product_adoption]

--- a/docs/architecture/data-architecture.md
+++ b/docs/architecture/data-architecture.md
@@ -1345,7 +1345,7 @@ Migration rules:
 
 Verified against the live `currentai` org on 2026-08-20: <!-- observed:2026-08-20 -->22 datasets,
 <!-- observed:2026-08-20 -->96 tables,
-<!-- count:tracked_warehouse_files -->26 tracked files under `warehouse/`. The structure below is the target, and the
+<!-- count:tracked_warehouse_files -->36 tracked files under `warehouse/`. The structure below is the target, and the
 mirror layout of 11.1 is now in place; the file manifest in 11.4 recorded the exact diff
 from the 2026-08-20 state (40 files), Phase 0b added `warehouse/audits/platform_models.json`,
 the deployed-model audit receipt, and Phase 2 added `warehouse/audits/source_runs.json`, the
@@ -1723,7 +1723,7 @@ this diff starts from.
 
 ```text
 warehouse/ tracked files, pre-Phase-0   <!-- observed:2026-08-20 -->44
-  of which SQL/Python models   <!-- count:model_files -->15   (13 models, 3 ingest, 17 mirror)
+  of which SQL/Python models   <!-- count:model_files -->25   (13 models, 3 ingest, 17 mirror)
 warehouse/ after the move    44 + 1 assets.yaml - 5 = 40
 repository-wide             +6 created, -5 deleted   = +1
 ```

--- a/docs/operations/deploy-models.md
+++ b/docs/operations/deploy-models.md
@@ -10,11 +10,15 @@ different places.
 |---|---|---|
 | Legacy warehouse | `entities`, `events`, `metrics`, and the legacy `scores` stack-map models | **Externalized (ADR-003)** — frozen under platform ownership and no longer in this repo. |
 | Scoring chain | `evidence.product_evidence` → `scores.openness_facts` → `scores.openness_computed`, plus the `signal_*` fetchers | On the OSO platform. The models are copied **read-only** into `warehouse/models/<dataset>/` and recorded as **dependency contracts in `warehouse/dependencies.yaml`** (each with a `mirror:` block) so they are legible from the repo; the deploy script and the working copies you push from sit one level up in `currentai-org/{tools,udms}/`, outside version control. **Nothing deploys from the mirror copies.** |
+| Identity graph | all seven `identity.*` models (`artifact_nodes`, `candidates`, `artifact_identity_edges`, `membership_edges`, `equivalence_edges`, `org_edges`, `digest`), plus the pool feeds `signal_hfhub.model_universe`, `signal_openrouter.models`, `signal_goodailist.repo_catalog` | On the OSO platform, same mirror-and-contract pattern as the scoring chain. `build/identity_eval.py` and `build/identity_digest.py` are the repo-side readers. |
 
 The read-only mirror copies under `warehouse/models/<dataset>/` make the scoring models readable
 without platform access. They are snapshots, not the source of truth — see each contract's `mirror:`
 block in `warehouse/dependencies.yaml` for the deployed revision, hash and sync date the file
-reflects.
+reflects. The identity dataset is mirrored the same way, under `warehouse/models/identity/`: after
+any `identity.*` revision is released, resync the mirror file from the platform's released code and
+update that contract's `verified_revision`, `mirror.revision`, `mirror.hash`, `mirror.local_sha256`
+and `mirror.synced_at`, or the dependency gate fails on the hash.
 
 ## The deploy mechanic: revision → RELEASE → run
 
@@ -74,6 +78,7 @@ holds it against the `cron:` lines it quotes.
 | What | When (UTC) | Where the cron lives |
 |---|---|---|
 | `registry` static models | every push to `main` touching `sources/**` | `.github/workflows/registry.yml`, no cron |
+| `identity` dataset | Sunday 05:30 | dataset cron, timezone UTC |
 | `evidence` dataset | Monday 03:00 | dataset cron, timezone UTC |
 | `scores` dataset | Monday 04:00 | dataset cron, timezone UTC |
 | `parity` gate | Monday 06:00 | `.github/workflows/parity.yml` |

--- a/docs/reference/identity.md
+++ b/docs/reference/identity.md
@@ -295,6 +295,34 @@ one with the most characters, never the first one it happens to read. `build/val
 this shape as a warning (not an error, since it is a legitimate case) whenever one family's
 pattern is a literal prefix of another's and the two name different products.
 
+## Where the graph lives
+
+The identity questions this guide describes in prose are also computed as a graph on the OSO
+platform, in the `currentai.identity` dataset. Seven models, all deployed:
+
+| Table | What one row is |
+|---|---|
+| `artifact_nodes` | a folded artifact, with every declared spelling that folds onto it |
+| `candidates` | an undeclared pool artifact worth reviewing |
+| `artifact_identity_edges` | two declared spellings that are the same artifact |
+| `membership_edges` | an artifact belongs to a product |
+| `equivalence_edges` | a candidate is the same product as a declared one |
+| `org_edges` | a candidate belongs to an organization |
+| `digest` | a reviewable claim, ranked for the weekly sweep |
+
+The pool feeds `signal_hfhub.model_universe`, `signal_openrouter.models` and
+`signal_goodailist.repo_catalog` supply the undeclared candidates. All ten tables are
+platform-owned: the repo keeps read-only mirrors under `warehouse/models/identity/` and
+`warehouse/models/signal_{hfhub,openrouter,goodailist}/`, each recorded as a dependency contract
+in `warehouse/dependencies.yaml` with a `mirror:` block pinning the model id, revision and file
+hash (ADR-003). They are not governed assets — nothing deploys from the mirror copies, and editing
+one changes nothing.
+
+Two repo-side readers grade the deployed graph. `build/identity_eval.py` replays the four edge
+tables against the resolution ledger's prior human rulings; `build/identity_digest.py` renders
+`identity.digest` into the weekly review digest. Both are audit roots, which is what puts the
+dataset inside the repo's governed dependency closure.
+
 ## Related
 
 - `docs/reference/evidence-and-freshness.md` — how a score earns `last_verified`, and the gates

--- a/tests/test_identity_digest.py
+++ b/tests/test_identity_digest.py
@@ -5,6 +5,8 @@ footer numbers.
 a fixture resolution ledger), never the warehouse, so this suite runs offline like every
 other test in this repo. The CLI's warehouse plumbing (table-not-found vs any other error,
 `--allow-unprovisioned`) is exercised by monkeypatching `build.identity_digest.load_rows_from_warehouse`.
+`currentai.identity.digest` is deployed and contracted, so `--allow-unprovisioned` is refused
+against the committed tree; the tests that need the query path stand in an empty manifest.
 """
 
 from __future__ import annotations
@@ -370,7 +372,20 @@ def test_missing_table_exits_2_without_allow_unprovisioned(monkeypatch, tmp_path
     assert not out.exists()
 
 
-def test_missing_table_exits_0_with_allow_unprovisioned(monkeypatch, tmp_path):
+@pytest.fixture
+def uncontracted_digest(monkeypatch, tmp_path):
+    """Point the provisioning record at an empty dependency manifest.
+
+    The two tests below are about which EXCEPTION CLASS `--allow-unprovisioned` may swallow.
+    The committed tree contracts `identity.digest` with a mirror block, so the flag is refused
+    before any query runs unless the fixture withdraws that record first.
+    """
+    deps = tmp_path / "dependencies.yaml"
+    deps.write_text(yaml.dump({"dependencies": []}))
+    monkeypatch.setattr(digest, "DEPENDENCIES_PATH", deps)
+
+
+def test_missing_table_exits_0_with_allow_unprovisioned(monkeypatch, tmp_path, uncontracted_digest):
     def _raise():
         raise digest.WarehouseTableMissing(digest.TABLE, RuntimeError("does not exist"))
 
@@ -381,7 +396,9 @@ def test_missing_table_exits_0_with_allow_unprovisioned(monkeypatch, tmp_path):
     assert not out.exists()
 
 
-def test_other_warehouse_failure_always_exits_2_even_with_allow_unprovisioned(monkeypatch, tmp_path):
+def test_other_warehouse_failure_always_exits_2_even_with_allow_unprovisioned(
+    monkeypatch, tmp_path, uncontracted_digest
+):
     def _raise():
         raise digest.WarehouseQueryFailed(digest.TABLE, RuntimeError("access denied"))
 
@@ -390,6 +407,41 @@ def test_other_warehouse_failure_always_exits_2_even_with_allow_unprovisioned(mo
     code = digest.main(["--week", "2026-36", "--out", str(out), "--allow-unprovisioned"])
     assert code == 2
     assert not out.exists()
+
+
+def test_digest_is_contracted_reads_the_committed_manifest():
+    assert digest._digest_is_contracted() is True
+
+
+def test_digest_is_contracted_ignores_a_contract_with_no_mirror(tmp_path):
+    deps = tmp_path / "dependencies.yaml"
+    deps.write_text(yaml.dump({"dependencies": [{"table": digest.TABLE}]}))
+    assert digest._digest_is_contracted(deps) is False
+
+
+def test_allow_unprovisioned_is_refused_once_the_table_is_contracted(monkeypatch, tmp_path):
+    """No query is attempted -- the refusal comes before the warehouse is touched."""
+    def _boom():
+        raise AssertionError("the warehouse must not be queried after the refusal")
+
+    monkeypatch.setattr(digest, "load_rows_from_warehouse", _boom)
+    out = tmp_path / "out.md"
+    code = digest.main(["--week", "2026-36", "--out", str(out), "--allow-unprovisioned"])
+    assert code == 2
+    assert not out.exists()
+
+
+def test_the_digest_workflow_does_not_pass_allow_unprovisioned():
+    """The flag cannot come back while the contract stands: `main` refuses it, so a workflow
+    still passing it would fail every scheduled run."""
+    wf = (ROOT / ".github" / "workflows" / "identity-digest.yml").read_text()
+    for line in wf.splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        assert "--allow-unprovisioned" not in line, (
+            "identity-digest.yml passes --allow-unprovisioned, but currentai.identity.digest "
+            "is contracted in warehouse/dependencies.yaml and build.identity_digest refuses it"
+        )
 
 
 def test_rows_flag_reads_a_fixture_instead_of_the_warehouse(tmp_path):

--- a/tests/test_identity_eval.py
+++ b/tests/test_identity_eval.py
@@ -6,11 +6,13 @@ directly (`_equivalence_from_ledger`, `_membership_from_ledger`) rather than goi
 produce without raising (two rulings against one artifact, two different products) can still
 be tested here -- see `test_membership_truth_keeps_two_products_for_one_artifact_distinct`.
 
-The `currentai.identity.*` dataset has not deployed, so nothing here touches the warehouse;
+All seven `currentai.identity.*` models are deployed, but nothing here touches the warehouse;
 the F2 tests stub `build.warehouse.query` directly rather than hitting a real endpoint.
 """
 
 from __future__ import annotations
+
+from pathlib import Path
 
 import pytest
 import yaml
@@ -26,6 +28,7 @@ from build.identity_eval import (
     WarehouseQueryFailed,
     WarehouseTableMissing,
     _equivalence_from_ledger,
+    _identity_dataset_contracted,
     _identity_dataset_deployed,
     _is_table_not_found,
     _membership_from_ledger,
@@ -43,6 +46,7 @@ from build.identity_eval import (
     validate_columns,
 )
 
+ROOT = Path(__file__).resolve().parent.parent
 REAL_TRUTH = load_truth()
 
 
@@ -750,7 +754,24 @@ def test_load_edges_from_warehouse_other_failure_raises_query_failed_not_missing
         load_edges_from_warehouse()
 
 
-def test_main_allow_unprovisioned_exits_0_on_genuine_table_not_found(monkeypatch):
+@pytest.fixture
+def unrecorded_deploy(monkeypatch, tmp_path):
+    """Point both provisioning records at empty files.
+
+    The F2 tests below are about which EXCEPTION CLASS `--allow-unprovisioned` may swallow, not
+    about the refusal. The committed tree now records the identity dataset as deployed (seven
+    mirror-bound contracts), so the flag is refused before any query runs unless the fixture
+    withdraws that record first.
+    """
+    assets = tmp_path / "assets.yaml"
+    assets.write_text(yaml.dump({"assets": []}))
+    deps = tmp_path / "dependencies.yaml"
+    deps.write_text(yaml.dump({"dependencies": []}))
+    monkeypatch.setattr(identity_eval_module, "ASSETS_PATH", assets)
+    monkeypatch.setattr(identity_eval_module, "DEPENDENCIES_PATH", deps)
+
+
+def test_main_allow_unprovisioned_exits_0_on_genuine_table_not_found(monkeypatch, unrecorded_deploy):
     def fake_query(sql):
         raise Exception(REAL_TRINO_TABLE_NOT_FOUND)
 
@@ -759,7 +780,7 @@ def test_main_allow_unprovisioned_exits_0_on_genuine_table_not_found(monkeypatch
     assert rc == 0
 
 
-def test_main_allow_unprovisioned_still_exits_2_on_a_non_missing_table_failure(monkeypatch):
+def test_main_allow_unprovisioned_still_exits_2_on_a_non_missing_table_failure(monkeypatch, unrecorded_deploy):
     """F2: the flag exists to cover exactly one signal. An auth failure, a timeout, or a
     missing column on a table that DOES exist must exit 2 even with the flag set -- otherwise
     a rotated API key or a broken deployed schema reports "skipped" and stays green forever."""
@@ -809,6 +830,69 @@ def test_main_rejects_allow_unprovisioned_when_dataset_deployed(tmp_path, monkey
     monkeypatch.setattr(identity_eval_module, "ASSETS_PATH", p)
     rc = main(["--from-warehouse", "--allow-unprovisioned"])
     assert rc == 2
+
+
+def test_identity_dataset_contracted_reads_mirror_bound_contracts(tmp_path):
+    p = tmp_path / "dependencies.yaml"
+    p.write_text(yaml.dump({"dependencies": [
+        {"table": "currentai.identity.digest", "mirror": {"revision": 4, "model_id": "x"}},
+    ]}))
+    assert _identity_dataset_contracted(p) == ["currentai.identity.digest"]
+
+
+def test_identity_dataset_contracted_ignores_a_contract_with_no_mirror(tmp_path):
+    p = tmp_path / "dependencies.yaml"
+    p.write_text(yaml.dump({"dependencies": [{"table": "currentai.identity.digest"}]}))
+    assert _identity_dataset_contracted(p) == []
+
+
+def test_identity_dataset_contracted_ignores_non_identity_tables(tmp_path):
+    p = tmp_path / "dependencies.yaml"
+    p.write_text(yaml.dump({"dependencies": [
+        {"table": "currentai.signal_hfhub.model_universe", "mirror": {"revision": 3}},
+    ]}))
+    assert _identity_dataset_contracted(p) == []
+
+
+def test_main_rejects_allow_unprovisioned_when_the_dataset_is_contracted(tmp_path, monkeypatch):
+    """A contract with a mirror block is the platform-owned equivalent of a materialized asset.
+
+    identity.* tables are never governed assets under ADR-003, so `_identity_dataset_deployed`
+    stays empty however deployed the dataset is -- the contract is the only record, and the
+    refusal has to read it or the flag would outlive the deploy forever.
+    """
+    assets = tmp_path / "assets.yaml"
+    assets.write_text(yaml.dump({"assets": []}))
+    deps = tmp_path / "dependencies.yaml"
+    deps.write_text(yaml.dump({"dependencies": [
+        {"table": "currentai.identity.membership_edges", "mirror": {"revision": 2, "model_id": "x"}},
+    ]}))
+    monkeypatch.setattr(identity_eval_module, "ASSETS_PATH", assets)
+    monkeypatch.setattr(identity_eval_module, "DEPENDENCIES_PATH", deps)
+    rc = main(["--from-warehouse", "--allow-unprovisioned"])
+    assert rc == 2
+
+
+def test_the_committed_tree_refuses_allow_unprovisioned():
+    """The real repo state, not a fixture: the dataset is contracted, so the flag is dead."""
+    assert _identity_dataset_contracted() != []
+    assert main(["--from-warehouse", "--allow-unprovisioned"]) == 2
+
+
+def test_the_eval_workflow_does_not_pass_allow_unprovisioned():
+    """The flag cannot come back while the contracts stand.
+
+    `main` refuses it, so a workflow that still passed it would fail every scheduled run -- this
+    catches that at review time instead, and pins the two facts together.
+    """
+    wf = (ROOT / ".github" / "workflows" / "identity-eval.yml").read_text()
+    for line in wf.splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        assert "--allow-unprovisioned" not in line, (
+            "identity-eval.yml passes --allow-unprovisioned, but the identity dataset is "
+            "contracted in warehouse/dependencies.yaml and build.identity_eval refuses the flag"
+        )
 
 
 def test_main_rejects_allow_unprovisioned_without_from_warehouse(tmp_path):

--- a/tests/test_scope_gates.py
+++ b/tests/test_scope_gates.py
@@ -592,8 +592,23 @@ def _contract(mirror=True):
 
 
 def _serve_contract(monkeypatch, contract):
-    real = A.dependencies()
+    """Stand in the fixture's contract for RECLAIM_TABLE's real one.
+
+    The committed `dependencies.yaml` now carries a contract for RECLAIM_TABLE (the reclaim is
+    real), so the fixture has to REPLACE it rather than append beside it -- otherwise `None`
+    would not mean "no contract" and the no-contract cases could never fire.
+    """
+    real = [d for d in A.dependencies() if d.get("table") != RECLAIM_TABLE]
     monkeypatch.setattr(A, "dependencies", lambda: real + ([contract] if contract else []))
+
+
+def _receipt_without_the_reclaim():
+    """The committed receipt as it read before RECLAIM_TABLE was reclaimed."""
+    r = _real_receipt()
+    r["reclaims"] = []
+    r["reclaimed_count"] = 0
+    r["still_external_count"] = r["count"]
+    return r
 
 
 def _serve_read(monkeypatch, reader, table=RECLAIM_TABLE):
@@ -670,7 +685,7 @@ def test_reclaimed_contract_without_a_mirror_block_is_flagged(monkeypatch):
 
 
 def test_contract_for_an_externalized_table_without_a_reclaim_is_flagged(monkeypatch):
-    r = _real_receipt()
+    r = _receipt_without_the_reclaim()
     _serve(monkeypatch, r)  # no reclaims entry at all
     _serve_contract(monkeypatch, _contract())
     assert any("with no reclaim record" in v for v in A.reclaim_violations())
@@ -733,7 +748,7 @@ def test_reclaimed_mirror_file_may_exist_again(monkeypatch):
     real_has = A._worktree_has
     monkeypatch.setattr(A, "_worktree_has", lambda p: p == RECLAIM_MIRROR or real_has(p))
 
-    pristine = _real_receipt()
+    pristine = _receipt_without_the_reclaim()
     r = copy.deepcopy(pristine)
     rec = _reclaim_record(r)
     _serve(monkeypatch, r)
@@ -829,4 +844,10 @@ def test_a_version_2_receipt_without_reclaims_still_validates(monkeypatch):
     for k in ("reclaims", "reclaimed_count", "still_external_count", "reclaim_note"):
         r.pop(k, None)
     _serve(monkeypatch, r)
+    # A pre-reclaim receipt also predates RECLAIM_TABLE's contract and its restored mirror, so
+    # the fixture withdraws both; left in place, the converse and archived-file checks would fire
+    # and the version bump would look at fault.
+    _serve_contract(monkeypatch, None)
+    real_has = A._worktree_has
+    monkeypatch.setattr(A, "_worktree_has", lambda p: p != RECLAIM_MIRROR and real_has(p))
     assert A.externalization_receipt_violations() == []

--- a/warehouse/assets.yaml
+++ b/warehouse/assets.yaml
@@ -483,6 +483,9 @@ assets:
   population: gap_map
   release_path: true
   role: governed-output
+  read_by:
+    models:
+    - warehouse/models/identity/membership_edges.sql
   consumer_checks:
     repository: checked
     platform_notebooks: checked
@@ -701,6 +704,9 @@ assets:
   population: gap_map
   release_path: true
   role: governed-output
+  read_by:
+    models:
+    - warehouse/models/identity/equivalence_edges.sql
   consumer_checks:
     repository: checked
     platform_notebooks: checked
@@ -722,6 +728,9 @@ assets:
   population: gap_map
   release_path: true
   role: governed-output
+  read_by:
+    models:
+    - warehouse/models/identity/org_edges.sql
   consumer_checks:
     repository: checked
     platform_notebooks: checked
@@ -743,6 +752,9 @@ assets:
   population: gap_map
   release_path: true
   role: governed-output
+  read_by:
+    models:
+    - warehouse/models/identity/org_edges.sql
   consumer_checks:
     repository: checked
     platform_notebooks: checked
@@ -767,6 +779,9 @@ assets:
   population: gap_map
   release_path: true
   role: governed-output
+  read_by:
+    models:
+    - warehouse/models/identity/equivalence_edges.sql
   consumer_checks:
     repository: checked
     platform_notebooks: checked
@@ -790,6 +805,8 @@ assets:
   role: governed-output
   read_by:
     models:
+    - warehouse/models/identity/artifact_nodes.sql
+    - warehouse/models/identity/membership_edges.sql
     - warehouse/models/observations/product_adoption_current.sql
     - warehouse/models/signal_github/artifact_state.py
     - warehouse/models/signal_github/repo_state.py
@@ -964,6 +981,8 @@ assets:
   role: governed-output
   read_by:
     models:
+    - warehouse/models/identity/equivalence_edges.sql
+    - warehouse/models/identity/membership_edges.sql
     - warehouse/models/scores/openness_facts.sql
     - warehouse/models/signal_github/product_adoption.sql
     - warehouse/models/signal_huggingface/product_adoption.sql
@@ -988,6 +1007,10 @@ assets:
   population: gap_map
   release_path: true
   role: governed-output
+  read_by:
+    models:
+    - warehouse/models/identity/candidates.sql
+    - warehouse/models/identity/equivalence_edges.sql
   consumer_checks:
     repository: checked
     platform_notebooks: checked
@@ -1009,6 +1032,11 @@ assets:
   population: gap_map
   release_path: true
   role: governed-output
+  read_by:
+    models:
+    - warehouse/models/identity/artifact_nodes.sql
+    - warehouse/models/identity/equivalence_edges.sql
+    - warehouse/models/identity/membership_edges.sql
   consumer_checks:
     repository: checked
     platform_notebooks: checked

--- a/warehouse/audits/externalization.json
+++ b/warehouse/audits/externalization.json
@@ -4,9 +4,19 @@
  "reclaim_note": "A table can legitimately come back. When an in-scope governed asset starts reading an externalized table, the transition is recorded as a 'reclaims' event -- disposition history in-scope -> externalized -> reclaimed-as-dependency -- and the original 'assets' entry stays byte-identical, because it is history. 'reclaimed-as-dependency' means the table is STILL platform-owned and still not deployed from this repo; it is once again inside the repo's governed dependency graph, represented by a warehouse/dependencies.yaml contract with a mirror block (provenance, not ownership). Each record carries table, prior_disposition, prior_date, new_disposition, date, reason and governed_reader (the in-repo file that now reads it). build.assets.reclaim_violations() checks the prior entry exists with the stated disposition and date, that governed_reader exists and genuinely reads the table (same scanner the rest of the graph uses), and that the contract with a mirror block exists; a contract for an externalized table with no reclaim record is a hard error too. Only 'frozen-without-producer' is reclaimable: a 'transferred' table is owned by its named destination repo, so a contract's owner: oso would be false, and that case needs a ruling. A reclaim re-admits ONLY the files its own contract claims (the mirror model and any schema beside it, both content-bound by the mirror hashes); every other archived path stays under the deleted-from-the-worktree rule, and only the contract's own mirror path may derive the reclaimed table. 'count' and 'assets' are the HISTORICAL removed set and never shrink; 'still_external_count' = count - reclaimed_count is the population currently outside the graph, stated here rather than inferred.",
  "externalization_base_commit": "caebc97ef1c6cbb541d4a98a64f2b6ad30af810e",
  "count": 28,
- "reclaimed_count": 0,
- "still_external_count": 28,
- "reclaims": [],
+ "reclaimed_count": 1,
+ "still_external_count": 27,
+ "reclaims": [
+  {
+   "table": "currentai.signal_goodailist.repo_catalog",
+   "prior_disposition": "frozen-without-producer",
+   "prior_date": "2026-08-30",
+   "new_disposition": "reclaimed-as-dependency",
+   "date": "2026-09-04",
+   "reason": "read by the identity graph's artifact_nodes model, which entered scope on 2026-09-03",
+   "governed_reader": "warehouse/models/identity/artifact_nodes.sql"
+  }
+ ],
  "assets": [
   {
    "id": "catalog.country_populations",

--- a/warehouse/audits/platform_models.json
+++ b/warehouse/audits/platform_models.json
@@ -155,7 +155,9 @@
     "currentai.entities.repos",
     "currentai.signal_goodailist.repo_catalog"
    ],
-   "in_scope_reads": [],
+   "in_scope_reads": [
+    "currentai.signal_goodailist.repo_catalog"
+   ],
    "has_repository_source": false
   },
   {
@@ -169,7 +171,9 @@
    "internal_reads": [
     "currentai.signal_goodailist.repo_catalog"
    ],
-   "in_scope_reads": [],
+   "in_scope_reads": [
+    "currentai.signal_goodailist.repo_catalog"
+   ],
    "has_repository_source": false
   },
   {
@@ -267,7 +271,9 @@
     "currentai.entities.repos",
     "currentai.signal_goodailist.repo_catalog"
    ],
-   "in_scope_reads": [],
+   "in_scope_reads": [
+    "currentai.signal_goodailist.repo_catalog"
+   ],
    "has_repository_source": false
   },
   {
@@ -284,7 +290,9 @@
     "currentai.scores.dependency_graph",
     "currentai.signal_goodailist.repo_catalog"
    ],
-   "in_scope_reads": [],
+   "in_scope_reads": [
+    "currentai.signal_goodailist.repo_catalog"
+   ],
    "has_repository_source": false
   },
   {
@@ -364,7 +372,9 @@
     "currentai.entities.repos",
     "currentai.signal_goodailist.repo_catalog"
    ],
-   "in_scope_reads": [],
+   "in_scope_reads": [
+    "currentai.signal_goodailist.repo_catalog"
+   ],
    "has_repository_source": false
   },
   {
@@ -384,7 +394,9 @@
     "currentai.scores.fragility",
     "currentai.signal_goodailist.repo_catalog"
    ],
-   "in_scope_reads": [],
+   "in_scope_reads": [
+    "currentai.signal_goodailist.repo_catalog"
+   ],
    "has_repository_source": false
   },
   {
@@ -399,7 +411,9 @@
     "currentai.metrics.daily",
     "currentai.signal_goodailist.repo_catalog"
    ],
-   "in_scope_reads": [],
+   "in_scope_reads": [
+    "currentai.signal_goodailist.repo_catalog"
+   ],
    "has_repository_source": false
   },
   {
@@ -511,7 +525,7 @@
    "language": "python",
    "internal_reads": [],
    "in_scope_reads": [],
-   "has_repository_source": false
+   "has_repository_source": true
   },
   {
    "table": "currentai.signal_huggingface.artifact_state",

--- a/warehouse/dependencies.yaml
+++ b/warehouse/dependencies.yaml
@@ -111,6 +111,7 @@ dependencies:
   required_by:
   - build/check_artifacts.py
   - warehouse/models/evidence/product_evidence.sql
+  - warehouse/models/identity/artifact_identity_edges.sql
   - warehouse/models/observations/product_adoption_current.sql
   - warehouse/models/signal_github/product_adoption.sql
   verified_revision: 2
@@ -214,3 +215,211 @@ dependencies:
   owner: oso
   verified_at: '2026-08-29'
   content_contract_sha256: fc944c8a4d6faf77bd3ee10b4616e6dc99ea1a1481e0ff94a0ceca29ee9543fc
+- table: currentai.identity.artifact_nodes
+  purpose: identity_graph_nodes
+  expected_grain: one row per (artifact_kind, artifact_key)
+  freshness_requirement: <= 8 days (weekly platform refresh)
+  required_by:
+  - warehouse/models/identity/artifact_identity_edges.sql
+  - warehouse/models/identity/candidates.sql
+  - warehouse/models/identity/digest.sql
+  - warehouse/models/identity/equivalence_edges.sql
+  - warehouse/models/identity/org_edges.sql
+  verified_revision: 3
+  owner: oso
+  files:
+    model: warehouse/models/identity/artifact_nodes.sql
+  mirror:
+    model_id: 0840576c-47d4-4152-bfac-9e38c5272281
+    revision: 3
+    hash: c3e497612e897b7f76f17f540abe9e4ea4db972e43466a5387f5561c5ff1fa9b
+    local_sha256: 457e083c6ebcf0ef2652a5886e6c4405e43b5c51a535f3d8450bfbadeda0a509
+    synced_at: '2026-09-04'
+  platform_schedule:
+    cron: 30 5 * * 0
+    timezone: UTC
+    last_observed_trigger: MANUAL
+- table: currentai.identity.artifact_identity_edges
+  purpose: identity_artifact_pair_evidence
+  expected_grain: one row per (artifact_kind, artifact_id_a, artifact_id_b), artifact_id_a < artifact_id_b
+  freshness_requirement: <= 8 days (weekly platform refresh)
+  required_by:
+  - build/identity_eval.py
+  verified_revision: 4
+  owner: oso
+  files:
+    model: warehouse/models/identity/artifact_identity_edges.sql
+  mirror:
+    model_id: 6e2c9743-16ca-4a56-b84f-c83fd9a37774
+    revision: 4
+    hash: a37c47d1a980b4465467d6171785772978fe6b56b1a9e5a413742bfea5573877
+    local_sha256: 094c313884e48e6f3b9264004ba4dd766f48d2bfefd6ee9c305410f01b60dfd4
+    synced_at: '2026-09-04'
+  platform_schedule:
+    cron: 30 5 * * 0
+    timezone: UTC
+    last_observed_trigger: MANUAL
+- table: currentai.identity.candidates
+  purpose: identity_review_candidates
+  expected_grain: one row per candidate_key
+  freshness_requirement: <= 8 days (weekly platform refresh)
+  required_by:
+  - warehouse/models/identity/digest.sql
+  - warehouse/models/identity/membership_edges.sql
+  verified_revision: 3
+  owner: oso
+  files:
+    model: warehouse/models/identity/candidates.sql
+  mirror:
+    model_id: fbe4495a-8908-4e04-9269-1727d88a0bf5
+    revision: 3
+    hash: 7cffa8f8d5331e4207ceb7fcdd7e5117cd8a17376d0a941f469a74b5fe43a893
+    local_sha256: 1ab19f1712401ea280bef97d68bdce79fcf584a38ca57fbff7ca53a68c157786
+    synced_at: '2026-09-04'
+  platform_schedule:
+    cron: 30 5 * * 0
+    timezone: UTC
+    last_observed_trigger: MANUAL
+- table: currentai.identity.membership_edges
+  purpose: identity_product_membership
+  expected_grain: one row per (artifact_kind, artifact_id, product_tier, product_slug)
+  freshness_requirement: <= 8 days (weekly platform refresh)
+  required_by:
+  - build/identity_eval.py
+  - warehouse/models/identity/digest.sql
+  verified_revision: 2
+  owner: oso
+  files:
+    model: warehouse/models/identity/membership_edges.sql
+  mirror:
+    model_id: cb3be49c-a049-4874-885b-f940a263632c
+    revision: 2
+    hash: 090307bd5a58796d872c4aa6de1642cf94d407bcc3a8f5bd25ca8a9768258dc8
+    local_sha256: 2caaded893310531eccddb0bd49c59bb6b02435ea0dca2174518bc394e75fa61
+    synced_at: '2026-09-04'
+  platform_schedule:
+    cron: 30 5 * * 0
+    timezone: UTC
+    last_observed_trigger: MANUAL
+- table: currentai.identity.equivalence_edges
+  purpose: identity_equivalence_evidence
+  expected_grain: one row per (candidate_key, product_tier, product_slug)
+  freshness_requirement: <= 8 days (weekly platform refresh)
+  required_by:
+  - build/identity_eval.py
+  - warehouse/models/identity/digest.sql
+  verified_revision: 5
+  owner: oso
+  files:
+    model: warehouse/models/identity/equivalence_edges.sql
+  mirror:
+    model_id: 10fc9fc9-799b-454b-bead-6b7fb91e2123
+    revision: 5
+    hash: c9bca213c7442ee20a62fdb7725299d2b8b10c34777efb7e1814a9391fc1fd92
+    local_sha256: d1d4c3e5400bf4b365020be262381320d4927f8afe22cceefacca60b82ad4342
+    synced_at: '2026-09-04'
+  platform_schedule:
+    cron: 30 5 * * 0
+    timezone: UTC
+    last_observed_trigger: MANUAL
+- table: currentai.identity.org_edges
+  purpose: identity_org_attribution
+  expected_grain: one row per (candidate_key, org_slug)
+  freshness_requirement: <= 8 days (weekly platform refresh)
+  required_by:
+  - build/identity_eval.py
+  - warehouse/models/identity/digest.sql
+  verified_revision: 3
+  owner: oso
+  files:
+    model: warehouse/models/identity/org_edges.sql
+  mirror:
+    model_id: d64df19d-4f58-46db-89d4-83d8dad206eb
+    revision: 3
+    hash: fddb77887404396590f3855f9cbe606d0092f38a91f9d0c389acde26afa80b64
+    local_sha256: 18b943bbd141beda97cc3417fa32dbca072ac7aa8a8b3e880a234ec2b5c07ebe
+    synced_at: '2026-09-04'
+  platform_schedule:
+    cron: 30 5 * * 0
+    timezone: UTC
+    last_observed_trigger: MANUAL
+- table: currentai.identity.digest
+  purpose: identity_review_digest
+  expected_grain: one row per (sweep_week, item_id)
+  freshness_requirement: <= 8 days (weekly platform refresh)
+  required_by:
+  - build/identity_digest.py
+  verified_revision: 4
+  owner: oso
+  files:
+    model: warehouse/models/identity/digest.sql
+  mirror:
+    model_id: 8c2cdffc-58c7-4ea3-b90f-eef0e5c8cca3
+    revision: 4
+    hash: 9a013b01ab3daf786da07904d32ded934402195f898403177f8baccbdc39fddd
+    local_sha256: cd186745cff120b655448464024692de513c1fb258edd8403e1f6e3e005a7145
+    synced_at: '2026-09-04'
+  platform_schedule:
+    cron: 30 5 * * 0
+    timezone: UTC
+    last_observed_trigger: MANUAL
+- table: currentai.signal_hfhub.model_universe
+  purpose: huggingface_hub_candidate_universe
+  expected_grain: one row per Hub model repo (hf_id) with downloads_30d >= 1000 at fetch time
+  freshness_requirement: <= 8 days (weekly platform refresh)
+  required_by:
+  - warehouse/models/identity/artifact_nodes.sql
+  verified_revision: 3
+  owner: oso
+  files:
+    model: warehouse/models/signal_hfhub/model_universe.py
+  mirror:
+    model_id: b0f248d5-1f9e-41dd-9344-8a244969d5d6
+    revision: 3
+    hash: 538356e638af218bdf615c71355ca404cd99c25a7c0e6d2632d1724e25570b6e
+    local_sha256: 7902a1d8138d49a401292c51552632c7fbb32cd8cbe0f947d2efe2db0863de0f
+    synced_at: '2026-09-04'
+  platform_schedule:
+    cron: 30 1 * * 0
+    timezone: UTC
+    last_observed_trigger: null
+- table: currentai.signal_openrouter.models
+  purpose: openrouter_candidate_enrichment
+  expected_grain: one row per model
+  freshness_requirement: <= 8 days (weekly platform refresh)
+  required_by:
+  - warehouse/models/identity/candidates.sql
+  verified_revision: 2
+  owner: oso
+  files:
+    model: warehouse/models/signal_openrouter/models.py
+  mirror:
+    model_id: 5c77342a-b208-4b9f-b02e-593c2ec31420
+    revision: 2
+    hash: 6a71c8375494620b0fc9a39c958eba2f74bc2e2b8156be82a3ae1fe00df6e36d
+    local_sha256: f5c44e607701bfa420b300b9801464d8dbb677900fb574e40f9a759b1934adf3
+    synced_at: '2026-09-04'
+  platform_schedule:
+    cron: 0 1 * * 0
+    timezone: UTC
+    last_observed_trigger: null
+- table: currentai.signal_goodailist.repo_catalog
+  purpose: github_candidate_universe
+  expected_grain: one row per tracked GitHub repo (repo)
+  freshness_requirement: <= 8 days (weekly platform refresh)
+  required_by:
+  - warehouse/models/identity/artifact_nodes.sql
+  verified_revision: 4
+  owner: oso
+  files:
+    model: warehouse/models/signal_goodailist/repo_catalog.py
+  mirror:
+    model_id: c7d3a3d9-578c-4c54-8ccf-71879bdd43d2
+    revision: 4
+    hash: 5a6e622459ef9cf8edaa80953eaff8dc15e093649493831485f49d3a794c4c57
+    local_sha256: eaee5981530529fc1cbd6c21d2d18b7019b0ed2c15751f43b2d84f4f4bb0ae00
+    synced_at: '2026-09-04'
+  platform_schedule:
+    cron: 0 1 * * 0
+    timezone: UTC
+    last_observed_trigger: SCHEDULED

--- a/warehouse/models/identity/artifact_identity_edges.sql
+++ b/warehouse/models/identity/artifact_identity_edges.sql
@@ -1,0 +1,117 @@
+-- ────── PLATFORM MIRROR (read-only) ──────
+-- A snapshot of a model that runs on the OSO platform to build one of the gap map's
+-- tables. The platform is the source of truth; nothing deploys from this copy, and
+-- editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+-- currentai.identity.artifact_identity_edges
+--
+-- Grain: one row per (artifact_kind, artifact_id_a, artifact_id_b), with artifact_id_a <
+-- artifact_id_b (raw string order on the DECLARED spelling, not the folded artifact_key --
+-- see build/identity.py's docstring on why declared spelling is kept). An edge says "these two
+-- declared spellings name the same underlying artifact"; it is deliberately NOT the same
+-- question identity_equivalence_edges answers ("this artifact belongs to this product").
+--
+-- candidate_tier: the LOWER-ranked (worse) tier of the two spellings, rank head=1 < tail=2 <
+-- pool=3 -- pool if either side is pool, else tail if either is tail, else head. Looked up by
+-- finding each spelling's own node in currentai.identity.artifact_nodes (CONTAINS(also_seen_as,
+-- spelling)), not the pair's shared node -- for a fold_pairs row both spellings share one node
+-- (so this is trivially that node's best_tier), but a gh_redirects row can pair spellings from
+-- TWO different nodes (repo and resolved_repo can fold to different artifact_keys). A spelling
+-- with no matching node at all (confirmed live: a redirect's resolved_repo can be untracked --
+-- not declared, not in the pool feed) defaults to 'pool', the lowest-priority tier, since an
+-- untracked spelling carries no stronger claim than the pool.
+--
+-- Confidence: GREATEST(evidence...) - SUM(penalties), clamped with
+-- GREATEST(0, LEAST(1, ...)); `penalties` is ARRAY(VARCHAR) (a penalty reason per applied
+-- penalty, matching the eval's contract on all four edge tables); no penalty source is defined
+-- for this model today so it is always the empty array, kept as a column so a future penalty
+-- source needs no schema change.
+--
+-- Evidence sources:
+--   1.0  fold-collapse (non-homepage kinds) -- two distinct declared spellings that fold to the
+--        same artifact_key in currentai.identity.artifact_nodes.also_seen_as (structural:
+--        casing/punctuation only, never a different underlying repo).
+--   0.5  fold-collapse between two homepage spellings (capped) -- for artifact_kind = 'homepage',
+--        artifact_key is the full canonical URL lowercased (host lowercased, `www.` stripped,
+--        path kept, no trailing slash -- see identity_artifact_nodes.sql's header, corrected
+--        2026-09-04; it used to fold to the bare host). Two spellings that fold together are
+--        therefore the same URL up to case, not merely the same domain, and two products at
+--        `acme.com/a` and `acme.com/b` now correctly never pair here at all. Per reviewer
+--        ruling a homepage pair stays weak corroborating evidence: capped at 0.5, method
+--        'homepage_domain' (never 'fold_collapse'), so it can never alone cross the 0.99/1.0
+--        thresholds or suppress a second candidate. It has no other evidence source to combine
+--        with in THIS table (github_redirect only ever applies to artifact_kind = 'github'), so
+--        the "+0.1 on top of other evidence, clamped to 1" stacking rule never triggers here in
+--        practice; it is documented for readers who add a second homepage-kind evidence source
+--        later.
+--   0.9  GitHub redirect -- currentai.signal_github.artifact_state (a dependency contract) marks
+--        resolved_via_redirect = TRUE with a resolved_repo distinct from the declared repo. Below
+--        1.0 because it is inferred from an HTTP redirect, not a human ruling in the resolution
+--        ledger (that ruling, when it exists, lands in identity_equivalence_edges instead, since
+--        it is a product-equivalence verdict, not an artifact-pair fact).
+--
+-- registry.product_aliases (listed as an input in the design table) is NOT used here: its
+-- `alias` column is an alternate PRODUCT slug, not a second artifact identifier, so it carries
+-- no artifact-pair evidence at this grain. An alias-driven artifact equivalence, if one is ever
+-- declared, belongs in identity_equivalence_edges (candidate_key -> product_slug), not here.
+
+WITH fold_pairs AS (
+  SELECT
+    n.artifact_kind,
+    a.spelling AS artifact_id_a,
+    b.spelling AS artifact_id_b,
+    CASE WHEN n.artifact_kind = 'homepage' THEN 0.5 ELSE 1.0 END AS evidence,
+    CASE WHEN n.artifact_kind = 'homepage' THEN 'homepage_domain' ELSE 'fold_collapse' END AS method
+  FROM currentai.identity.artifact_nodes n
+  CROSS JOIN UNNEST(n.also_seen_as) AS a(spelling)
+  CROSS JOIN UNNEST(n.also_seen_as) AS b(spelling)
+  WHERE a.spelling < b.spelling
+),
+
+gh_redirects AS (
+  SELECT
+    'github' AS artifact_kind,
+    LEAST(repo, resolved_repo) AS artifact_id_a,
+    GREATEST(repo, resolved_repo) AS artifact_id_b,
+    0.9 AS evidence,
+    'github_redirect' AS method
+  FROM currentai.signal_github.artifact_state
+  WHERE resolved_via_redirect = TRUE
+    AND resolved_repo IS NOT NULL
+    AND resolved_repo <> repo
+),
+
+combined AS (
+  SELECT * FROM fold_pairs
+  UNION ALL
+  SELECT * FROM gh_redirects
+),
+
+tiered AS (
+  SELECT
+    c.*,
+    COALESCE(na.best_tier, 'pool') AS tier_a,
+    COALESCE(nb.best_tier, 'pool') AS tier_b
+  FROM combined c
+  LEFT JOIN currentai.identity.artifact_nodes na
+    ON na.artifact_kind = c.artifact_kind AND CONTAINS(na.also_seen_as, c.artifact_id_a)
+  LEFT JOIN currentai.identity.artifact_nodes nb
+    ON nb.artifact_kind = c.artifact_kind AND CONTAINS(nb.also_seen_as, c.artifact_id_b)
+)
+
+SELECT
+  CAST(artifact_kind AS VARCHAR) AS artifact_kind,
+  CAST(artifact_id_a AS VARCHAR) AS artifact_id_a,
+  CAST(artifact_id_b AS VARCHAR) AS artifact_id_b,
+  CAST(
+    CASE
+      WHEN 'pool' IN (MAX(tier_a), MAX(tier_b)) THEN 'pool'
+      WHEN 'tail' IN (MAX(tier_a), MAX(tier_b)) THEN 'tail'
+      ELSE 'head'
+    END AS VARCHAR
+  ) AS candidate_tier,
+  CAST(GREATEST(0, LEAST(1, MAX(evidence) - 0)) AS DOUBLE) AS confidence,
+  ARRAY_SORT(ARRAY_DISTINCT(ARRAY_AGG(method))) AS method,
+  CAST(ARRAY[] AS ARRAY(VARCHAR)) AS penalties
+FROM tiered
+GROUP BY artifact_kind, artifact_id_a, artifact_id_b

--- a/warehouse/models/identity/artifact_nodes.sql
+++ b/warehouse/models/identity/artifact_nodes.sql
@@ -1,0 +1,152 @@
+-- ────── PLATFORM MIRROR (read-only) ──────
+-- A snapshot of a model that runs on the OSO platform to build one of the gap map's
+-- tables. The platform is the source of truth; nothing deploys from this copy, and
+-- editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+-- currentai.identity.artifact_nodes
+--
+-- Grain: one row per (artifact_kind, artifact_key). `artifact_key` is the FOLDED comparison
+-- form -- see build/identity.py::fold_for_proposal, which this SQL mirrors exactly:
+--   github, huggingface_model, huggingface_dataset  -> LOWER(x)
+--   pypi, crates                                    -> REGEXP_REPLACE(LOWER(x), '[-_.]+', '-')
+--   homepage                                        -> LOWER(x)
+-- A homepage artifact_id is the FULL canonical URL as the repo publishes it -- scheme-less,
+-- host lowercased, leading `www.` stripped, PATH KEPT as declared, no trailing slash (see
+-- build/identity.py::_homepage_canonical). Its fold is that whole string lowercased
+-- (fold_for_proposal's `homepage -> c.lower()`), NOT the bare host: two distinct products at
+-- `acme.com/a` and `acme.com/b` are legitimately different homepage artifacts, and collapsing
+-- them onto the host made every homepage key disagree with the repo's truth key. Verified
+-- 2026-09-04 against the 27 declared homepage rows in currentai.registry.tail_products
+-- (currentai.registry.product_artifacts declares none): every published id is already
+-- scheme-less with no `www.` prefix, so LOWER() alone reproduces fold_for_proposal exactly.
+-- Anything downstream that needs the bare HOST extracts it from the key itself
+-- (identity_org_edges.sql does; do not reintroduce a host-only fold here to serve it).
+-- `artifact_id` keeps the DECLARED spelling (never folded): identity.py's own docstring is
+-- explicit that the declared spelling must survive because downstream joins against externally
+-- sourced signal tables (GitHub's own casing, PyPI's own package name) are on raw equality.
+-- Where more than one declared spelling folds to the same artifact_key, one representative
+-- artifact_id is kept -- chosen by tier priority (head, then tail, then pool) and then
+-- alphabetically -- and every distinct spelling seen is kept in `also_seen_as` so
+-- identity_artifact_identity_edges can emit the fold-collapse pairs.
+--
+-- Inputs:
+--   currentai.registry.product_artifacts   (tier=head; every row is a declared artifact)
+--   currentai.registry.tail_products       (tier=tail; every row is a declared artifact)
+--   currentai.signal_hfhub.model_universe  (kind=huggingface_model, tier=pool; undeclared hub models)
+--   currentai.signal_goodailist.repo_catalog (kind=github, tier=pool; undeclared GitHub repos)
+-- currentai.signal_openrouter.models is NOT a node source here (it names `provider_model`
+-- identifiers on OpenRouter's own namespace, not a first-class artifact kind in build/identity.py
+-- -- design table row for identity.artifact_nodes lists it as "as provider_model evidence only,
+-- not a node kind"); it is read by identity_candidates.sql instead.
+--
+-- Verified on deploy (2026-09-03, ListTablesForDataset): signal_hfhub.model_universe
+-- (hf_id, downloads_30d BIGINT, likes BIGINT, fetched_at TIMESTAMP) and
+-- signal_goodailist.repo_catalog (repo, stars BIGINT, source_updated_at TIMESTAMP) match the
+-- columns read below; no drift.
+
+WITH declared AS (
+  SELECT
+    artifact_kind,
+    artifact_id,
+    1 AS tier_rank,
+    'head' AS tier,
+    product_slug AS declared_by
+  FROM currentai.registry.product_artifacts
+
+  UNION ALL
+
+  SELECT
+    artifact_kind,
+    artifact_id,
+    2 AS tier_rank,
+    'tail' AS tier,
+    slug AS declared_by
+  FROM currentai.registry.tail_products
+),
+
+hub AS (
+  SELECT
+    'huggingface_model' AS artifact_kind,
+    hf_id AS artifact_id,
+    3 AS tier_rank,
+    'pool' AS tier,
+    CAST(NULL AS VARCHAR) AS declared_by,
+    downloads_30d,
+    likes,
+    CAST(NULL AS BIGINT) AS stars,
+    CAST(fetched_at AS TIMESTAMP(6)) AS observed_at
+  FROM currentai.signal_hfhub.model_universe
+),
+
+gh AS (
+  SELECT
+    'github' AS artifact_kind,
+    repo AS artifact_id,
+    3 AS tier_rank,
+    'pool' AS tier,
+    CAST(NULL AS VARCHAR) AS declared_by,
+    CAST(NULL AS BIGINT) AS downloads_30d,
+    CAST(NULL AS BIGINT) AS likes,
+    stars,
+    CAST(source_updated_at AS TIMESTAMP(6)) AS observed_at
+  FROM currentai.signal_goodailist.repo_catalog
+),
+
+unioned AS (
+  SELECT
+    artifact_kind, artifact_id, tier_rank, tier, declared_by,
+    CAST(NULL AS BIGINT) AS downloads_30d,
+    CAST(NULL AS BIGINT) AS likes,
+    CAST(NULL AS BIGINT) AS stars,
+    CAST(NULL AS TIMESTAMP(6)) AS observed_at
+  FROM declared
+
+  UNION ALL
+
+  SELECT artifact_kind, artifact_id, tier_rank, tier, declared_by,
+         downloads_30d, likes, stars, observed_at
+  FROM hub
+
+  UNION ALL
+
+  SELECT artifact_kind, artifact_id, tier_rank, tier, declared_by,
+         downloads_30d, likes, stars, observed_at
+  FROM gh
+),
+
+keyed AS (
+  SELECT
+    *,
+    CASE
+      WHEN artifact_kind IN ('github', 'huggingface_model', 'huggingface_dataset')
+        THEN LOWER(artifact_id)
+      WHEN artifact_kind IN ('pypi', 'crates')
+        THEN REGEXP_REPLACE(LOWER(artifact_id), '[-_.]+', '-')
+      -- homepage folds the WHOLE canonical URL, path included -- see the header. The declared
+      -- id already arrives scheme-less and `www.`-free, so LOWER() is the whole fold.
+      WHEN artifact_kind = 'homepage'
+        THEN LOWER(artifact_id)
+      ELSE LOWER(artifact_id)
+    END AS artifact_key
+  FROM unioned
+)
+
+SELECT
+  CAST(artifact_kind AS VARCHAR) AS artifact_kind,
+  CAST(artifact_key AS VARCHAR) AS artifact_key,
+  -- representative declared spelling: lowest tier_rank (head < tail < pool), then alphabetical.
+  -- Trino has no WITHIN GROUP for array_agg -- the sort goes inside the aggregate's arg list.
+  CAST(ARRAY_AGG(artifact_id ORDER BY tier_rank, artifact_id)[1] AS VARCHAR) AS artifact_id,
+  CAST(CASE MIN(tier_rank)
+    WHEN 1 THEN 'head'
+    WHEN 2 THEN 'tail'
+    ELSE 'pool'
+  END AS VARCHAR) AS best_tier,
+  ARRAY_SORT(ARRAY_DISTINCT(ARRAY_AGG(artifact_id))) AS also_seen_as,
+  ARRAY_DISTINCT(ARRAY_AGG(declared_by) FILTER (WHERE declared_by IS NOT NULL)) AS declared_by,
+  MAX(downloads_30d) AS downloads_30d,
+  MAX(likes) AS likes,
+  MAX(stars) AS stars,
+  MAX(observed_at) AS last_observed_at
+FROM keyed
+GROUP BY artifact_kind, artifact_key

--- a/warehouse/models/identity/candidates.sql
+++ b/warehouse/models/identity/candidates.sql
@@ -1,0 +1,123 @@
+-- ────── PLATFORM MIRROR (read-only) ──────
+-- A snapshot of a model that runs on the OSO platform to build one of the gap map's
+-- tables. The platform is the source of truth; nothing deploys from this copy, and
+-- editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+-- currentai.identity.candidates
+--
+-- Grain: one row per candidate_key (the resolved set's primary artifact -- i.e. an
+-- currentai.identity.artifact_nodes row with no declared spelling at all, best_tier = 'pool').
+-- candidate_key = <artifact_kind> || ':' || <artifact_key> (the folded comparison form of
+-- artifact_id, see build/identity.py::fold_for_proposal). The kind prefix is required so that
+-- candidate_key is globally unique across artifact kinds -- two different kinds can fold to the
+-- same bare string (e.g. a homepage host and a PyPI name) -- and so every downstream reader
+-- (equivalence_edges, org_edges, digest) can recover artifact_kind from candidate_key alone.
+-- `artifact_key` (unprefixed) is kept as its own column for kind-scoped joins and for readers
+-- that already have artifact_kind in hand.
+--
+-- Inputs: currentai.identity.artifact_nodes, filtered to best_tier = 'pool' (nodes minus
+-- anything declared in currentai.registry.product_artifacts or currentai.registry.tail_products
+-- -- a node with ANY declared spelling has best_tier head/tail and is excluded here).
+-- currentai.signal_openrouter.models is read only to enrich `source` for a huggingface_model
+-- candidate that is ALSO listed on OpenRouter under the same id; it never creates a candidate
+-- row of its own -- OpenRouter's `provider_model` is not a first-class artifact kind in
+-- build/identity.py (see the header of identity_artifact_nodes.sql).
+--
+-- first_seen / last_evidence_change / evidence_kinds: added so identity_digest.sql can derive
+-- park/resurface state without reading its own prior output (no model may read its own prior
+-- materialization). first_seen is the earliest observation of the artifact across its node
+-- inputs (currentai.identity.artifact_nodes.last_observed_at is itself a MAX over fetched_at /
+-- source_updated_at, so it is reused directly rather than re-deriving a MIN here -- there is no
+-- earlier per-fetch timestamp exposed at the node grain to MIN over). last_evidence_change is the
+-- latest of: the node's last_observed_at, and the resolution_ledger's decided_on for any ruling
+-- naming this candidate (a ledger ruling is evidence of a state change even when it does not
+-- itself become a digest item).
+--
+-- evidence_kinds is DELIBERATELY EMPTY here. It was originally the distinct method vocabulary
+-- seen for this candidate_key across the three edge tables (membership, equivalence, org), but
+-- currentai.identity.membership_edges reads currentai.identity.candidates (for its name-match
+-- evidence), so reading membership_edges back from this model is a genuine circular dependency in
+-- the model DAG -- not a staleness question the platform can schedule around. The cycle is broken
+-- HERE, on the upstream side, because the only consumer of evidence_kinds is
+-- identity_digest.sql, which already joins all three edge tables and can aggregate the method
+-- vocabulary itself with no cycle. The column stays in the schema as an empty ARRAY(VARCHAR) so
+-- the digest's park/resurface test (evidence_kinds = ARRAY['name_match']) needs no schema change
+-- when it is moved there. Until the digest does that aggregation, park/resurface eligibility will
+-- read as "no evidence yet" for every candidate.
+--
+-- TODO verify on deploy: whether currentai.signal_openrouter.models.model_id namespaces line up
+-- with currentai.signal_hfhub.model_universe.hf_id closely enough for a raw equality join to be
+-- useful; sampled rows on 2026-09-03 suggest OpenRouter's `<provider>/<slug>` ids do not
+-- generally match Hub `<namespace>/<repo>` ids, so this join may contribute few or zero rows
+-- today -- it is left in as a documented no-harm enrichment, not load-bearing for the grain.
+
+WITH pool_nodes AS (
+  SELECT
+    artifact_kind,
+    artifact_key,
+    artifact_kind || ':' || artifact_key AS candidate_key,
+    artifact_id,
+    best_tier,
+    downloads_30d,
+    likes,
+    stars,
+    last_observed_at
+  FROM currentai.identity.artifact_nodes
+  WHERE best_tier = 'pool'
+),
+
+openrouter_seen AS (
+  SELECT DISTINCT LOWER(model_id) AS candidate_key_lower
+  FROM currentai.signal_openrouter.models
+),
+
+-- one row per candidate_key naming every ledger ruling that mentions it, folded the same way
+-- artifact_nodes/candidates fold artifact_id -- duplicated here for the same reason
+-- identity_equivalence_edges.sql duplicates it: Trino has no shared macro.
+ledger_evidence_change AS (
+  SELECT
+    artifact_kind || ':' ||
+      CASE
+        WHEN artifact_kind IN ('github', 'huggingface_model', 'huggingface_dataset')
+          THEN LOWER(artifact_id)
+        WHEN artifact_kind IN ('pypi', 'crates')
+          THEN REGEXP_REPLACE(LOWER(artifact_id), '[-_.]+', '-')
+        -- homepage folds the WHOLE canonical URL, path included -- the fold must stay
+        -- byte-identical to identity_artifact_nodes.sql's `keyed` CTE, or a ledger ruling
+        -- naming a homepage would key to a candidate that does not exist. Inert today
+        -- (resolution_ledger carries only github rows, verified 2026-09-04).
+        WHEN artifact_kind = 'homepage'
+          THEN LOWER(artifact_id)
+        ELSE LOWER(artifact_id)
+      END AS candidate_key,
+    MAX(CAST(decided_on AS TIMESTAMP(6))) AS last_ruling_at
+  FROM currentai.registry.resolution_ledger
+  GROUP BY 1
+)
+
+SELECT
+  CAST(p.candidate_key AS VARCHAR) AS candidate_key,
+  CAST(p.artifact_kind AS VARCHAR) AS artifact_kind,
+  CAST(p.artifact_key AS VARCHAR) AS artifact_key,
+  CAST(p.artifact_id AS VARCHAR) AS artifact_id,
+  CAST(
+    CASE p.artifact_kind
+      WHEN 'huggingface_model' THEN 'signal_hfhub.model_universe'
+      WHEN 'github' THEN 'signal_goodailist.repo_catalog'
+      ELSE 'unknown'
+    END ||
+      (CASE WHEN o.candidate_key_lower IS NOT NULL THEN '+signal_openrouter.models' ELSE '' END)
+    AS VARCHAR) AS source,
+  CAST(p.last_observed_at AS TIMESTAMP(6)) AS first_seen,
+  CAST(GREATEST(
+    p.last_observed_at,
+    COALESCE(lec.last_ruling_at, p.last_observed_at)
+  ) AS TIMESTAMP(6)) AS last_evidence_change,
+  -- always empty: see the header note on the membership_edges <-> candidates cycle
+  CAST(ARRAY[] AS ARRAY(VARCHAR)) AS evidence_kinds,
+  p.downloads_30d,
+  p.stars
+FROM pool_nodes p
+LEFT JOIN openrouter_seen o
+  ON p.artifact_kind = 'huggingface_model' AND LOWER(p.artifact_key) = o.candidate_key_lower
+LEFT JOIN ledger_evidence_change lec ON lec.candidate_key = p.candidate_key

--- a/warehouse/models/identity/digest.sql
+++ b/warehouse/models/identity/digest.sql
@@ -1,0 +1,384 @@
+-- ────── PLATFORM MIRROR (read-only) ──────
+-- A snapshot of a model that runs on the OSO platform to build one of the gap map's
+-- tables. The platform is the source of truth; nothing deploys from this copy, and
+-- editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+-- currentai.identity.digest
+--
+-- Grain: one row per (sweep_week, item_id). item_id identifies a single reviewable claim drawn
+-- from the three edge tables:
+--   'membership:<artifact_kind>:<artifact_id>-><product_tier>:<product_slug>'
+--   'equivalence:<candidate_key>-><product_tier>:<product_slug>'
+--   'org:<candidate_key>-><org_slug>'
+-- The relation prefix is load-bearing, not decoration: without it a membership item and an
+-- equivalence item over the same artifact and product produce byte-identical item_ids, because
+-- artifact_id and artifact_key are the same string for an already-lowercase repo. That collided
+-- on 33 item_ids live (2026-09-04) and broke the stated grain.
+-- Declared edges (method = ['declared'] or ['resolution_ledger'] or ['product_alias']) are NOT
+-- reviewable claims -- a human already wrote them down -- so this model excludes any item whose
+-- method set is entirely made of those authoritative sources; it carries only the edges that
+-- still need a human look.
+-- Caveat on 'product_alias', worth a maintainer ruling: as of 2026-09-04 that source no longer
+-- carries confidence 1.0. identity_equivalence_edges.sql caps it at 0.9 because the alias ->
+-- product half is declared but the alias -> node half is matched by name, and the name match is
+-- namespace-blind (`tiny-random/phi-4` earns the same alias edge as `microsoft/phi-4`). The
+-- exclusion below is unchanged, so those 46 rows still never reach a reviewer. If the cap is
+-- right then the exclusion is arguably wrong; both cannot be. Left as ruled rather than changed
+-- unilaterally, because dropping 'product_alias' from the exclusion list would push items into
+-- the 25-slot weekly cap and change what a reviewer sees.
+--
+-- Tier scope: identity_equivalence_edges.sql and identity_org_edges.sql now compute over
+-- currentai.identity.artifact_nodes -- ALL tiers (head, tail, pool), not just undeclared pool
+-- candidates -- per the reviewer ruling that the replay eval needs to compare edges against
+-- artifacts humans already declared, not only against the undeclared pool. Both tables carry the
+-- source artifact's tier as `candidate_tier`. This model still reviews pool-tier items only: a
+-- head/tail artifact's equivalence or org relation is already established by the registry
+-- declaration that put it in that tier, so it is not a reviewable claim here. `equivalence_items`
+-- and `org_items` below both filter `candidate_tier = 'pool'`.
+--
+-- Shape follows the design's digest schema exactly: item_id, relation, sweep_week,
+-- candidate_key, left and right as canonical (kind, id) pairs, confidence, method, evidence[],
+-- penalties[], proposed_action, blast_radius, tiebreak, options, default_if_ignored.
+--   relation      'membership' | 'equivalence' | 'org', matching the item_id prefix above.
+--   candidate_key <artifact_kind>:<artifact_key> of the artifact side (see identity_candidates.sql).
+--   left          ROW(kind, id) for the artifact side: kind = artifact_kind, id = the declared
+--                 artifact_id for membership items, or the unprefixed folded artifact_key for
+--                 equivalence/org items (those edge tables carry no declared spelling).
+--   right         ROW(kind, id) for the other side: ('product', product_slug) for membership and
+--                 equivalence, ('org', org_slug) for org.
+--   evidence      Per-item evidence strings. The three edge tables pre-aggregate method into one
+--                 sorted/distinct array per row (no per-method confidence survives that
+--                 aggregation), so evidence[] here is method[] verbatim. Kept as its own column
+--                 because the design and the eval contract both name it separately.
+--   proposed_action 'confirm_<relation>_edge' -- the single action this item's evidence points
+--                 toward; `options` (below) is what a reviewer can actually choose.
+--   options       ['confirm', 'reject', 'park'] for every relation today. No relation-specific
+--                 vocabulary is defined by the design brief, so this model does not invent one.
+--   default_if_ignored always the literal 'no edge' -- an unreviewed item never gets promoted to
+--                 an edge by default.
+--
+-- blast_radius (INTEGER, categorical, per reviewer ruling -- NOT downloads + stars):
+--   3  the item is a membership edge, scoring_bearing = TRUE, product_tier = 'head'
+--      (a ruling here would move a score or a band).
+--   2  the item is an equivalence edge onto a head-tier product, OR the underlying candidate's
+--      downloads_30d >= 1000, OR its stars >= 1000 (a promotion decision -- could move a stage).
+--   1  otherwise.
+-- tiebreak (BIGINT, separate column, used after blast_radius and before confidence in ranking) =
+--   COALESCE(downloads_30d, 0) + COALESCE(stars, 0) on the underlying artifact/candidate.
+--   BIGINT, not INTEGER (changed 2026-09-04). Both inputs are BIGINT columns on
+--   currentai.identity.candidates and the sum is a raw download count: the live maximum is
+--   246,135,287, already 11% of the INT32 range, so a corpus one order of magnitude larger turns
+--   the cast into a hard run failure rather than a degraded value. Nothing downstream reads it as
+--   a 32-bit value -- it is a sort key only.
+--
+-- Candidate context: downloads_30d, stars and first_seen are read from
+-- currentai.identity.candidates by candidate_key -- for membership items, candidate_key is
+-- derived by folding the artifact via currentai.identity.artifact_nodes.
+--
+-- evidence_kinds and last_evidence_change are NOT read from currentai.identity.candidates.
+-- candidates.evidence_kinds tried to aggregate membership_edges' method vocabulary, but
+-- membership_edges' name_match evidence itself reads currentai.identity.candidates -- a genuine
+-- cycle in the model DAG (candidates -> membership_edges -> candidates), so the platform can
+-- never resolve it and candidates.evidence_kinds is deployed as a permanently empty array. This
+-- model breaks the cycle on the read side: it aggregates the method vocabulary itself, straight
+-- from the three edge tables it already joins, in the `candidate_evidence` CTE below -- and it
+-- never reads its own prior output either, so no model in this dataset reads its own prior
+-- materialization. last_evidence_change is the MAX of whatever per-edge timestamp this model can
+-- reach (today: only currentai.identity.artifact_nodes.last_observed_at, reachable for membership
+-- items via the same fold-join used for candidate_key), falling back to the candidate's own
+-- last_evidence_change when nothing edge-side is reachable.
+--
+-- sweep_week = sweep_week_start = DATE_TRUNC('week', CURRENT_DATE) AS DATE. This model runs
+-- weekly (Sunday 05:30 UTC, see docs/operations/deploy-models.md), so each run's CURRENT_DATE
+-- lands in exactly one week.
+--
+-- NOTE for a future revision: identity_artifact_identity_edges.sql now carries a `candidate_tier`
+-- column (revision 3), so a future version of this model can join it consistently with the other
+-- two edge tables. It is not read here yet.
+--
+-- state:
+--   parked      evidence_kinds = ARRAY['name_match'] (the weakest signal -- no other evidence has
+--               ever attached to this candidate) AND last_evidence_change is more than 7 days
+--               old AND first_seen is less than 56 days old. Held back from the review queue.
+--   resurfaced  name-match-only, but EITHER first_seen >= 56 days ago (resurfaced_reason =
+--               'age') OR last_evidence_change is within the last 7 days (resurfaced_reason =
+--               'evidence_changed'). Competes for the same 25 weekly slots as `active`.
+--   active      not name-match-only (or has no candidate context to test); ranked alongside
+--               `resurfaced` items and capped at 25 rows per sweep_week.
+--   pool        an active- or resurfaced-eligible item that ranked beyond the top 25 this week;
+--               overflow, not reviewed this sweep. resurfaced_reason is NULL for a pool row even
+--               if it was resurfaced-eligible pre-cap -- it did not actually resurface this week.
+-- Cap: ROW_NUMBER() OVER (PARTITION BY sweep_week ORDER BY CASE relation WHEN 'equivalence' THEN
+-- 0 ELSE 1 END, blast_radius DESC, tiebreak DESC, confidence DESC) among state IN
+-- ('active', 'resurfaced')-eligible rows; rank <= 25 keeps its state, rank > 25 becomes 'pool'.
+-- Output is ordered by the same key.
+--
+-- Output casts: explicit CAST on every output column (DATE sweep_week, VARCHAR strings, DOUBLE
+-- confidence, ARRAY(VARCHAR) method/evidence/penalties/options, INTEGER blast_radius, BIGINT
+-- tiebreak). Date arithmetic uses DATE_ADD('day', -N, sweep_week), not the
+-- `date - INTERVAL 'N' DAY` operator form, and the result is cast to TIMESTAMP(6) before
+-- comparing against first_seen/last_evidence_change (both TIMESTAMP(6)).
+
+WITH sweep AS (
+  SELECT CAST(DATE_TRUNC('week', CURRENT_DATE) AS DATE) AS sweep_week
+),
+
+-- Method vocabulary and reachable evidence timestamp per candidate_key, aggregated straight from
+-- the three edge tables (no read of currentai.identity.candidates.evidence_kinds, which is a
+-- permanently empty array -- see the header note above on why). This is the cycle-free
+-- replacement for the aggregation candidates.sql used to do.
+membership_evidence AS (
+  SELECT
+    n.artifact_kind || ':' || n.artifact_key AS candidate_key,
+    meth AS method,
+    n.last_observed_at AS evidence_ts
+  FROM currentai.identity.membership_edges m
+  JOIN currentai.identity.artifact_nodes n
+    ON n.artifact_kind = m.artifact_kind AND CONTAINS(n.also_seen_as, m.artifact_id)
+  CROSS JOIN UNNEST(m.method) AS t(meth)
+),
+
+equivalence_evidence AS (
+  SELECT
+    e.candidate_key,
+    meth AS method,
+    CAST(NULL AS TIMESTAMP(6)) AS evidence_ts
+  FROM currentai.identity.equivalence_edges e
+  CROSS JOIN UNNEST(e.method) AS t(meth)
+),
+
+org_evidence AS (
+  SELECT
+    o.candidate_key,
+    meth AS method,
+    CAST(NULL AS TIMESTAMP(6)) AS evidence_ts
+  FROM currentai.identity.org_edges o
+  CROSS JOIN UNNEST(o.method) AS t(meth)
+),
+
+candidate_evidence AS (
+  SELECT
+    candidate_key,
+    CAST(ARRAY_SORT(ARRAY_DISTINCT(ARRAY_AGG(method))) AS ARRAY(VARCHAR)) AS evidence_kinds,
+    MAX(evidence_ts) AS max_edge_ts
+  FROM (
+    SELECT * FROM membership_evidence
+    UNION ALL
+    SELECT * FROM equivalence_evidence
+    UNION ALL
+    SELECT * FROM org_evidence
+  )
+  GROUP BY candidate_key
+),
+
+membership_items AS (
+  SELECT
+    'membership' AS relation,
+    -- The 'membership:' prefix is load-bearing -- see the header note on the item_id collision.
+    'membership:' || m.artifact_kind || ':' || m.artifact_id || '->' || m.product_tier || ':'
+      || m.product_slug AS item_id,
+    n.artifact_kind || ':' || n.artifact_key AS candidate_key,
+    CAST(ROW(m.artifact_kind, m.artifact_id) AS ROW(kind VARCHAR, id VARCHAR)) AS left_pair,
+    CAST(ROW('product', m.product_slug) AS ROW(kind VARCHAR, id VARCHAR)) AS right_pair,
+    m.confidence,
+    m.method,
+    m.method AS evidence,
+    m.penalties,
+    'confirm_membership_edge' AS proposed_action,
+    (m.scoring_bearing AND m.product_tier = 'head') AS is_blast_3,
+    (m.product_tier = 'head') AS product_is_head,
+    c.downloads_30d,
+    c.stars,
+    COALESCE(c.first_seen, DATE '1970-01-01') AS first_seen,
+    COALESCE(c.last_evidence_change, TIMESTAMP '1970-01-01') AS candidate_last_evidence_change
+  FROM currentai.identity.membership_edges m
+  LEFT JOIN currentai.identity.artifact_nodes n
+    ON n.artifact_kind = m.artifact_kind AND n.artifact_id = m.artifact_id
+  LEFT JOIN currentai.identity.candidates c
+    ON c.candidate_key = n.artifact_kind || ':' || n.artifact_key
+  WHERE NOT (CARDINALITY(m.method) = 1 AND m.method[1] IN ('declared'))
+),
+
+equivalence_items AS (
+  SELECT
+    'equivalence' AS relation,
+    'equivalence:' || e.candidate_key || '->' || e.product_tier || ':' || e.product_slug AS item_id,
+    e.candidate_key,
+    CAST(
+      ROW(
+        e.artifact_kind,
+        COALESCE(c.artifact_key, SUBSTR(e.candidate_key, LENGTH(e.artifact_kind) + 2))
+      ) AS ROW(kind VARCHAR, id VARCHAR)
+    ) AS left_pair,
+    CAST(ROW('product', e.product_slug) AS ROW(kind VARCHAR, id VARCHAR)) AS right_pair,
+    e.confidence,
+    e.method,
+    e.method AS evidence,
+    e.penalties,
+    'confirm_equivalence_edge' AS proposed_action,
+    FALSE AS is_blast_3,
+    (e.product_tier = 'head') AS product_is_head,
+    c.downloads_30d,
+    c.stars,
+    COALESCE(c.first_seen, DATE '1970-01-01') AS first_seen,
+    COALESCE(c.last_evidence_change, TIMESTAMP '1970-01-01') AS candidate_last_evidence_change
+  FROM currentai.identity.equivalence_edges e
+  LEFT JOIN currentai.identity.candidates c ON c.candidate_key = e.candidate_key
+  WHERE e.candidate_tier = 'pool'
+    AND NOT (
+      CARDINALITY(e.method) = 1
+      AND e.method[1] IN ('resolution_ledger', 'product_alias')
+    )
+),
+
+org_items AS (
+  SELECT
+    'org' AS relation,
+    'org:' || o.candidate_key || '->' || o.org_slug AS item_id,
+    o.candidate_key,
+    CAST(
+      ROW(
+        o.artifact_kind,
+        COALESCE(c.artifact_key, SUBSTR(o.candidate_key, LENGTH(o.artifact_kind) + 2))
+      ) AS ROW(kind VARCHAR, id VARCHAR)
+    ) AS left_pair,
+    CAST(ROW('org', o.org_slug) AS ROW(kind VARCHAR, id VARCHAR)) AS right_pair,
+    o.confidence,
+    o.method,
+    o.method AS evidence,
+    o.penalties,
+    'confirm_org_edge' AS proposed_action,
+    FALSE AS is_blast_3,
+    FALSE AS product_is_head,
+    c.downloads_30d,
+    c.stars,
+    COALESCE(c.first_seen, DATE '1970-01-01') AS first_seen,
+    COALESCE(c.last_evidence_change, TIMESTAMP '1970-01-01') AS candidate_last_evidence_change
+  -- org_edges has no 1.0 authoritative source in this plan (0.85/0.80/0.75 only), so the only
+  -- filter here is the pool-tier restriction.
+  FROM currentai.identity.org_edges o
+  LEFT JOIN currentai.identity.candidates c ON c.candidate_key = o.candidate_key
+  WHERE o.candidate_tier = 'pool'
+),
+
+current_items AS (
+  SELECT * FROM membership_items
+  UNION ALL
+  SELECT * FROM equivalence_items
+  UNION ALL
+  SELECT * FROM org_items
+),
+
+scored AS (
+  SELECT
+    s.sweep_week,
+    ci.relation,
+    ci.item_id,
+    ci.candidate_key,
+    ci.left_pair,
+    ci.right_pair,
+    ci.confidence,
+    ci.method,
+    ci.evidence,
+    ci.penalties,
+    ci.proposed_action,
+    CASE
+      WHEN ci.is_blast_3 THEN 3
+      WHEN (ci.relation = 'equivalence' AND ci.product_is_head)
+        OR COALESCE(ci.downloads_30d, 0) >= 1000
+        OR COALESCE(ci.stars, 0) >= 1000
+        THEN 2
+      ELSE 1
+    END AS blast_radius,
+    -- BIGINT, not INTEGER: the live max is already 11% of the INT32 range. See the header.
+    CAST(COALESCE(ci.downloads_30d, 0) + COALESCE(ci.stars, 0) AS BIGINT) AS tiebreak,
+    CAST(ARRAY['confirm', 'reject', 'park'] AS ARRAY(VARCHAR)) AS options,
+    CAST('no edge' AS VARCHAR) AS default_if_ignored,
+    CAST(ci.first_seen AS TIMESTAMP(6)) AS first_seen,
+    CAST(COALESCE(ce.max_edge_ts, ci.candidate_last_evidence_change) AS TIMESTAMP(6))
+      AS last_evidence_change,
+    COALESCE(ce.evidence_kinds, ci.method) AS evidence_kinds
+  FROM current_items ci
+  CROSS JOIN sweep s
+  LEFT JOIN candidate_evidence ce ON ce.candidate_key = ci.candidate_key
+),
+
+-- week_ago / eight_weeks_ago via DATE_ADD (not the `date - INTERVAL` operator form) and cast to
+-- TIMESTAMP(6) so they compare cleanly against last_evidence_change/first_seen.
+thresholds AS (
+  SELECT
+    *,
+    (evidence_kinds = ARRAY['name_match']) AS is_name_match_only,
+    CAST(DATE_ADD('day', -7, sweep_week) AS TIMESTAMP(6)) AS week_ago,
+    CAST(DATE_ADD('day', -56, sweep_week) AS TIMESTAMP(6)) AS eight_weeks_ago
+  FROM scored
+),
+
+pre_state AS (
+  SELECT
+    *,
+    CASE
+      WHEN NOT is_name_match_only THEN 'active_candidate'
+      WHEN first_seen <= eight_weeks_ago THEN 'resurfaced_age'
+      WHEN last_evidence_change >= week_ago THEN 'resurfaced_evidence'
+      ELSE 'parked'
+    END AS pre_state_label
+  FROM thresholds
+),
+
+ranked AS (
+  SELECT
+    *,
+    CASE
+      WHEN pre_state_label <> 'parked' THEN
+        ROW_NUMBER() OVER (
+          PARTITION BY sweep_week
+          ORDER BY
+            CASE relation WHEN 'equivalence' THEN 0 ELSE 1 END,
+            blast_radius DESC,
+            tiebreak DESC,
+            confidence DESC
+        )
+    END AS eligible_rank
+  FROM pre_state
+)
+
+SELECT
+  CAST(sweep_week AS DATE) AS sweep_week,
+  CAST(relation AS VARCHAR) AS relation,
+  CAST(item_id AS VARCHAR) AS item_id,
+  CAST(candidate_key AS VARCHAR) AS candidate_key,
+  left_pair AS "left",
+  right_pair AS "right",
+  CAST(confidence AS DOUBLE) AS confidence,
+  CAST(method AS ARRAY(VARCHAR)) AS method,
+  CAST(evidence AS ARRAY(VARCHAR)) AS evidence,
+  CAST(penalties AS ARRAY(VARCHAR)) AS penalties,
+  CAST(proposed_action AS VARCHAR) AS proposed_action,
+  CAST(blast_radius AS INTEGER) AS blast_radius,
+  CAST(tiebreak AS BIGINT) AS tiebreak,
+  options,
+  default_if_ignored,
+  first_seen,
+  last_evidence_change,
+  CAST(
+    CASE
+      WHEN pre_state_label = 'parked' THEN 'parked'
+      WHEN eligible_rank <= 25 AND pre_state_label = 'active_candidate' THEN 'active'
+      WHEN eligible_rank <= 25 THEN 'resurfaced'
+      ELSE 'pool'
+    END AS VARCHAR
+  ) AS state,
+  CAST(
+    CASE
+      WHEN eligible_rank <= 25 AND pre_state_label = 'resurfaced_age' THEN 'age'
+      WHEN eligible_rank <= 25 AND pre_state_label = 'resurfaced_evidence' THEN 'evidence_changed'
+      ELSE CAST(NULL AS VARCHAR)
+    END AS VARCHAR
+  ) AS resurfaced_reason
+FROM ranked
+ORDER BY
+  CASE relation WHEN 'equivalence' THEN 0 ELSE 1 END,
+  blast_radius DESC,
+  tiebreak DESC,
+  confidence DESC

--- a/warehouse/models/identity/equivalence_edges.sql
+++ b/warehouse/models/identity/equivalence_edges.sql
@@ -1,0 +1,293 @@
+-- ────── PLATFORM MIRROR (read-only) ──────
+-- A snapshot of a model that runs on the OSO platform to build one of the gap map's
+-- tables. The platform is the source of truth; nothing deploys from this copy, and
+-- editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+-- currentai.identity.equivalence_edges
+--
+-- Grain: one row per (candidate_key, product_tier, product_slug). candidate_key =
+-- <artifact_kind> || ':' || <folded artifact_key> (build/identity.py::fold_for_proposal).
+--
+-- Sourced from currentai.identity.artifact_nodes (`all_nodes` below), which spans ALL tiers
+-- (head, tail, pool) -- NOT currentai.identity.candidates, which is pool-only. Per reviewer
+-- ruling: the replay eval compares edges against what humans already declared, so this model
+-- must be able to emit an equivalence edge onto a head- or tail-tier artifact too, not just an
+-- undeclared pool one. `candidate_tier` (the node's `best_tier`: head/tail/pool) is carried as
+-- its own explicit output column so a downstream reader can filter back down to pool-only
+-- (currentai.identity.digest does exactly that -- see its header).
+--
+-- The resolution_ledger evidence path is the one exception that does NOT read `all_nodes`
+-- directly: a ledger ruling can name an artifact that is not in today's live node fetch (a
+-- historical or since-archived candidate), so its candidate_key is still computed independently
+-- via the fold CASE (the same rule as identity_artifact_nodes.sql's `keyed` CTE -- Trino has no
+-- shared macro, so it is intentionally duplicated, not re-derived differently), and its
+-- candidate_tier is looked up against `all_nodes` with a `'pool'` fallback when the artifact is
+-- not found live (matching the tier a since-archived pool candidate almost always had).
+-- `artifact_kind` is carried as its own explicit column (not just embedded in candidate_key) per
+-- the schema ruling that every edge table names its artifact kind directly.
+--
+-- Confidence: GREATEST(evidence...) - SUM(penalties), clamped with GREATEST(0, LEAST(1, ...)).
+-- `penalties` is ARRAY(VARCHAR); no penalty source is defined for this model today, so it is
+-- always the empty array.
+--
+-- Evidence sources:
+--   1.0  resolution ledger -- currentai.registry.resolution_ledger, verdict IN
+--        ('existing_product', 'sku_of'). `relation` absent means product_equivalence per the
+--        ledger schema (docs/schemas/resolution_ledger.schema.json); relation =
+--        'product_membership' rulings (member_of / not_member_of) answer a different question
+--        and are excluded here.
+--   0.9  declared alias -- currentai.registry.product_aliases. Its `alias` column is a bare
+--        product-name-shaped string with no artifact_kind of its own (confirmed live: columns
+--        are alias, product_slug only), so it cannot be turned into a candidate_key on its own.
+--        Matched against the candidate's NAME segment (`candidate_names.normalized_name`), the
+--        same side the model-family patterns match, NOT against artifact_key: an alias is shaped
+--        like `serde-json` while artifact_key for the dominant kinds is `<namespace>/<name>`, so
+--        the artifact_key comparison this CTE used until 2026-09-04 matched NOTHING and the
+--        source was inert (0 rows). Both sides are folded the same way -- lowercased,
+--        non-alphanumeric runs collapsed to `-`, leading/trailing `-` trimmed -- which subsumes
+--        fold_for_proposal's `[-_.]+ -> -` rule for every alias shape in the live vocabulary.
+--        Restricted to the Hub and package kinds (huggingface_model, huggingface_dataset, pypi,
+--        crates, npm) and NOT github: a GitHub repo name is frequently not the product name
+--        (`ggerganov/llama.cpp`, `vllm-project/vllm`), so matching an alias against it invents
+--        equivalences the vocabulary never declared.
+--        Capped at 0.9, not the 1.0 a declared alias would otherwise carry. The alias->product
+--        half of the mapping IS declared by a curator, but the alias->NODE half is inferred by
+--        name, and the spot check on the 46 rows it now emits shows that inference is not
+--        certain: the alias matches the name segment regardless of namespace, so
+--        `tiny-random/phi-4` (a random-weights test stub, not phi-4 at all) earns the same edge
+--        as `microsoft/phi-4`. 0.9 keeps a declared alias ahead of a model-family match (0.8)
+--        and behind a resolution_ledger ruling (1.0), which is the true ordering of how much
+--        human judgment stands behind each.
+--   0.8  model family -- currentai.registry.model_families, `pattern` matched via LIKE with the
+--        glob `*` turned into SQL `%` (ESCAPE '\', and any literal `%` in the pattern escaped
+--        first so it is not itself read as a wildcard). Where several pattern rows match the same
+--        candidate, only the row with the greatest LENGTH(pattern) is kept (longest match wins).
+--        Matched against the candidate's NAME segment (`candidate_names.normalized_name`: the part
+--        after the first `/`, lowercased, non-alphanumerics folded to `-`), NOT against
+--        artifact_key. artifact_key for a Hub artifact is `<namespace>/<name>` (verified live
+--        2026-09-04: e.g. `meta-llama/llama-guard-3-8b`), so a family pattern like `llama-guard-*`
+--        would match nothing at all against artifact_key -- the family vocabulary names model
+--        LINES, not namespaced repo ids. Restricted to huggingface_model / huggingface_dataset:
+--        the patterns describe model families, and matching them against GitHub repo names would
+--        fire `llama-*` on `ggerganov/llama.cpp` (normalized `llama-cpp`) and attach a 0.8
+--        equivalence edge onto the wrong product.
+--   0.5  name match (a CEILING, never higher) -- same normalization rule as
+--        identity_membership_edges.sql's candidate_names CTE.
+--
+-- Homepage-domain evidence: per reviewer ruling, a shared homepage domain is weak corroborating
+-- evidence for PRODUCT equivalence too -- capped at 0.5, method 'homepage_domain', and able to
+-- add at most +0.1 on top of other evidence for the same (candidate_key, product_tier,
+-- product_slug), clamped to 1, rather than following the plain MAX(evidence) formula. This model
+-- has no such evidence source today: currentai.registry.products carries no homepage column, and
+-- currentai.registry.product_artifacts has zero artifact_kind = 'homepage' rows live (checked
+-- 2026-09-03), so there is nothing to match a homepage-kind candidate's domain against at the
+-- product grain (org-level domain matching is identity_org_edges.sql's homepage_evidence, which
+-- answers a different question -- who owns it, not which product it equals). If a product-level
+-- homepage source is added, its evidence must be wired through the capped/stacked rule above,
+-- not the plain MAX(evidence) - penalty_sum formula used for the other four sources.
+--
+-- Verified live 2026-09-04: currentai.registry.model_families exists with 26 rows and exactly the
+-- brief's columns (pattern, product_slug, note, decided_in). currentai.registry.resolution_ledger
+-- has NO `product` column (its columns are artifact_kind, artifact_id, relation, verdict,
+-- boundary, decided_in, decided_on, note, resolves_to), so the product slug is read straight from
+-- `resolves_to`, which is populated on every existing_product / sku_of row.
+--
+-- Output casts: explicit CAST on every output column (VARCHAR strings, DOUBLE confidence,
+-- ARRAY(VARCHAR) method/penalties), matching the deploy pass's fix on the first four models --
+-- the confidence literals (1.0/0.9/0.8/0.5) are Trino DECIMAL, not DOUBLE, so `GREATEST(0, LEAST(1,
+-- MAX(confidence) - 0))` would otherwise leave the column typed DECIMAL and liable to drift
+-- against the other edge tables' DOUBLE confidence.
+
+WITH all_nodes AS (
+  SELECT
+    artifact_kind,
+    artifact_key,
+    artifact_kind || ':' || artifact_key AS candidate_key,
+    best_tier AS candidate_tier,
+    artifact_id
+  FROM currentai.identity.artifact_nodes
+),
+
+ledger_key AS (
+  SELECT
+    verdict,
+    resolves_to AS product_slug,
+    artifact_kind,
+    artifact_kind || ':' ||
+      CASE
+        WHEN artifact_kind IN ('github', 'huggingface_model', 'huggingface_dataset')
+          THEN LOWER(artifact_id)
+        WHEN artifact_kind IN ('pypi', 'crates')
+          THEN REGEXP_REPLACE(LOWER(artifact_id), '[-_.]+', '-')
+        WHEN artifact_kind = 'homepage'
+          THEN REGEXP_REPLACE(
+                 REGEXP_EXTRACT(LOWER(artifact_id), '^(?:[a-z]+://)?([^/]+)', 1),
+                 '^www\.', ''
+               )
+        ELSE LOWER(artifact_id)
+      END AS candidate_key
+  FROM currentai.registry.resolution_ledger
+  WHERE verdict IN ('existing_product', 'sku_of')
+    AND (relation IS NULL OR relation = 'product_equivalence')
+),
+
+-- Head tier is currentai.registry.products, NOT the distinct product_slug of
+-- currentai.registry.product_artifacts. Head-ness is a declaration, and a head product is under
+-- no obligation to declare artifacts: 121 of the 615 products have zero product_artifacts rows
+-- (verified live 2026-09-04), and the two rosters are disjoint from tail_products (0 overlap).
+-- Deriving head from product_artifacts silently dropped every evidence row pointing at one of
+-- those 121 -- including the resolution_ledger ruling a2aproject/a2a -> agent2agent-protocol,
+-- which is exactly the kind of hand-made ruling this model exists to honor.
+products_tier_ranked AS (
+  SELECT slug, product_tier
+  FROM (
+    SELECT
+      slug,
+      product_tier,
+      ROW_NUMBER() OVER (PARTITION BY slug ORDER BY tier_rank) AS rn
+    FROM (
+      SELECT slug, 1 AS tier_rank, 'head' AS product_tier
+      FROM currentai.registry.products
+      UNION ALL
+      SELECT slug, 2 AS tier_rank, 'tail' AS product_tier
+      FROM currentai.registry.tail_products
+      GROUP BY slug
+    )
+  )
+  WHERE rn = 1
+),
+
+ledger_evidence AS (
+  SELECT
+    lk.candidate_key,
+    lk.artifact_kind,
+    COALESCE(n.candidate_tier, 'pool') AS candidate_tier,
+    pt.product_tier,
+    lk.product_slug,
+    1.0 AS confidence,
+    'resolution_ledger' AS method
+  FROM ledger_key lk
+  LEFT JOIN all_nodes n
+    ON n.candidate_key = lk.candidate_key AND n.artifact_kind = lk.artifact_kind
+  JOIN products_tier_ranked pt ON pt.slug = lk.product_slug
+),
+
+candidate_names AS (
+  SELECT
+    candidate_key,
+    artifact_kind,
+    candidate_tier,
+    LOWER(
+      TRIM(BOTH '-' FROM REGEXP_REPLACE(
+        CASE
+          WHEN artifact_kind IN ('github', 'huggingface_model', 'huggingface_dataset')
+               AND STRPOS(artifact_id, '/') > 0
+            THEN SUBSTR(artifact_id, STRPOS(artifact_id, '/') + 1)
+          ELSE artifact_id
+        END,
+        '[^a-zA-Z0-9]+', '-'
+      ))
+    ) AS normalized_name
+  FROM all_nodes
+),
+
+-- product_aliases carries no artifact_kind of its own (confirmed live: alias, product_slug only),
+-- so an alias fires only when it matches a live node's NAME segment, and inherits that node's
+-- artifact_kind/candidate_key/candidate_tier. Matched against candidate_names.normalized_name,
+-- not artifact_key -- see the header: an alias is `serde-json`-shaped and artifact_key is
+-- `<namespace>/<name>`, so the artifact_key form matched nothing at all. The alias is folded with
+-- the same rule as normalized_name so the two sides are comparable. Restricted to the Hub and
+-- package kinds; github is excluded because a repo name is often not the product name.
+alias_evidence AS (
+  SELECT
+    cn.candidate_key,
+    cn.artifact_kind,
+    cn.candidate_tier,
+    pt.product_tier,
+    pa.product_slug,
+    0.9 AS confidence,
+    'product_alias' AS method
+  FROM currentai.registry.product_aliases pa
+  JOIN candidate_names cn
+    ON cn.normalized_name =
+       LOWER(TRIM(BOTH '-' FROM REGEXP_REPLACE(pa.alias, '[^a-zA-Z0-9]+', '-')))
+  JOIN products_tier_ranked pt ON pt.slug = pa.product_slug
+  WHERE cn.artifact_kind IN (
+    'huggingface_model', 'huggingface_dataset', 'pypi', 'crates', 'npm'
+  )
+),
+
+-- longest pattern wins where several currentai.registry.model_families rows match one candidate.
+-- Matched against normalized_name (the name segment), not artifact_key -- see the header.
+-- The glob `*` is turned into SQL `%`; a literal `%` in a pattern is escaped first so it is not
+-- itself read as a wildcard, with a single-character ESCAPE.
+family_matches AS (
+  SELECT
+    cn.candidate_key,
+    cn.artifact_kind,
+    cn.candidate_tier,
+    mf.product_slug,
+    mf.pattern,
+    ROW_NUMBER() OVER (
+      PARTITION BY cn.candidate_key
+      ORDER BY LENGTH(mf.pattern) DESC
+    ) AS pattern_rank
+  FROM candidate_names cn
+  JOIN currentai.registry.model_families mf
+    ON cn.normalized_name LIKE
+         REPLACE(REPLACE(mf.pattern, '%', '\%'), '*', '%') ESCAPE '\'
+  WHERE cn.artifact_kind IN ('huggingface_model', 'huggingface_dataset')
+),
+
+family_evidence AS (
+  SELECT
+    candidate_key,
+    artifact_kind,
+    candidate_tier,
+    product_slug,
+    0.8 AS confidence,
+    'model_family' AS method
+  FROM family_matches
+  WHERE pattern_rank = 1
+),
+
+name_evidence AS (
+  SELECT
+    cn.candidate_key,
+    cn.artifact_kind,
+    cn.candidate_tier,
+    pt.product_tier,
+    p.slug AS product_slug,
+    0.5 AS confidence,
+    'name_match' AS method
+  FROM candidate_names cn
+  JOIN currentai.registry.products p ON cn.normalized_name = LOWER(p.slug)
+  JOIN products_tier_ranked pt ON pt.slug = p.slug
+),
+
+combined AS (
+  SELECT candidate_key, artifact_kind, candidate_tier, product_tier, product_slug, confidence, method
+  FROM ledger_evidence
+  UNION ALL
+  SELECT candidate_key, artifact_kind, candidate_tier, product_tier, product_slug, confidence, method
+  FROM alias_evidence
+  UNION ALL
+  SELECT fe.candidate_key, fe.artifact_kind, fe.candidate_tier, pt.product_tier, fe.product_slug, fe.confidence, fe.method
+  FROM family_evidence fe
+  JOIN products_tier_ranked pt ON pt.slug = fe.product_slug
+  UNION ALL
+  SELECT candidate_key, artifact_kind, candidate_tier, product_tier, product_slug, confidence, method
+  FROM name_evidence
+)
+
+SELECT
+  CAST(candidate_key AS VARCHAR) AS candidate_key,
+  CAST(artifact_kind AS VARCHAR) AS artifact_kind,
+  CAST(MAX(candidate_tier) AS VARCHAR) AS candidate_tier,
+  CAST(product_tier AS VARCHAR) AS product_tier,
+  CAST(product_slug AS VARCHAR) AS product_slug,
+  CAST(GREATEST(0, LEAST(1, MAX(confidence) - 0)) AS DOUBLE) AS confidence,
+  CAST(ARRAY_SORT(ARRAY_DISTINCT(ARRAY_AGG(method))) AS ARRAY(VARCHAR)) AS method,
+  CAST(ARRAY[] AS ARRAY(VARCHAR)) AS penalties
+FROM combined
+GROUP BY candidate_key, artifact_kind, product_tier, product_slug

--- a/warehouse/models/identity/membership_edges.sql
+++ b/warehouse/models/identity/membership_edges.sql
@@ -1,0 +1,143 @@
+-- ────── PLATFORM MIRROR (read-only) ──────
+-- A snapshot of a model that runs on the OSO platform to build one of the gap map's
+-- tables. The platform is the source of truth; nothing deploys from this copy, and
+-- editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+-- currentai.identity.membership_edges
+--
+-- Grain: one row per (artifact_kind, artifact_id, product_tier, product_slug).
+--
+-- Confidence: GREATEST(evidence...) - SUM(penalties), clamped with GREATEST(0, LEAST(1, ...)).
+-- `penalties` is ARRAY(VARCHAR) (a penalty reason per applied penalty, matching the eval's
+-- contract on all four edge tables); no penalty source is defined for this model today, so it is
+-- always the empty array and the confidence formula's penalty_sum term is 0.
+--
+-- Evidence sources (per the design and the corrected plan for this pass):
+--   1.0  declared -- currentai.registry.product_artifacts (product_tier=head) and
+--        currentai.registry.tail_products (product_tier=tail): the product declares this exact
+--        artifact.
+--   0.5  name match (a CEILING, never higher) -- a currentai.identity.candidates row whose
+--        artifact-local name (the part after the owner/namespace for github and
+--        huggingface_model) normalizes to the same string as a currentai.registry.products slug.
+--        Backlinks from build/propose_artifacts.py's declared_repo are NOT available in SQL
+--        today (design table row for this model), so this model emits ONLY the declared 1.0
+--        edges and the name-match 0.5 edges -- nothing else -- in this plan.
+--
+-- scoring_bearing: TRUE iff currentai.registry.adoption_routes declares a route for this
+-- artifact_kind (i.e. some evaluation route actually reads this kind of artifact for adoption).
+-- Spot check from the deploy brief: a PyPI-declared product should read TRUE (pypi has a route),
+-- a homepage-declared product should read FALSE (homepage has no adoption route).
+--
+-- TODO verify on deploy: the name-normalization rule below (lowercase, non [a-z0-9] runs
+-- collapsed to a single '-', trimmed) is a reasonable guess at "the same product name", not a
+-- rule taken from an existing module; tighten or replace once real name-match false positives
+-- are observed.
+
+WITH declared_head AS (
+  SELECT
+    artifact_kind,
+    artifact_id,
+    'head' AS product_tier,
+    product_slug,
+    1.0 AS confidence,
+    'declared' AS method
+  FROM currentai.registry.product_artifacts
+),
+
+declared_tail AS (
+  SELECT
+    artifact_kind,
+    artifact_id,
+    'tail' AS product_tier,
+    slug AS product_slug,
+    1.0 AS confidence,
+    'declared' AS method
+  FROM currentai.registry.tail_products
+),
+
+products_tier AS (
+  SELECT product_slug AS slug, 1 AS tier_rank, 'head' AS product_tier
+  FROM currentai.registry.product_artifacts
+  GROUP BY product_slug
+
+  UNION ALL
+
+  SELECT slug, 2 AS tier_rank, 'tail' AS product_tier
+  FROM currentai.registry.tail_products
+  GROUP BY slug
+),
+
+products_tier_ranked AS (
+  SELECT slug, product_tier
+  FROM (
+    SELECT
+      slug,
+      product_tier,
+      ROW_NUMBER() OVER (PARTITION BY slug ORDER BY tier_rank) AS rn
+    FROM products_tier
+  )
+  WHERE rn = 1
+),
+
+candidate_names AS (
+  SELECT
+    artifact_kind,
+    artifact_id,
+    LOWER(
+      TRIM(BOTH '-' FROM REGEXP_REPLACE(
+        CASE
+          WHEN artifact_kind IN ('github', 'huggingface_model', 'huggingface_dataset')
+               AND STRPOS(artifact_id, '/') > 0
+            THEN SUBSTR(artifact_id, STRPOS(artifact_id, '/') + 1)
+          ELSE artifact_id
+        END,
+        '[^a-zA-Z0-9]+', '-'
+      ))
+    ) AS normalized_name
+  FROM currentai.identity.candidates
+),
+
+name_match AS (
+  SELECT
+    c.artifact_kind,
+    c.artifact_id,
+    pt.product_tier,
+    p.slug AS product_slug,
+    0.5 AS confidence,
+    'name_match' AS method
+  FROM candidate_names c
+  JOIN currentai.registry.products p
+    ON c.normalized_name = LOWER(p.slug)
+  JOIN products_tier_ranked pt
+    ON pt.slug = p.slug
+),
+
+combined AS (
+  SELECT * FROM declared_head
+  UNION ALL
+  SELECT * FROM declared_tail
+  UNION ALL
+  SELECT * FROM name_match
+),
+
+route_kinds AS (
+  -- The NULL artifact_kind is filtered deliberately, not defensively: registry.adoption_routes
+  -- carries a route row with a NULL artifact_kind, and a NULL inside an IN list makes
+  -- `x IN (...)` evaluate to NULL rather than FALSE for any non-matching x -- which would make
+  -- scoring_bearing NULL (not FALSE) for every unrouted kind, homepage included.
+  SELECT DISTINCT artifact_kind
+  FROM currentai.registry.adoption_routes
+  WHERE artifact_kind IS NOT NULL
+)
+
+SELECT
+  CAST(m.artifact_kind AS VARCHAR) AS artifact_kind,
+  CAST(m.artifact_id AS VARCHAR) AS artifact_id,
+  CAST(m.product_tier AS VARCHAR) AS product_tier,
+  CAST(m.product_slug AS VARCHAR) AS product_slug,
+  CAST(GREATEST(0, LEAST(1, MAX(m.confidence) - 0)) AS DOUBLE) AS confidence,
+  ARRAY_SORT(ARRAY_DISTINCT(ARRAY_AGG(m.method))) AS method,
+  CAST(ARRAY[] AS ARRAY(VARCHAR)) AS penalties,
+  CAST(m.artifact_kind IN (SELECT artifact_kind FROM route_kinds) AS BOOLEAN) AS scoring_bearing
+FROM combined m
+GROUP BY m.artifact_kind, m.artifact_id, m.product_tier, m.product_slug

--- a/warehouse/models/identity/org_edges.sql
+++ b/warehouse/models/identity/org_edges.sql
@@ -1,0 +1,242 @@
+-- ────── PLATFORM MIRROR (read-only) ──────
+-- A snapshot of a model that runs on the OSO platform to build one of the gap map's
+-- tables. The platform is the source of truth; nothing deploys from this copy, and
+-- editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+-- currentai.identity.org_edges
+--
+-- Grain: one row per (candidate_key, org_slug). Only onto orgs that already exist --
+-- every evidence source below joins to currentai.registry.organizations, so a candidate can
+-- never manufacture a new org here.
+--
+-- Sourced from currentai.identity.artifact_nodes (`all_nodes` below), which spans ALL tiers
+-- (head, tail, pool) -- NOT currentai.identity.candidates, which is pool-only. Per reviewer
+-- ruling: the replay eval compares edges against what humans already declared, so this model
+-- must be able to emit an org edge onto a head- or tail-tier artifact too, not just an undeclared
+-- pool one. `candidate_tier` (the node's `best_tier`: head/tail/pool) is carried as its own
+-- explicit output column so a downstream reader can filter back down to pool-only
+-- (currentai.identity.digest does exactly that -- see its header). candidate_key =
+-- <artifact_kind> || ':' || <artifact_key>; `artifact_kind` is also carried as its own explicit
+-- column per the schema ruling that every edge table names its artifact kind directly.
+--
+-- Confidence: GREATEST(evidence...) - SUM(penalties), clamped with GREATEST(0, LEAST(1, ...)).
+-- `penalties` is ARRAY(VARCHAR); no penalty source is defined for this model today, so it is
+-- always the empty array.
+--
+-- Evidence sources:
+--   0.85 org handle -- currentai.registry.org_handles (platform, handle, org_slug): the
+--        candidate's owner/namespace segment matches a registered handle for that platform.
+--        org_handles.platform does NOT use the artifact_kind vocabulary (verified live
+--        2026-09-04: the distinct set is github 220, homepage_domain 257, huggingface 2 -- 479
+--        rows). It is coarser on the Hub side and differently spelled on the homepage side, so
+--        the join goes through the `handle_platform_map` CTE below rather than a bare
+--        `platform = artifact_kind` equality, which would have matched only the github rows and
+--        silently dropped the other 259. The homepage row shape also differs in WHAT is compared:
+--        a homepage_domain handle is a bare domain, so it is matched against the HOST of the
+--        candidate's artifact_key, not against owner_handle, which is NULL for a homepage
+--        artifact and would have matched nothing. It also differs in HOW: a homepage handle
+--        matches its own subdomains too (see the host-matching note below).
+--   0.80 HF namespace -- a huggingface_model/huggingface_dataset candidate's namespace segment
+--        (the part before the first `/`) matches an org's slug directly, with no registered
+--        handle in org_handles. Lower confidence than an explicit handle because it is a bare
+--        slug-equality guess, not a curated mapping.
+--   0.75 homepage domain -- a homepage candidate's host matches the host of an org's
+--        currentai.registry.organizations.homepage. This 0.75 stands uncapped -- unlike the
+--        weak-corroboration cap applied to homepage-domain evidence in
+--        identity_artifact_identity_edges.sql and identity_equivalence_edges.sql, org ownership
+--        is exactly the relation a shared domain is good evidence for.
+--
+-- Host matching, both homepage paths (fixed 2026-09-04 -- both emitted ZERO rows before):
+--   1. The host is extracted from artifact_key rather than used raw:
+--      REGEXP_EXTRACT(artifact_key, '^([^/]+)', 1) with a leading `www.` stripped. Homepage
+--      artifact_id is moving to the full canonical URL (host lowercased, `www.` stripped, path
+--      kept, no trailing slash) in a parallel repo change, so `example.com/product` will fold to
+--      a key with a path segment in it. Today's 27 homepage keys are still bare hosts, so the
+--      extraction is a no-op on live data -- it exists so the model does not silently go to zero
+--      the week the repo change lands.
+--   2. A candidate host matches an org domain when it EQUALS it or is a SUBDOMAIN of it
+--      (`host LIKE '%.' || domain`). Exact equality alone is why both paths were inert: none of
+--      the 27 homepage nodes is a bare registered org domain, but three are subdomains of one --
+--      `rocm.docs.amd.com` (amd), `developer.nvidia.com` (nvidia),
+--      `developers.llamaindex.ai` (llamaindex). LIKE is safe without an ESCAPE clause here
+--      because a hostname cannot contain `%` or `_`.
+--   3. On the organizations.homepage path only, an org host claimed by MORE THAN ONE org is
+--      dropped (`unambiguous_org_hosts` below). 7 hosts are shared live, and they are shared
+--      because they are code-hosting platforms, not company domains: 11 orgs give `github.com`
+--      as their homepage and 3 give `huggingface.co`. Without the filter a single homepage
+--      candidate under such a host would fan out to every one of those orgs at 0.75.
+--      org_handles needs no such filter -- its 257 homepage_domain handles are unambiguous
+--      (0 handles map to more than one org_slug, verified live).
+--   Both homepage paths land on the SAME three candidates today, so those rows carry
+--   method ['homepage_domain', 'org_handle'] and confidence 0.85 (the MAX), not 0.75. The two
+--   paths are kept separate anyway: they read different tables and either can grow on its own.
+--
+-- Verified live 2026-09-04: currentai.registry.org_handles exists with 479 rows and exactly the
+-- brief's columns (platform, handle, org_slug). Its `platform` vocabulary is coarser than
+-- artifact_kind -- 'huggingface' covers both HF kinds and 'homepage_domain' is the homepage
+-- spelling -- so `handle_platform_map` below carries the mapping, exactly the case the original
+-- TODO on this line anticipated.
+--
+-- Output casts: explicit CAST on every output column (VARCHAR strings, DOUBLE confidence,
+-- ARRAY(VARCHAR) method/penalties), matching the deploy pass's fix on the first four models --
+-- the confidence literals (0.85/0.80/0.75) are Trino DECIMAL, not DOUBLE, so
+-- `GREATEST(0, LEAST(1, MAX(evidence) - 0))` would otherwise leave the column typed DECIMAL.
+
+WITH all_nodes AS (
+  SELECT
+    artifact_kind,
+    artifact_key,
+    artifact_kind || ':' || artifact_key AS candidate_key,
+    best_tier AS candidate_tier,
+    artifact_id
+  FROM currentai.identity.artifact_nodes
+),
+
+candidate_owner AS (
+  SELECT
+    candidate_key,
+    artifact_kind,
+    candidate_tier,
+    artifact_key,
+    artifact_id,
+    CASE
+      WHEN artifact_kind IN ('github', 'huggingface_model', 'huggingface_dataset')
+           AND STRPOS(artifact_id, '/') > 0
+        THEN LOWER(SUBSTR(artifact_id, 1, STRPOS(artifact_id, '/') - 1))
+      ELSE NULL
+    END AS owner_handle,
+    -- What an org_handles row is compared against, per platform: the owner/namespace segment for
+    -- github and the two Hub kinds, the bare host for homepage (a homepage artifact has no owner
+    -- segment at all). The host is EXTRACTED from artifact_key up to the first `/` rather than
+    -- used raw, so a canonical-URL key like `example.com/product` still yields `example.com`.
+    CASE
+      WHEN artifact_kind = 'homepage'
+        THEN REGEXP_REPLACE(REGEXP_EXTRACT(artifact_key, '^([^/]+)', 1), '^www\.', '')
+      WHEN artifact_kind IN ('github', 'huggingface_model', 'huggingface_dataset')
+           AND STRPOS(artifact_id, '/') > 0
+        THEN LOWER(SUBSTR(artifact_id, 1, STRPOS(artifact_id, '/') - 1))
+      ELSE NULL
+    END AS handle_token
+  FROM all_nodes
+),
+
+-- org_handles.platform -> artifact_kind. Read live, not assumed: platform is
+-- {github, huggingface, homepage_domain}, artifact_kind is
+-- {github, huggingface_model, huggingface_dataset, homepage, pypi, crates, npm, arxiv}.
+handle_platform_map AS (
+  SELECT * FROM (
+    VALUES
+      ('github', 'github'),
+      ('huggingface', 'huggingface_model'),
+      ('huggingface', 'huggingface_dataset'),
+      ('homepage_domain', 'homepage')
+  ) AS t (platform, artifact_kind)
+),
+
+handle_evidence AS (
+  SELECT
+    co.candidate_key,
+    co.artifact_kind,
+    co.candidate_tier,
+    oh.org_slug,
+    0.85 AS evidence,
+    'org_handle' AS method
+  FROM candidate_owner co
+  JOIN handle_platform_map hpm ON hpm.artifact_kind = co.artifact_kind
+  JOIN currentai.registry.org_handles oh
+    ON oh.platform = hpm.platform
+   AND LOWER(oh.handle) = co.handle_token
+  JOIN currentai.registry.organizations o ON o.slug = oh.org_slug
+),
+
+-- Subdomain half of the org-handle path, homepage only: `rocm.docs.amd.com` is the amd handle
+-- `amd.com` one level down. Split out from handle_evidence rather than folded into its join
+-- condition so the github/Hub path stays a plain equi-join. Strictly the subdomain case
+-- (`%.` || handle), so it can never duplicate a handle_evidence row.
+homepage_handle_evidence AS (
+  SELECT
+    co.candidate_key,
+    co.artifact_kind,
+    co.candidate_tier,
+    oh.org_slug,
+    0.85 AS evidence,
+    'org_handle' AS method
+  FROM candidate_owner co
+  JOIN currentai.registry.org_handles oh
+    ON oh.platform = 'homepage_domain'
+   AND co.handle_token LIKE '%.' || LOWER(oh.handle)
+  JOIN currentai.registry.organizations o ON o.slug = oh.org_slug
+  WHERE co.artifact_kind = 'homepage'
+),
+
+hf_namespace_evidence AS (
+  SELECT
+    co.candidate_key,
+    co.artifact_kind,
+    co.candidate_tier,
+    o.slug AS org_slug,
+    0.80 AS evidence,
+    'hf_namespace' AS method
+  FROM candidate_owner co
+  JOIN currentai.registry.organizations o ON LOWER(o.slug) = co.owner_handle
+  WHERE co.artifact_kind IN ('huggingface_model', 'huggingface_dataset')
+),
+
+-- currentai.registry.organizations.homepage, folded to a bare host the same way the candidate
+-- side is. A host claimed by more than one org is dropped: those are code-hosting platforms
+-- (github.com on 11 orgs, huggingface.co on 3), not company domains, and matching one would fan a
+-- single candidate out to every org sharing it.
+org_hosts AS (
+  SELECT
+    o.slug,
+    REGEXP_REPLACE(
+      REGEXP_EXTRACT(LOWER(o.homepage), '^(?:[a-z]+://)?([^/]+)', 1),
+      '^www\.', ''
+    ) AS org_host
+  FROM currentai.registry.organizations o
+  WHERE o.homepage IS NOT NULL
+),
+
+unambiguous_org_hosts AS (
+  SELECT org_host, MAX(slug) AS slug
+  FROM org_hosts
+  WHERE org_host IS NOT NULL
+  GROUP BY org_host
+  HAVING COUNT(DISTINCT slug) = 1
+),
+
+homepage_evidence AS (
+  SELECT
+    co.candidate_key,
+    co.artifact_kind,
+    co.candidate_tier,
+    h.slug AS org_slug,
+    0.75 AS evidence,
+    'homepage_domain' AS method
+  FROM candidate_owner co
+  JOIN unambiguous_org_hosts h
+    ON co.handle_token = h.org_host
+    OR co.handle_token LIKE '%.' || h.org_host
+  WHERE co.artifact_kind = 'homepage'
+),
+
+combined AS (
+  SELECT * FROM handle_evidence
+  UNION ALL
+  SELECT * FROM homepage_handle_evidence
+  UNION ALL
+  SELECT * FROM hf_namespace_evidence
+  UNION ALL
+  SELECT * FROM homepage_evidence
+)
+
+SELECT
+  CAST(candidate_key AS VARCHAR) AS candidate_key,
+  CAST(artifact_kind AS VARCHAR) AS artifact_kind,
+  CAST(MAX(candidate_tier) AS VARCHAR) AS candidate_tier,
+  CAST(org_slug AS VARCHAR) AS org_slug,
+  CAST(GREATEST(0, LEAST(1, MAX(evidence) - 0)) AS DOUBLE) AS confidence,
+  CAST(ARRAY_SORT(ARRAY_DISTINCT(ARRAY_AGG(method))) AS ARRAY(VARCHAR)) AS method,
+  CAST(ARRAY[] AS ARRAY(VARCHAR)) AS penalties
+FROM combined
+GROUP BY candidate_key, artifact_kind, org_slug

--- a/warehouse/models/signal_goodailist/repo_catalog.py
+++ b/warehouse/models/signal_goodailist/repo_catalog.py
@@ -1,0 +1,265 @@
+# ────── PLATFORM MIRROR (read-only) ──────
+# A snapshot of a model that runs on the OSO platform to build one of the gap map's
+# tables. The platform is the source of truth; nothing deploys from this copy, and
+# editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+"""GoodAI List repo catalog, read live from goodailist.com's public API.
+
+Replaces the hand-uploaded `catalog.goodailist_repos` static model. No auth
+required. The upstream refreshes daily, so this runs daily.
+
+Two things this adds over the static table:
+  * `first_seen` and `is_new` — the discovery signal for new entrants.
+  * `source_updated_at` — upstream freshness, distinct from our run time, so a
+    stale upstream is visible rather than silently presented as current.
+
+~17k repos across 18 pages at 1000/page. Page count stays under the sandbox's
+25-in-flight cap, so the fan-out is a single wave with no queueing.
+
+Builds a pyarrow Table directly and does NOT use polars. The sandbox is pyodide,
+which is wasm32, and polars' `to_arrow()` allocates through Rust with 32-bit
+capacity — at this row count it panics with `pyo3_runtime.PanicException:
+capacity overflow` during Arrow IPC serialization, after the model's own code has
+finished successfully. Chunking the frame does not avoid it and neither does
+rechunk(); the panic is in the polars->Arrow conversion itself. Returning a
+pyarrow Table skips that conversion, since the runner uses the table as-is.
+
+Keep this model polars-free. Any transformation added here must be expressed in
+plain Python or pyarrow.
+"""
+
+import asyncio
+from collections.abc import AsyncIterator
+from datetime import date, datetime, timezone
+from urllib.parse import urlencode
+
+import oso
+import pyarrow as pa
+
+BASE = "https://goodailist.com"
+SUMMARY_PATH = "/api/summary"
+REPOS_PATH = "/api/repos"
+PAGE_SIZE = 1000
+
+# Two distinct limits bite here, and both fixes are needed.
+#   1. Returning polars panics in Arrow serialization (see the module docstring).
+#      Fixed by building a pyarrow Table.
+#   2. Shipping the whole ~5.5MB table in one response kills the host with
+#      "UDM host /chunks request failed: Server disconnected without sending a
+#      response". Fixed by yielding it in slices.
+# At ~325 bytes/row this is roughly 1.3MB per chunk.
+CHUNK_ROWS = 4000
+
+TEXT_COLUMNS = [
+    "repo",
+    "description",
+    "category",
+    "subcat",
+    "keywords",
+    "country",
+    "top_devs",
+    "language",
+]
+INT_COLUMNS = ["stars", "forks", "contributors", "star_1d", "star_7d"]
+FLOAT_COLUMNS = ["star_1d_pct", "star_7d_pct"]
+DATE_COLUMNS = ["created_at", "updated_at", "first_seen"]
+BOOL_COLUMNS = ["is_new", "archived"]
+
+
+def _repos_url(page: int) -> str:
+    """Build a /api/repos URL for one page."""
+    query = urlencode(
+        {
+            "page": page,
+            "limit": PAGE_SIZE,
+            "sort_by": "stars",
+            "sort_order": "desc",
+        }
+    )
+    return f"{BASE}{REPOS_PATH}?{query}"
+
+
+def _records(payload: object) -> list[dict]:
+    """Pull the `repos` array out of an untyped payload."""
+    if not isinstance(payload, dict):
+        return []
+    entries = payload.get("repos")
+    if not isinstance(entries, list):
+        return []
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def _page_count(payload: object) -> int:
+    """Read `pages` out of an untyped payload."""
+    if isinstance(payload, dict):
+        value = payload.get("pages")
+        if isinstance(value, bool):
+            return 0
+        if isinstance(value, int):
+            return value
+    return 0
+
+
+def _upstream_stamp(payload: object) -> datetime | None:
+    """Parse `updated_at` from /api/summary, which reports upstream freshness."""
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("updated_at")
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value).replace(tzinfo=None, microsecond=0)
+    except ValueError:
+        return None
+
+
+def _as_text(value: object) -> str | None:
+    if value is None:
+        return None
+    return value if isinstance(value, str) else str(value)
+
+
+def _as_int(value: object) -> int | None:
+    """bool is a subclass of int, so reject it explicitly rather than store 0/1."""
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(float(value))
+        except ValueError:
+            return None
+    return None
+
+
+def _as_float(value: object) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _as_date(value: object) -> date | None:
+    """Upstream sends YYYY-MM-DD, sometimes with a time component appended."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return date.fromisoformat(value[:10])
+    except ValueError:
+        return None
+
+
+def _as_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in ("true", "t", "1", "yes"):
+            return True
+        if lowered in ("false", "f", "0", "no"):
+            return False
+    return None
+
+
+def _dedupe(records: list[dict]) -> list[dict]:
+    """Keep the first occurrence of each repo.
+
+    Upstream returns a handful of exact duplicates (4 of ~17k on the first run),
+    all with identical stars and category, most likely because paging a
+    live-sorted list can show the same row twice. Results are sorted by stars
+    descending, so the first occurrence is the higher-star copy.
+    """
+    seen: set[str] = set()
+    out: list[dict] = []
+    for record in records:
+        repo = _as_text(record.get("repo"))
+        if repo is None or repo in seen:
+            continue
+        seen.add(repo)
+        out.append(record)
+    return out
+
+
+def _build_table(
+    records: list[dict], upstream: datetime | None, stamp: datetime
+) -> pa.Table:
+    """Assemble the Arrow table column by column, with types pinned explicitly.
+
+    The schema is declared rather than inferred so an all-null column still lands
+    with the right type instead of arriving as null and breaking the table
+    contract.
+    """
+    columns: dict[str, pa.Array] = {}
+    for name in TEXT_COLUMNS:
+        columns[name] = pa.array([_as_text(r.get(name)) for r in records], type=pa.string())
+    for name in INT_COLUMNS:
+        columns[name] = pa.array([_as_int(r.get(name)) for r in records], type=pa.int64())
+    for name in FLOAT_COLUMNS:
+        columns[name] = pa.array([_as_float(r.get(name)) for r in records], type=pa.float64())
+    for name in DATE_COLUMNS:
+        columns[name] = pa.array([_as_date(r.get(name)) for r in records], type=pa.date32())
+    for name in BOOL_COLUMNS:
+        columns[name] = pa.array([_as_bool(r.get(name)) for r in records], type=pa.bool_())
+
+    timestamp = pa.timestamp("us")
+    columns["source_updated_at"] = pa.array([upstream] * len(records), type=timestamp)
+    columns["ingested_at"] = pa.array([stamp] * len(records), type=timestamp)
+
+    ordered = (
+        TEXT_COLUMNS
+        + INT_COLUMNS
+        + FLOAT_COLUMNS
+        + DATE_COLUMNS
+        + BOOL_COLUMNS
+        + ["source_updated_at", "ingested_at"]
+    )
+    return pa.table({name: columns[name] for name in ordered})
+
+
+@oso.model(external_origins=["https://goodailist.com"])
+async def repo_catalog(context: oso.AsyncContext) -> AsyncIterator[oso.DataFrame]:
+    summary_response = await context.fetch(f"{BASE}{SUMMARY_PATH}")
+    if summary_response.status != 200:
+        raise RuntimeError(f"goodailist /api/summary returned {summary_response.status}")
+    upstream = _upstream_stamp(summary_response.json())
+
+    first = await context.fetch(_repos_url(1))
+    if first.status != 200:
+        raise RuntimeError(f"goodailist /api/repos returned {first.status} on page 1")
+
+    payload = first.json()
+    pages = _page_count(payload)
+    records: list[dict] = _records(payload)
+
+    if pages > 1:
+        rest = list(range(2, pages + 1))
+        responses = await asyncio.gather(
+            *(context.fetch(_repos_url(page)) for page in rest)
+        )
+        for page, response in zip(rest, responses):
+            if response.status != 200:
+                raise RuntimeError(
+                    f"goodailist /api/repos returned {response.status} on page {page}"
+                )
+            records.extend(_records(response.json()))
+
+    if not records:
+        raise RuntimeError("goodailist returned no repos")
+
+    stamp = datetime.now(timezone.utc).replace(tzinfo=None, microsecond=0)
+    table = _build_table(_dedupe(records), upstream, stamp)
+
+    # combine_chunks() materializes each slice into its own buffers. A bare
+    # pa.Table.slice() is a zero-copy view over the parent, so the IPC writer can
+    # still walk the full-size buffers behind it and defeat the point of chunking.
+    for start in range(0, table.num_rows, CHUNK_ROWS):
+        yield table.slice(start, CHUNK_ROWS).combine_chunks()

--- a/warehouse/models/signal_hfhub/model_universe.py
+++ b/warehouse/models/signal_hfhub/model_universe.py
@@ -1,0 +1,207 @@
+# ────── PLATFORM MIRROR (read-only) ──────
+# A snapshot of a model that runs on the OSO platform to build one of the gap map's
+# tables. The platform is the source of truth; nothing deploys from this copy, and
+# editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+"""The live Hugging Face Hub model universe — the missing input #329 asks for.
+
+`currentai.catalog.model_repos` is a one-time, hand-loaded dump: 21,229 rows as
+of this model's authoring, no declared selection rule, no `downloads_30d` floor
+(median 30-day downloads across the table is 13, and 83% of rows sit below
+1,000), and about 38% of rows carry no `pipeline_tag` at all. It reads like an
+unfiltered crawl of a fixed window, not a reproducible criterion, and nothing
+refreshes it. `signal_huggingface.artifact_state` cannot substitute for it
+either — that model is keyed to the artifacts the registry already declares, so
+it can only report on models the map has already found, never on what else
+exists on the Hub.
+
+This model sweeps the Hub's public `/api/models` list endpoint directly
+(`sort=downloads&direction=-1`), paging while `downloads` (the Hub's own
+rolling 30-day figure, same field `huggingface_hub_state.py` reads from the
+single-model endpoint) stays at or above `DOWNLOADS_FLOOR_30D`. Sampling the
+live distribution before choosing a floor: about 11,000 models clear a
+5,000-download floor, about 27,000 clear 1,000, and about 45,000 clear 500.
+1,000 is chosen as the floor -- it lands the sweep in the middle of the
+5,000-50,000 order of magnitude a useful universe needs, comfortably above the
+whole-Hub scale (millions of near-zero-download repos) the frozen table never
+excluded.
+
+Grain: one row per Hub model repo (`hf_id`) with `downloads_30d >=
+DOWNLOADS_FLOOR_30D` at fetch time. Not registry-scoped -- this is the
+candidate universe the registry is drawn from, not the registry itself.
+
+Two shape traps carried over from `huggingface_hub_state.py`:
+  * the list endpoint has no `cardData`, so license comes from the
+    `license:<slug>` tag instead of `cardData.license`.
+  * `gated` is a bool or a mode string ("auto" / "manual"); recorded as both a
+    flag and the mode is dropped here (list endpoint gives only the raw
+    value) -- kept as the boolean flag `gated`, string mode collapses to
+    `gated=True`.
+
+Paging is capped at `MAX_PAGES` (40 x 1,000 = 40,000 rows scanned, well above
+the ~27 pages the 1,000-download floor is expected to need) so a runaway sweep
+cannot run long or unbounded. A 429 gets up to 3 retries with exponential
+backoff before the run fails loud rather than silently truncating the
+universe.
+"""
+
+import asyncio
+import re
+from datetime import datetime, timezone
+
+import oso
+import polars as pl
+
+HF_API = "https://huggingface.co"
+LIST_ENDPOINT = "https://huggingface.co/api/models"
+PAGE_SIZE = 1000
+DOWNLOADS_FLOOR_30D = 1000
+MAX_PAGES = 40
+MAX_RETRIES = 3
+RETRY_BASE_SECONDS = 2.0
+PAGE_PAUSE_SECONDS = 0.25
+NEXT_LINK_PATTERN = r'<([^>]+)>;\s*rel="next"'
+
+
+def _license(tags: object) -> str | None:
+    """The list endpoint carries no `cardData`; license rides a `license:` tag."""
+    if not isinstance(tags, list):
+        return None
+    for tag in tags:
+        if isinstance(tag, str) and tag.startswith("license:"):
+            value = tag[len("license:") :]
+            return value or None
+    return None
+
+
+def _gated(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return True
+    return None
+
+
+def _stamp(raw: object) -> datetime | None:
+    if not isinstance(raw, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=None, microsecond=0)
+
+
+def _tags_json(tags: object) -> str | None:
+    if not isinstance(tags, list):
+        return None
+    names = [t for t in tags if isinstance(t, str)]
+    return "[" + ",".join('"' + n.replace('"', '\\"') + '"' for n in names) + "]"
+
+
+def _next_url(headers: dict) -> str | None:
+    link = headers.get("Link") or headers.get("link")
+    if not isinstance(link, str):
+        return None
+    match = re.search(NEXT_LINK_PATTERN, link)
+    return match.group(1) if match else None
+
+
+@oso.model(
+    secrets=["HUGGING_FACE_TOKEN"],
+    environment_name="Default",
+    external_origins=["https://huggingface.co"],
+    capabilities=oso.Capabilities(fetch=True),
+)
+async def model_universe(context: oso.AsyncContext) -> oso.DataFrame:
+    token: str = await context.secret("HUGGING_FACE_TOKEN")
+    headers: dict[str, str] = {
+        "Authorization": f"Bearer {token}",
+        "User-Agent": "oso-udm-client/1.0",
+    }
+
+    url: str | None = (
+        f"{LIST_ENDPOINT}?sort=downloads&direction=-1&limit={PAGE_SIZE}&full=true"
+    )
+    fetched = datetime.now(timezone.utc).replace(tzinfo=None, microsecond=0)
+    rows: list[dict] = []
+    page_count = 0
+    floor_reached = False
+
+    while url is not None and page_count < MAX_PAGES and not floor_reached:
+        response = None
+        for attempt in range(MAX_RETRIES + 1):
+            response = await context.fetch(url, headers=headers)
+            if response.status != 429:
+                break
+            if attempt == MAX_RETRIES:
+                break
+            await asyncio.sleep(RETRY_BASE_SECONDS * (2**attempt))
+
+        if response is None or response.status != 200:
+            status = response.status if response is not None else "no response"
+            raise RuntimeError(
+                f"Hub list request failed after retries: page {page_count + 1}, "
+                f"status {status}, url {url}"
+            )
+
+        page_count += 1
+        payload = response.json()
+        if not isinstance(payload, list):
+            raise RuntimeError(f"unexpected Hub list payload shape on page {page_count}")
+
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            downloads = item.get("downloads")
+            downloads_int = downloads if isinstance(downloads, int) else None
+            if downloads_int is None or downloads_int < DOWNLOADS_FLOOR_30D:
+                floor_reached = True
+                break
+            likes = item.get("likes")
+            rows.append(
+                {
+                    "hf_id": item.get("id"),
+                    "author": item.get("author"),
+                    "pipeline_tag": item.get("pipeline_tag"),
+                    "library_name": item.get("library_name"),
+                    "license": _license(item.get("tags")),
+                    "downloads_30d": downloads_int,
+                    "likes": likes if isinstance(likes, int) else None,
+                    "created_at": _stamp(item.get("createdAt")),
+                    "last_modified": _stamp(item.get("lastModified")),
+                    "gated": _gated(item.get("gated")),
+                    "private": item.get("private") if isinstance(item.get("private"), bool) else None,
+                    "tags": _tags_json(item.get("tags")),
+                    "fetched_at": fetched,
+                }
+            )
+
+        if len(payload) < PAGE_SIZE:
+            break
+
+        url = _next_url(response.headers)
+        if url is not None and not floor_reached:
+            await asyncio.sleep(PAGE_PAUSE_SECONDS)
+
+    if not rows:
+        raise RuntimeError("Hub sweep returned zero models at or above the downloads floor")
+
+    return pl.DataFrame(
+        rows,
+        schema={
+            "hf_id": pl.Utf8,
+            "author": pl.Utf8,
+            "pipeline_tag": pl.Utf8,
+            "library_name": pl.Utf8,
+            "license": pl.Utf8,
+            "downloads_30d": pl.Int64,
+            "likes": pl.Int64,
+            "created_at": pl.Datetime("us"),
+            "last_modified": pl.Datetime("us"),
+            "gated": pl.Boolean,
+            "private": pl.Boolean,
+            "tags": pl.Utf8,
+            "fetched_at": pl.Datetime("us"),
+        },
+    )

--- a/warehouse/models/signal_openrouter/models.py
+++ b/warehouse/models/signal_openrouter/models.py
@@ -1,0 +1,192 @@
+# ────── PLATFORM MIRROR (read-only) ──────
+# A snapshot of a model that runs on the OSO platform to build one of the gap map's
+# tables. The platform is the source of truth; nothing deploys from this copy, and
+# editing it here changes nothing. See README.md and manifest.yaml in this folder.
+
+"""OpenRouter model list — the release-watcher's first leg.
+
+OpenRouter aggregates model listings across providers (OpenAI, Anthropic, Google,
+Meta, open-weights hosts and more) into one JSON endpoint, no auth required. A
+weekly pull of this list is the raw signal a "new model release" diff runs
+against: a fresh row with a `created` timestamp inside the last week is a new
+closed- or open-model release worth surfacing (a new Grok, Claude, Gemini, ...).
+
+This replaces the hand-loaded `openrouter_snapshot` static model (last touched
+2026-07-05, one snapshot, 340 rows) as the live source. `openrouter_snapshot` and
+its downstream `ai_demand_curve` chain are left untouched here — repointing that
+reader to this table is a separate, later change.
+
+`pricing.prompt` / `pricing.completion` arrive as strings (decimal literals, USD
+per token) rather than numbers, so they are parsed explicitly rather than trusted
+to a numeric cast. `supported_parameters` is a list and is serialized to a JSON
+string column rather than exploded, since its length and contents vary per model.
+"""
+
+import json
+import time
+from datetime import datetime, timezone
+
+import oso
+import polars as pl
+
+OPENROUTER_URL = "https://openrouter.ai/api/v1/models"
+USER_AGENT = "currentai-org-gap-map/1.0 (+https://github.com/currentai-org/os-ai-map)"
+
+TRANSIENT_STATUSES = [429, 500, 502, 503, 504]
+MAX_ATTEMPTS = 4
+
+
+def _records(payload: object) -> list[dict]:
+    """Rows live under `data`; narrow rather than assume."""
+    if not isinstance(payload, dict):
+        return []
+    rows = payload.get("data")
+    if not isinstance(rows, list):
+        return []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _text(payload: object, key: str) -> str | None:
+    if isinstance(payload, dict):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _int(payload: object, key: str) -> int | None:
+    if isinstance(payload, dict):
+        value = payload.get(key)
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            return value
+    return None
+
+
+def _bool(payload: object, key: str) -> bool | None:
+    if isinstance(payload, dict):
+        value = payload.get(key)
+        if isinstance(value, bool):
+            return value
+    return None
+
+
+def _nested_text(payload: object, block: str, key: str) -> str | None:
+    if isinstance(payload, dict):
+        inner = payload.get(block)
+        if isinstance(inner, dict):
+            return _text(inner, key)
+    return None
+
+
+def _nested_bool(payload: object, block: str, key: str) -> bool | None:
+    if isinstance(payload, dict):
+        inner = payload.get(block)
+        if isinstance(inner, dict):
+            return _bool(inner, key)
+    return None
+
+
+def _price(payload: object, key: str) -> float | None:
+    """Pricing arrives as a decimal string, e.g. "0.0000001". Parse, don't cast."""
+    raw = _nested_text(payload, "pricing", key)
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+def _provider(model_id: str | None) -> str | None:
+    """The prefix before the first "/" in the model id, e.g. "anthropic"."""
+    if not model_id or "/" not in model_id:
+        return None
+    return model_id.split("/", 1)[0]
+
+
+def _created_at(payload: object) -> datetime | None:
+    epoch = _int(payload, "created")
+    if epoch is None:
+        return None
+    try:
+        return datetime.fromtimestamp(epoch, tz=timezone.utc).replace(tzinfo=None)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _supported_parameters(payload: object) -> str:
+    if isinstance(payload, dict):
+        value = payload.get("supported_parameters")
+        if isinstance(value, list):
+            return json.dumps(value)
+    return json.dumps([])
+
+
+@oso.model(
+    external_origins=["https://openrouter.ai"],
+    capabilities=oso.Capabilities(fetch=True),
+)
+def models(context: oso.Context) -> oso.DataFrame:
+    headers = {"User-Agent": USER_AGENT}
+
+    response = None
+    delay = 1.0
+    for attempt in range(MAX_ATTEMPTS):
+        response = context.fetch(OPENROUTER_URL, headers=headers)
+        if response.status == 200:
+            break
+        if response.status not in TRANSIENT_STATUSES or attempt == MAX_ATTEMPTS - 1:
+            raise RuntimeError(
+                f"OpenRouter returned {response.status} after {attempt + 1} attempt(s)"
+            )
+        time.sleep(delay)
+        delay *= 2
+
+    if response is None or response.status != 200:
+        raise RuntimeError("OpenRouter did not return a successful response")
+
+    records = _records(response.json())
+    if not records:
+        raise RuntimeError("OpenRouter returned no models")
+
+    fetched = datetime.now(timezone.utc).replace(tzinfo=None, microsecond=0)
+
+    rows: list[dict] = []
+    for record in records:
+        model_id = _text(record, "id")
+        rows.append(
+            {
+                "model_id": model_id,
+                "name": _text(record, "name"),
+                "provider": _provider(model_id),
+                "created": _created_at(record),
+                "context_length": _int(record, "context_length"),
+                "pricing_prompt": _price(record, "prompt"),
+                "pricing_completion": _price(record, "completion"),
+                "architecture_modality": _nested_text(record, "architecture", "modality"),
+                "architecture_tokenizer": _nested_text(record, "architecture", "tokenizer"),
+                "top_provider_is_moderated": _nested_bool(
+                    record, "top_provider", "is_moderated"
+                ),
+                "supported_parameters": _supported_parameters(record),
+                "fetched_at": fetched,
+            }
+        )
+
+    schema: dict = {
+        "model_id": pl.Utf8,
+        "name": pl.Utf8,
+        "provider": pl.Utf8,
+        "created": pl.Datetime("us"),
+        "context_length": pl.Int64,
+        "pricing_prompt": pl.Float64,
+        "pricing_completion": pl.Float64,
+        "architecture_modality": pl.Utf8,
+        "architecture_tokenizer": pl.Utf8,
+        "top_provider_is_moderated": pl.Boolean,
+        "supported_parameters": pl.Utf8,
+        "fetched_at": pl.Datetime("us"),
+    }
+    return pl.DataFrame(rows, schema=schema)


### PR DESCRIPTION
Brings the whole deployed identity graph under ADR-003 governance, records GoodAIList's return to
the dependency graph, and retires the `--allow-unprovisioned` escape hatch now that nothing is
unprovisioned.

## Seven mirrors, seven contracts

Read-only mirrors under `warehouse/models/identity/`, each byte-identical to that model's released
revision on the platform, plus a dependency contract in `warehouse/dependencies.yaml` carrying the
grain from the model's own header, `freshness_requirement: <= 8 days (weekly platform refresh)`,
`owner: oso`, `verified_revision`, a `mirror` block (model id, revision, platform hash,
`local_sha256`, `synced_at`) and `platform_schedule` (`30 5 * * 0` UTC, `last_observed_trigger:
MANUAL` — the dataset cron is configured but has never fired).

| Table | Model id | Rev |
|---|---|---|
| `identity.artifact_nodes` | `0840576c-47d4-4152-bfac-9e38c5272281` | 3 |
| `identity.candidates` | `fbe4495a-8908-4e04-9269-1727d88a0bf5` | 3 |
| `identity.artifact_identity_edges` | `6e2c9743-16ca-4a56-b84f-c83fd9a37774` | 4 |
| `identity.membership_edges` | `cb3be49c-a049-4874-885b-f940a263632c` | 2 |
| `identity.equivalence_edges` | `10fc9fc9-799b-454b-bead-6b7fb91e2123` | 5 |
| `identity.org_edges` | `d64df19d-4f58-46db-89d4-83d8dad206eb` | 3 |
| `identity.digest` | `8c2cdffc-58c7-4ea3-b90f-eef0e5c8cca3` | 4 |

Every mirror was diffed against the platform's released code, not against a local working copy.
Six matched it exactly. `identity.digest` did not: the working copy carried expanded comments that
were never released. The platform wins, so the mirror is revision 4's code; the difference is 52
comment lines and no SQL.

`build/identity_eval.py` and `build/identity_digest.py` are the two in-repo readers and both are
audit roots, which is what puts the dataset inside the reachability closure. With all seven
deployed, the earlier "needed by a governed reader but absent from `dependencies.yaml`" violations
for `equivalence_edges` and `org_edges` are gone.

## Pool feeds

The mirrors read three feeds with no other in-repo reader, so each is mirrored and contracted the
same way: `signal_hfhub.model_universe` (rev 3), `signal_openrouter.models` (rev 2),
`signal_goodailist.repo_catalog` (rev 4).

## The GoodAIList reclaim

`currentai.signal_goodailist.repo_catalog` was externalized on 2026-08-30
(`frozen-without-producer`) in the 28-table long-tail cleanup. `artifact_nodes`'s `gh` CTE reads
it, so it is contracted again, recorded through the mechanism #481 added: a `reclaims` record in
`warehouse/audits/externalization.json` with `reclaimed_count: 1` and `still_external_count: 27`.
`count: 28` and the original `assets` entry are byte-identical — they are history. The mirror is
restored at `warehouse/models/signal_goodailist/repo_catalog.py`, content-bound by the contract's
hashes.

The reclaim fixtures in `tests/test_scope_gates.py` now replace the committed contract and receipt
state rather than appending beside it, so the no-contract and no-reclaim cases still fire now that
both exist for real. No gate was loosened.

## `--allow-unprovisioned` is retired

Both workflows drop the flag, and both readers now refuse it.

The old refusal read `warehouse/assets.yaml` for an `identity.*` asset marked
`materialized: true`. Under ADR-003 that can never happen: a platform-authored table is a
dependency contract, never a governed asset, so the check would have read empty however deployed
the dataset was. A contract with a `mirror` block is the equivalent record — it pins a model id, a
released revision and the hash of the mirrored code, none of which can be written for a table that
does not exist. So `build/identity_eval.py` gains `_identity_dataset_contracted()` (and names
whichever record refused the flag), and `build/identity_digest.py` gains `_digest_is_contracted()`
and refuses before any query is attempted. The asset check stays, so both signals count.

Two tests pin the flag shut: it is refused against the committed tree, and neither workflow may
pass it while the contracts stand.

## Also

- `warehouse/assets.yaml` gains derived `read_by` entries for the registry tables the new mirrors
  read; `warehouse/audits/platform_models.json`'s two projected fields (`in_scope_reads`,
  `has_repository_source`) re-derived read-only, no platform fetch.
- `docs/operations/deploy-models.md`: an identity row in the deploy table, the Sunday 05:30 UTC
  schedule row, and the resync step a maintainer owes a contract after any `identity.*` release.
- `docs/reference/identity.md`: a "Where the graph lives" section naming all seven tables and both
  readers.
- `current-state-dag.md` regenerated with the repo generator; count markers updated
  (`dependencies` 8 → 18, `tracked_warehouse_files` 33 → 36, `model_files` 22 → 25). The stale
  `38 governed assets + 8 dependency contracts` figures in `CLAUDE.md` and ADR-003 corrected to
  42 + 18.

## Test plan

- `uv run pytest tests/test_scope_gates.py tests/test_assets_inventory.py tests/test_docs_integrity.py tests/test_schedule_doc.py tests/test_identity_eval.py tests/test_identity_digest.py -q -n 4` — 287 passed
- `uv run python -m build.validate` — 0 errors, 2 pre-existing warnings
- `uv run pytest -q -n 4 -m "not serial"` — 1527 passed
- `role_violations`, `dependency_violations`, `externalization_receipt_violations`,
  `reclaim_violations` — 0 each

Refs #365
