### PR TITLE
Measure org recall against recoverable truth

### DIFF
--- a/build/identity_eval.py
+++ b/build/identity_eval.py
@@ -100,6 +100,29 @@ artifacts in the corpus today genuinely belong to two orgs each
 which silently kept only the first org read and scored the second as a false positive. Every
 emitted org in the truth set for a candidate counts as correct.
 
+## Org recall is measured against recoverable truth
+
+The graph can only recover an org through a declared handle in `sources/org_handles.yaml`
+(`registry.org_handles` once published) -- there is no other route from an artifact to an
+org. Org truth, however, is every declared `(candidate_key, org_slug)` pair bridged through a
+product's org roster, whether or not that org happens to declare a handle -- most of the
+corpus does (302 of 347 orgs, any platform, as of this writing), but a curation gap in
+`org_handles.yaml` is not a graph defect, and scoring recall against the full, unrestricted
+truth set bounds recall at the coverage fraction no matter how good the graph is. So **org
+recall truth is restricted to pairs whose `org_slug` declares at least one handle** (any
+platform) in `sources/org_handles.yaml` -- `Truth.recoverable_orgs`, loaded via the same
+optional-YAML loader `build.validate` uses (`_load_optional_yaml`, tolerant of the file not
+existing at all in an older tree). Precision truth is unchanged: every emitted org edge is
+still judged against the full truth set, since an edge to an org with no handle is either
+wrong (real false positive) or a graph capability this eval has no business hiding.
+
+Two things stay visible so the restriction cannot quietly hide the curation gap: the eval
+prints a `handle coverage: <orgs with >=1 handle>/<orgs rostered> (<pct>)` line (`orgs
+rostered` = every organization with at least one product on its roster, the population org
+truth is drawn from), and `Metrics.n_truth_unrecoverable` -- the truth pairs dropped from
+`org`'s recall denominator because their org has no handle -- appears in the table for every
+relation (0 except for `org`).
+
 ## What `--from-warehouse` supplies, and what it does not
 
 Only the four edge tables -- `currentai.identity.{artifact_identity,membership,equivalence,
@@ -174,6 +197,7 @@ import yaml
 from build import resolution
 from build.identity import KINDS, fold_for_proposal
 from build.serialize_registry import artifact_id
+from build.validate import _load_optional_yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 ASSETS_PATH = ROOT / "warehouse" / "assets.yaml"
@@ -416,6 +440,12 @@ class Truth:
     `route_kinds`: artifact kinds `sources/signal_routing.yaml` compiles at least one adoption
     route for -- used only to split membership truth into scoring/non-scoring buckets for
     `n_truth`, mirroring `identity_membership_edges.sql`'s own `scoring_bearing` derivation.
+    `recoverable_orgs`: rostered org slugs (every org with >=1 product on its roster) that
+    declare at least one handle in `sources/org_handles.yaml` -- the graph's only route from an
+    artifact to an org. `org` recall truth is restricted to this set (see the module docstring
+    "Org recall is measured against recoverable truth"); `org` precision truth is not.
+    `orgs_rostered`: every rostered org slug, recoverable or not -- the denominator of the
+    `handle coverage` line (`org_handle_coverage`).
     """
 
     equivalence: dict[str, str] = field(default_factory=dict)
@@ -424,6 +454,8 @@ class Truth:
     org: dict[str, set[str]] = field(default_factory=dict)
     identity_pairs: set[tuple[str, str, str]] = field(default_factory=set)
     route_kinds: frozenset[str] = field(default_factory=frozenset)
+    recoverable_orgs: frozenset[str] = field(default_factory=frozenset)
+    orgs_rostered: frozenset[str] = field(default_factory=frozenset)
 
 
 @dataclass
@@ -432,6 +464,10 @@ class Metrics:
     recall: float | None
     n_truth: int
     n_emitted_at_threshold: int
+    # Truth pairs excluded from `n_truth`/recall because they cannot be recovered by the graph
+    # at all -- only meaningful for `org` (an org with no declared handle in
+    # `sources/org_handles.yaml`); 0 for every other relation.
+    n_truth_unrecoverable: int = 0
 
 
 class KnownNegativeDeclaredError(ValueError):
@@ -500,6 +536,32 @@ def _membership_from_ledger(entries: Iterable[dict]) -> dict[tuple[Key, str], bo
         if slug:
             out[(resolution.artifact_of(entry), slug)] = entry["verdict"] == "member_of"
     return out
+
+
+ORG_HANDLES_PATH = ROOT / "sources" / "org_handles.yaml"
+
+
+def _orgs_with_handles(path: Path = ORG_HANDLES_PATH) -> frozenset[str]:
+    """Org slugs that declare at least one handle (any platform) in `sources/org_handles.yaml`.
+
+    Reuses `build.validate._load_optional_yaml` -- the same loader `validate_sources` reads
+    this file with -- so an older tree that predates the file (no `sources/org_handles.yaml`
+    at all) reads as "no orgs declare a handle" rather than raising, exactly as it does there.
+    """
+    doc = _load_optional_yaml(path, {"version": 1, "handles": []})
+    return frozenset(
+        entry["org"]
+        for entry in doc.get("handles") or []
+        if isinstance(entry, dict) and isinstance(entry.get("org"), str)
+    )
+
+
+def org_handle_coverage(truth: Truth) -> tuple[int, int]:
+    """`(orgs with >=1 handle, orgs rostered)` -- the two numbers behind the `handle coverage`
+    line. `truth.recoverable_orgs` is already restricted to rostered orgs (see `load_truth`),
+    so its size is the numerator directly.
+    """
+    return len(truth.recoverable_orgs), len(truth.orgs_rostered)
 
 
 def _route_kinds() -> frozenset[str]:
@@ -587,6 +649,9 @@ def load_truth(known_negatives: tuple[dict[str, str], ...] = KNOWN_NEGATIVES) ->
             )
         membership[(key, neg["product_slug"])] = False
 
+    orgs_rostered = frozenset(o for orgs in product_org.values() for o in orgs)
+    recoverable_orgs = orgs_rostered & _orgs_with_handles()
+
     return Truth(
         equivalence=equivalence,
         equivalence_negatives=equivalence_negatives,
@@ -594,6 +659,8 @@ def load_truth(known_negatives: tuple[dict[str, str], ...] = KNOWN_NEGATIVES) ->
         org=org,
         identity_pairs=identity_pairs,
         route_kinds=_route_kinds(),
+        recoverable_orgs=recoverable_orgs,
+        orgs_rostered=orgs_rostered,
     )
 
 
@@ -652,15 +719,26 @@ def _score_org(emitted: list[dict], truth: Truth) -> Metrics:
     correctly emitted org as a false positive. `n_truth` counts distinct
     `(candidate_key, org_slug)` PAIRS, not distinct candidate_keys, so a two-org artifact
     counts as two truth items for recall, not one.
+
+    Recall truth is further restricted to pairs whose org declares a handle
+    (`truth.recoverable_orgs` -- see the module docstring "Org recall is measured against
+    recoverable truth"); precision truth is not. `correct_fn` returns `tk = None` for a
+    correct-but-unrecoverable match, which keeps it out of `matched_truth`/recall (via `_score`
+    filtering `tk is not None`) while it still counts toward `n_correct`/precision, since
+    `is_correct` is `True` either way.
     """
 
     def correct_fn(e: dict):
         ck, slug = e.get("candidate_key"), e.get("org_slug")
         ok = slug in truth.org.get(ck, ())
-        return ok, ((ck, slug) if ok else None)
+        recoverable = ok and slug in truth.recoverable_orgs
+        return ok, ((ck, slug) if recoverable else None)
 
-    n_truth = sum(len(orgs) for orgs in truth.org.values())
-    return _score(emitted, _org_key, correct_fn, n_truth)
+    n_truth_total = sum(len(orgs) for orgs in truth.org.values())
+    n_truth = sum(1 for orgs in truth.org.values() for slug in orgs if slug in truth.recoverable_orgs)
+    metrics = _score(emitted, _org_key, correct_fn, n_truth)
+    metrics.n_truth_unrecoverable = n_truth_total - n_truth
+    return metrics
 
 
 def _identity_pair(e: dict) -> tuple[str, str, str]:
@@ -692,7 +770,7 @@ def _score_tiered(rows: list[dict], truth: Truth, relation: str, score_fn, key_f
     emitted_pool = [e for e in pool if emits(e, relation)]
     metrics = score_fn(emitted_declared, truth)
     pool_count = len({key_fn(e) for e in emitted_pool})
-    return Metrics(metrics.precision, metrics.recall, metrics.n_truth, pool_count)
+    return Metrics(metrics.precision, metrics.recall, metrics.n_truth, pool_count, metrics.n_truth_unrecoverable)
 
 
 def replay(edges: dict[str, list[dict]], truth: Truth) -> dict[str, Metrics]:
@@ -934,7 +1012,7 @@ def floor_failures(metrics: dict[str, Metrics]) -> list[str]:
 def print_table(metrics: dict[str, Metrics]) -> None:
     header = (
         f"{'relation':24s} {'precision':>10s} {'recall':>10s} {'n_truth':>8s} "
-        f"{'n_emitted':>10s}  status"
+        f"{'n_emitted':>10s} {'n_unrecov':>10s}  status"
     )
     print(header)
     print("-" * len(header))
@@ -944,7 +1022,11 @@ def print_table(metrics: dict[str, Metrics]) -> None:
         recall = f"{m.recall:.3f}" if m and m.recall is not None else "n/a"
         n_truth = m.n_truth if m else 0
         n_emitted = m.n_emitted_at_threshold if m else 0
-        print(f"{relation:24s} {precision:>10s} {recall:>10s} {n_truth:>8d} {n_emitted:>10d}  {floor_status(relation, metrics)}")
+        n_unrecov = m.n_truth_unrecoverable if m else 0
+        print(
+            f"{relation:24s} {precision:>10s} {recall:>10s} {n_truth:>8d} {n_emitted:>10d} "
+            f"{n_unrecov:>10d}  {floor_status(relation, metrics)}"
+        )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1012,6 +1094,10 @@ def main(argv: list[str] | None = None) -> int:
     truth = load_truth()
     metrics = replay(edges, truth)
     print_table(metrics)
+
+    n_with_handle, n_rostered = org_handle_coverage(truth)
+    pct = (100 * n_with_handle / n_rostered) if n_rostered else 0.0
+    print(f"\nhandle coverage: {n_with_handle}/{n_rostered} ({pct:.1f}%)")
 
     if args.floors:
         failures = floor_failures(metrics)

--- a/docs/reference/identity.md
+++ b/docs/reference/identity.md
@@ -257,6 +257,15 @@ error, folded the same way any other identity comparison is (case-insensitive, a
 `princeton-nlp-openai` — the handle is assigned to the public or canonical org, and the row's
 `note` names the sibling; the sibling org file is untouched.
 
+A handle is also the graph's only route from an artifact to an org, which is why
+`build/identity_eval.py` measures `org` recall against **recoverable** truth rather than every
+declared `(candidate_key, org_slug)` pair: an org with no handle can never be recovered no matter
+how good the graph is, so including it would bound recall at the coverage fraction and read as a
+graph defect instead of the curation gap it actually is. Precision truth is unaffected — every
+emitted org edge is still judged against the full truth set. The eval prints a `handle coverage:
+<orgs with a handle>/<orgs rostered> (<pct>)` line so the gap stays visible as its own number
+rather than disappearing into a passing recall score.
+
 ### Model families bridge a release name to a tier-level slug
 
 Vendors ship version-numbered releases under one product line — `grok-3`, `grok-4` — but the map

--- a/tests/test_identity_eval.py
+++ b/tests/test_identity_eval.py
@@ -38,6 +38,7 @@ from build.identity_eval import (
     load_edges_from_warehouse,
     load_truth,
     main,
+    org_handle_coverage,
     replay,
     validate_columns,
 )
@@ -245,7 +246,7 @@ def test_duplicate_head_tail_edges_collapse_in_precision_and_recall():
 
 
 def test_recall_cannot_exceed_one():
-    truth = Truth(org={"github:a/b": {"acme"}})
+    truth = Truth(org={"github:a/b": {"acme"}}, recoverable_orgs=frozenset({"acme"}))
     edges = {
         "org": [
             {"candidate_key": "github:a/b", "candidate_tier": "head", "org_slug": "acme",
@@ -287,7 +288,7 @@ def test_org_truth_holds_more_than_one_org_per_candidate_key_in_the_real_corpus(
 def test_second_org_for_a_shared_candidate_key_scores_correct_not_a_false_positive():
     """The F5 bug: `dict.setdefault` kept only the first org read and scored the second,
     equally correct org as a false positive. Both must score correct now."""
-    truth = Truth(org={"github:a/b": {"org-one", "org-two"}})
+    truth = Truth(org={"github:a/b": {"org-one", "org-two"}}, recoverable_orgs=frozenset({"org-one", "org-two"}))
     edges = {"org": [
         {"candidate_key": "github:a/b", "candidate_tier": "head", "org_slug": "org-one",
          "confidence": 1.0, "method": ["org_handle"]},
@@ -302,6 +303,68 @@ def test_second_org_for_a_shared_candidate_key_scores_correct_not_a_false_positi
 
 def test_org_n_truth_counts_pairs_not_candidate_keys():
     assert sum(len(orgs) for orgs in REAL_TRUTH.org.values()) > len(REAL_TRUTH.org)
+
+
+# ---------------------------------------------------------------------------
+# org recall is measured against recoverable truth (an org must declare a handle)
+# ---------------------------------------------------------------------------
+
+
+def test_org_without_a_handle_drops_out_of_recall_truth():
+    """An org with no declared handle can never be recovered by the graph, so it must not
+    inflate `org`'s recall denominator -- `n_truth` counts only pairs whose org is
+    recoverable."""
+    truth = Truth(
+        org={"github:a/b": {"has-handle"}, "github:c/d": {"no-handle"}},
+        recoverable_orgs=frozenset({"has-handle"}),
+        orgs_rostered=frozenset({"has-handle", "no-handle"}),
+    )
+    m = replay({"org": []}, truth)["org"]
+    assert m.n_truth == 1
+    assert m.n_truth_unrecoverable == 1
+
+
+def test_emitted_edge_to_a_handle_less_org_still_counts_toward_precision():
+    """Precision truth is unchanged: an edge correctly naming an org with no declared handle
+    is still a correct edge, and must not be scored as a false positive just because that org
+    cannot contribute to recall."""
+    truth = Truth(
+        org={"github:a/b": {"no-handle"}},
+        recoverable_orgs=frozenset(),
+        orgs_rostered=frozenset({"no-handle"}),
+    )
+    edges = {"org": [
+        {"candidate_key": "github:a/b", "candidate_tier": "head", "org_slug": "no-handle",
+         "confidence": 1.0, "method": ["org_handle"]},
+    ]}
+    m = replay(edges, truth)["org"]
+    assert m.precision == 1.0  # still counted correct for precision
+    assert m.n_truth == 0  # but excluded from the recall denominator
+    assert m.recall is None  # no recoverable truth at all -- nothing to have recalled
+    assert m.n_truth_unrecoverable == 1
+
+
+def test_handle_coverage_computed_correctly_on_a_fixture():
+    truth = Truth(
+        recoverable_orgs=frozenset({"a", "b"}),
+        orgs_rostered=frozenset({"a", "b", "c", "d"}),
+    )
+    assert org_handle_coverage(truth) == (2, 4)
+
+
+def test_org_handle_coverage_against_the_real_corpus_matches_recoverable_orgs():
+    n_with_handle, n_rostered = org_handle_coverage(REAL_TRUTH)
+    assert n_with_handle == len(REAL_TRUTH.recoverable_orgs)
+    assert n_rostered == len(REAL_TRUTH.orgs_rostered)
+    assert 0 < n_with_handle <= n_rostered
+
+
+def test_non_org_relations_carry_zero_n_truth_unrecoverable():
+    truth = Truth(equivalence={"github:a/b": "p"})
+    edges = {"equivalence": [{"candidate_key": "github:a/b", "candidate_tier": "head",
+                              "product_slug": "p", "confidence": 1.0, "method": ["m"]}]}
+    m = replay(edges, truth)["equivalence"]
+    assert m.n_truth_unrecoverable == 0
 
 
 # ---------------------------------------------------------------------------
@@ -490,7 +553,7 @@ def test_floor_status_not_evaluated_when_relation_absent():
 
 
 def test_floor_status_checked_and_failing():
-    truth = Truth(org={f"github:{i}/x": {"acme"} for i in range(30)})
+    truth = Truth(org={f"github:{i}/x": {"acme"} for i in range(30)}, recoverable_orgs=frozenset({"acme"}))
     edges = {"org": [
         {"candidate_key": f"github:{i}/x", "candidate_tier": "head", "org_slug": "wrong",
          "confidence": 1.0, "method": ["org_handle"]}
@@ -502,7 +565,7 @@ def test_floor_status_checked_and_failing():
 
 
 def test_floor_status_checked_and_passing():
-    truth = Truth(org={f"github:{i}/x": {"acme"} for i in range(30)})
+    truth = Truth(org={f"github:{i}/x": {"acme"} for i in range(30)}, recoverable_orgs=frozenset({"acme"}))
     edges = {"org": [
         {"candidate_key": f"github:{i}/x", "candidate_tier": "head", "org_slug": "acme",
          "confidence": 1.0, "method": ["org_handle"]}
@@ -517,7 +580,7 @@ def test_floor_status_abstains_on_precision_when_nothing_emitted():
     """SF2: `precision is None` (the declared slice emitted nothing at all) must not read as
     0.0 and fail a precision floor for a reason that is not a precision problem -- only
     recall's real 0.0 should fail here."""
-    truth = Truth(org={f"github:{i}/x": {"acme"} for i in range(30)})
+    truth = Truth(org={f"github:{i}/x": {"acme"} for i in range(30)}, recoverable_orgs=frozenset({"acme"}))
     edges = {"org": []}  # nothing emitted at all
     metrics = replay(edges, truth)
     assert metrics["org"].precision is None


### PR DESCRIPTION
## Why

`org` recall was scored against every declared `(candidate_key, org_slug)` pair, but the
graph's only route from an artifact to an org is a declared handle in
`sources/org_handles.yaml`. 45 of 347 orgs declare no handle on any platform, which bounds
recall at the coverage fraction no matter how good the graph is -- a curation gap in
`org_handles.yaml`, not a defect in the identity graph. A permanently red Monday eval on that
basis is not useful signal.

## The rule

Org recall truth is restricted to `(candidate_key, org_slug)` pairs whose `org_slug` declares
at least one handle (any platform) in `sources/org_handles.yaml`. Precision truth is
unchanged -- every emitted org edge is still judged against the full truth set, so an edge to
a handle-less org still counts as a real false positive if wrong. The eval now prints a
`handle coverage: <orgs with a handle>/<orgs rostered> (<pct>)` line, and `Metrics` carries
`n_truth_unrecoverable` (0 except for `org`), so the curation gap stays visible instead of
disappearing into a passing or failing recall number.

## Live table

Before (org recall against unrestricted truth):

```
org        0.989      0.328      845       1199    checked (FAIL)
```

After (org recall against recoverable truth):

```
relation                  precision     recall  n_truth  n_emitted  n_unrecov  status
-------------------------------------------------------------------------------------
org                           0.989      0.371      747       1199         98  checked (FAIL)

handle coverage: 302/347 (87.0%)
```

`org` still misses its recall floor (0.371 vs 0.85) -- restricting to recoverable truth is
about measuring the graph honestly, not about clearing the floor. The remaining gap is
closing the 45-org handle-coverage hole and/or improving how the graph uses the handles it
already has.

## Test plan

- `uv run pytest tests/test_identity_eval.py tests/test_docs_integrity.py -q -n 4` -- 81 passed
- `uv run python -m build.identity_eval --from-warehouse --floors` -- live run, table above
- `uv run pytest -q -n 4 -m "not serial"` -- 1510 passed

Refs #365