### PR TITLE
Publish the registry tables to Neon

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -177,8 +177,15 @@ jobs:
           NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
         run: uv run python -m build.publish_neon
       # Read the schema back independently and put the counts in the run summary. A publish
-      # returning 0 says the swap committed; this says what a reader now sees.
+      # returning 0 says the swap committed; this says what a reader now sees. Also teed to
+      # the step log, because the run summary is only readable in the web UI and this is the
+      # record you want when comparing two runs from a terminal. The report carries no part
+      # of the DSN, by construction — see build/neon_status.py.
       - name: Report what Neon is serving
         env:
           NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
-        run: uv run python -m build.neon_status >> "$GITHUB_STEP_SUMMARY"
+        # pipefail explicitly: the runner's shell is `bash -e` without it, so `tee` would
+        # succeed and the step would pass over a read-back that failed.
+        run: |
+          set -o pipefail
+          uv run python -m build.neon_status | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -168,7 +168,7 @@ jobs:
           OSO_ORG_ID: ${{ vars.OSO_ORG_ID }}
         run: uv run python -m build.publish_registry
       # The site's serving layer, after OSO rather than instead of it. The load goes into
-      # gapmap_staging and is swapped into gapmap in one transaction, so a reader mid-request
+      # os-ai-map_staging and is swapped into os-ai-map in one transaction, so a reader mid-request
       # sees the old schema or the new one. No `if:` guard on the secret: an absent
       # NEON_DATABASE_URL must fail this step loudly, because a publish that quietly skips
       # leaves the site serving whatever the last successful run left behind.

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -38,6 +38,7 @@ on:
       - "build/resolution.py"
       - "build/vocabulary.py"
       - "build/publish_registry.py"
+      - "build/publish_neon.py"
       - ".github/workflows/registry.yml"
   push:
     branches: [main]
@@ -64,6 +65,7 @@ on:
       - "build/resolution.py"
       - "build/vocabulary.py"
       - "build/publish_registry.py"
+      - "build/publish_neon.py"
   workflow_dispatch:
 
 jobs:
@@ -102,6 +104,10 @@ jobs:
       # here on the PR instead.
       - name: Check the scores table builds
         run: uv run python -m build.serialize_scores --check
+      # The Neon plan: which tables would be created and what type each column would get.
+      # Connects to nothing and needs no secret, so it runs on a fork PR too.
+      - name: Check the Neon publish plan
+        run: uv run python -m build.publish_neon --check
 
   # On main, serialize and push. Static models are created on first run and
   # reused after, so this is safe to run on every change to sources/.
@@ -136,3 +142,12 @@ jobs:
           # Org id is not sensitive, so it lives as a repo variable rather than a secret.
           OSO_ORG_ID: ${{ vars.OSO_ORG_ID }}
         run: uv run python -m build.publish_registry
+      # The site's serving layer, after OSO rather than instead of it. The load goes into
+      # gapmap_staging and is swapped into gapmap in one transaction, so a reader mid-request
+      # sees the old schema or the new one. No `if:` guard on the secret: an absent
+      # NEON_DATABASE_URL must fail this step loudly, because a publish that quietly skips
+      # leaves the site serving whatever the last successful run left behind.
+      - name: Publish to Neon
+        env:
+          NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+        run: uv run python -m build.publish_neon

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -39,6 +39,9 @@ on:
       - "build/vocabulary.py"
       - "build/publish_registry.py"
       - "build/publish_neon.py"
+      - "build/neon_schema.py"
+      - "build/neon_status.py"
+      - "build/notebook_data.json"
       - ".github/workflows/registry.yml"
   push:
     branches: [main]
@@ -66,7 +69,20 @@ on:
       - "build/vocabulary.py"
       - "build/publish_registry.py"
       - "build/publish_neon.py"
+      - "build/neon_schema.py"
+      - "build/neon_status.py"
+      # The site tables in Neon are built from the payload, so a regeneration of it is a
+      # change to what the serving layer holds.
+      - "build/notebook_data.json"
   workflow_dispatch:
+    inputs:
+      neon_only:
+        description: >-
+          Load Neon from the dispatched ref and skip the OSO publish. For verifying the
+          Postgres serving layer from a branch: the OSO static models are org-wide and a
+          branch must not overwrite them, so a branch run publishes to Neon alone.
+        type: boolean
+        default: false
 
 jobs:
   # On a PR, prove the registry is internally consistent. Structural problems
@@ -111,6 +127,12 @@ jobs:
 
   # On main, serialize and push. Static models are created on first run and
   # reused after, so this is safe to run on every change to sources/.
+  #
+  # A `workflow_dispatch` with `neon_only=true` runs the same job on the dispatched ref with
+  # the OSO publish skipped. That is how the Postgres serving layer gets verified from a
+  # branch: the Neon schema is swapped atomically and re-loadable, so a branch run costs
+  # nothing beyond a reload, whereas the OSO static models are org-wide and a branch must not
+  # overwrite them.
   publish:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
@@ -136,7 +158,10 @@ jobs:
         run: uv run python -m build.serialize_routing
       - name: Serialize the recorded scores
         run: uv run python -m build.serialize_scores
+      # Skipped on a `neon_only` dispatch. `inputs.neon_only` is empty on a push, so the
+      # negation is true there and the normal path is untouched.
       - name: Publish to OSO
+        if: ${{ !inputs.neon_only }}
         env:
           OSO_API_KEY: ${{ secrets.OSO_API_KEY }}
           # Org id is not sensitive, so it lives as a repo variable rather than a secret.
@@ -151,3 +176,9 @@ jobs:
         env:
           NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
         run: uv run python -m build.publish_neon
+      # Read the schema back independently and put the counts in the run summary. A publish
+      # returning 0 says the swap committed; this says what a reader now sees.
+      - name: Report what Neon is serving
+        env:
+          NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+        run: uv run python -m build.neon_status >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -74,15 +74,11 @@ on:
       # The site tables in Neon are built from the payload, so a regeneration of it is a
       # change to what the serving layer holds.
       - "build/notebook_data.json"
+  # A dispatch always means "load Neon from this ref, leave OSO alone". No input decides it:
+  # the OSO static models are org-wide, and a flag defaulting to false meant that forgetting
+  # `-f neon_only=true` published a branch's declarations over them. The guard is the event
+  # and the ref, which nobody can forget. tests/test_registry_triggers.py pins it.
   workflow_dispatch:
-    inputs:
-      neon_only:
-        description: >-
-          Load Neon from the dispatched ref and skip the OSO publish. For verifying the
-          Postgres serving layer from a branch: the OSO static models are org-wide and a
-          branch must not overwrite them, so a branch run publishes to Neon alone.
-        type: boolean
-        default: false
 
 jobs:
   # On a PR, prove the registry is internally consistent. Structural problems
@@ -128,11 +124,10 @@ jobs:
   # On main, serialize and push. Static models are created on first run and
   # reused after, so this is safe to run on every change to sources/.
   #
-  # A `workflow_dispatch` with `neon_only=true` runs the same job on the dispatched ref with
-  # the OSO publish skipped. That is how the Postgres serving layer gets verified from a
-  # branch: the Neon schema is swapped atomically and re-loadable, so a branch run costs
-  # nothing beyond a reload, whereas the OSO static models are org-wide and a branch must not
-  # overwrite them.
+  # A `workflow_dispatch` runs the same job on the dispatched ref with the OSO publish
+  # skipped. That is how the Postgres serving layer gets verified from a branch: the Neon
+  # schema is swapped atomically and re-loadable, so a branch run costs nothing beyond a
+  # reload, whereas the OSO static models are org-wide and a branch must not overwrite them.
   publish:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
@@ -158,16 +153,17 @@ jobs:
         run: uv run python -m build.serialize_routing
       - name: Serialize the recorded scores
         run: uv run python -m build.serialize_scores
-      # Skipped on a `neon_only` dispatch. `inputs.neon_only` is empty on a push, so the
-      # negation is true there and the normal path is untouched.
+      # Push to main only. The static models are org-wide, so a dispatch from any ref —
+      # including main — leaves them alone; there is no flag to forget.
       - name: Publish to OSO
-        if: ${{ !inputs.neon_only }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         env:
           OSO_API_KEY: ${{ secrets.OSO_API_KEY }}
           # Org id is not sensitive, so it lives as a repo variable rather than a secret.
           OSO_ORG_ID: ${{ vars.OSO_ORG_ID }}
         run: uv run python -m build.publish_registry
-      # The site's serving layer, after OSO rather than instead of it. The load goes into
+      # The site's serving layer, after OSO rather than instead of it, and on every event that
+      # reaches this job. The load goes into
       # os-ai-map_staging and is swapped into os-ai-map in one transaction, so a reader mid-request
       # sees the old schema or the new one. No `if:` guard on the secret: an absent
       # NEON_DATABASE_URL must fail this step loudly, because a publish that quietly skips

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ build/observations/
 # Temporary worktree build/check_corpus_diff.py creates to read the base ref's axis rows.
 # Always removed on exit (even on exception); ignored here as a belt-and-braces measure.
 .ccd-worktree/
+
+# Site tables rendered for the Neon publisher: derived from build/notebook_data.json
+build/neon/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,18 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
   `gapmap_staging` and the cutover is three schema renames in one transaction, so a reader
   mid-request sees the whole old schema or the whole new one. A `gapmap.publish_runs` row
   records the commit, the declaration version and the per-table row counts of each load (#365).
+- `build/publish_neon.py` loads the gap map into Neon (Postgres) as the `os-ai-map` schema, so
+  the site can read products, scores and freshness dates at request time instead of loading
+  `build/notebook_data.json`. Two groups of table: the target model from CLEVER FRANKE (products,
+  the three axes, sources, lineage, categories, layers, stages, gaps, aliases, long tail) and the
+  registry tables `publish_registry` publishes, prefixed `registry_`. Eight enums are enforced,
+  and an unmapped payload value fails the load rather than being coerced. It runs in
+  `registry.yml` on every push to `main`, one step after the OSO publish, and needs the
+  `NEON_DATABASE_URL` secret. The load is atomic: rows go into `os-ai-map_staging` and the
+  cutover is three schema renames in one transaction, so a reader mid-request sees the whole old
+  schema or the whole new one. A `publish_runs` row records the commit, the schema version, the
+  build and release dates and the per-table row counts of each load. The table set, grain and
+  types live in `build/neon_schema.py`, which is the one place to change them (#365).
 
 - An explicit `reclaimed-as-dependency` transition in the externalization receipt, so a table that
   an in-scope governed asset starts reading again moves from externalized back into the governed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,10 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
   cutover is three schema renames in one transaction, so a reader mid-request sees the whole old
   schema or the whole new one. A `publish_runs` row records the commit, the schema version, the
   build and release dates and the per-table row counts of each load. The table set, grain and
-  types live in `build/neon_schema.py`, which is the one place to change them (#365).
+  types live in `build/neon_schema.py`, which is the one place to change them. After the load,
+  `build/neon_status.py` connects again and writes the table and row counts a reader now sees,
+  plus the `publish_runs` row, to the run summary; `gh workflow run registry.yml --ref <branch>
+  -f neon_only=true` runs the same load from a branch with the OSO publish skipped (#365).
 
 - An explicit `reclaimed-as-dependency` transition in the externalization receipt, so a table that
   an in-scope governed asset starts reading again moves from externalized back into the governed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,17 +52,24 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
   the site can read products, scores and freshness dates at request time instead of loading
   `build/notebook_data.json`. Two groups of table: the target model from CLEVER FRANKE (products,
   the three axes, sources, lineage, categories, layers, stages, gaps, aliases, long tail) and the
-  registry tables `publish_registry` publishes, prefixed `registry_`. Eight enums are enforced,
-  and an unmapped payload value fails the load rather than being coerced. It runs in
+  registry tables `publish_registry` publishes, prefixed `registry_`. The model's primary keys,
+  `NOT NULL`s, uniques and foreign keys are enforced by the database, so a load that would serve
+  a dangling id fails instead. Five enums are enforced too, and an unmapped payload value fails
+  the load rather than being coerced. It runs in
   `registry.yml` on every push to `main`, one step after the OSO publish, and needs the
   `NEON_DATABASE_URL` secret. The load is atomic: rows go into `os-ai-map_staging` and the
-  cutover is three schema renames in one transaction, so a reader mid-request sees the whole old
-  schema or the whole new one. A `publish_runs` row records the commit, the schema version, the
+  cutover is two schema renames in one transaction, so a reader mid-request sees the whole old
+  schema or the whole new one. Nothing is dropped in that transaction: the old schema is
+  reclaimed at the start of the next run, and only after `pg_depend` shows nothing outside the
+  publisher's own schemas depends on it, because `CASCADE` follows dependencies rather than
+  schema membership. The gallery tables are not published at all — they are CMS-authored, and a
+  schema rebuilt from source cannot hold rows it did not produce. A `publish_runs` row records the commit, the schema version, the
   build and release dates and the per-table row counts of each load. The table set, grain and
   types live in `build/neon_schema.py`, which is the one place to change them. After the load,
   `build/neon_status.py` connects again and writes the table and row counts a reader now sees,
-  plus the `publish_runs` row, to the run summary; `gh workflow run registry.yml --ref <branch>
-  -f neon_only=true` runs the same load from a branch with the OSO publish skipped (#365).
+  the constraint tally and the `publish_runs` row, to the run summary;
+  `gh workflow run registry.yml --ref <branch>` runs the same load from a branch, with the OSO
+  publish guarded on `push` to `main` so a dispatch never reaches it (#365).
 
 - An explicit `reclaimed-as-dependency` transition in the externalization receipt, so a table that
   an in-scope governed asset starts reading again moves from externalized back into the governed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
   the gap where the repo's own gates stay green while the platform releases past a mirror; the
   first runs found eight of seventeen contracts behind. "Mirror resync" in
   `docs/operations/deploy-models.md` is the runbook (#365).
+- `build/publish_neon.py` loads the serialized registry tables into Neon (Postgres) as the
+  `gapmap` schema, so the front end can read the declarations at request time instead of going
+  through the warehouse. It runs in `registry.yml` on every push to `main`, one step after the
+  OSO publish, and requires the `NEON_DATABASE_URL` secret. The load is atomic: rows go into
+  `gapmap_staging` and the cutover is three schema renames in one transaction, so a reader
+  mid-request sees the whole old schema or the whole new one. A `gapmap.publish_runs` row
+  records the commit, the declaration version and the per-table row counts of each load (#365).
 
 - An explicit `reclaimed-as-dependency` transition in the externalization receipt, so a table that
   an in-scope governed asset starts reading again moves from externalized back into the governed

--- a/build/neon_schema.py
+++ b/build/neon_schema.py
@@ -78,6 +78,7 @@ from pathlib import Path
 from typing import Callable
 
 from build.publish_registry import TABLES as REGISTRY_TABLES
+from build.vocabulary import axes
 
 ROOT = Path(__file__).resolve().parents[1]
 PAYLOAD_PATH = ROOT / "build" / "notebook_data.json"
@@ -100,7 +101,9 @@ ENUMS: dict[str, tuple[str, ...]] = {
     "freshness_basis": ("commit", "verified"),
     "lineage_relation": ("derived_from", "curated_with", "trains"),
     "capability_relation": ("tier_below", "tier_above", "peer", "anchor"),
-    "metric_name": ("openness", "adoption", "capability"),
+    # The three scored axes, from the score schema rather than restated here — a fourth axis
+    # must not reach a serving layer whose enum silently rejects it.
+    "metric_name": axes(),
     "health_status": ("healthy", "partial", "gap"),
     "integration_type": ("known_build", "documented_component", "similarity"),
     "gap_type": ("structural", "weak_layer"),
@@ -125,7 +128,7 @@ ENUM_MAPS: dict[str, dict[str, str]] = {
         "two_below": "tier_below",
         "anchor": "anchor",
     },
-    "metric_name": {"openness": "openness", "adoption": "adoption", "capability": "capability"},
+    "metric_name": {axis: axis for axis in axes()},
 }
 
 
@@ -377,7 +380,7 @@ def _sources(payload: dict) -> list[dict]:
     out = []
     next_id = 1
     for slug, _cid, product in _by_slug(payload):
-        for metric in ("openness", "adoption", "capability"):
+        for metric in axes():
             for source in _axis(product, metric).get("sources") or []:
                 if not isinstance(source, dict):
                     continue

--- a/build/neon_schema.py
+++ b/build/neon_schema.py
@@ -314,12 +314,24 @@ def _products(payload: dict) -> list[dict]:
                 f"products.category (a single FK) cannot represent"
             )
         seen.add(slug)
+        org_slug = product.get("org_slug") or ""
+        if not org_slug:
+            # `products.org_slug` is NOT NULL and references `organizations`. Writing "" here
+            # sent an empty string into COPY, which CSV reads as NULL, so the load died on a
+            # constraint naming the column and not the row — leaving whoever hit it to find
+            # which of 615 products was missing an org. The payload's own gates should catch
+            # this first; if one slips through, it slips through named.
+            raise UnmappedValue(
+                f"product {slug!r} has no org_slug, which products.org_slug (NOT NULL, "
+                f"referencing organizations.slug) cannot represent. Give the product an "
+                f"organization in sources/, or the load will refuse it."
+            )
         freshness = _axis(product, "freshness")
         out.append(
             {
                 "id": ids[slug],
                 "slug": slug,
-                "org_slug": product.get("org_slug") or "",
+                "org_slug": org_slug,
                 "name": product.get("product") or "",
                 "org": product.get("org") or "",
                 "type": product.get("type") or "",

--- a/build/neon_schema.py
+++ b/build/neon_schema.py
@@ -27,12 +27,35 @@ is readable. The real key is `slug`, which is what a deep link carries. Organiza
 and the site needs it). Ids for `sources` and `product_lineage` are positional over a
 deterministic walk, for the same reason.
 
+## The constraints are real, and a violation fails the run
+
+Every `[pk]`, `[not null]`, `[unique]` and `ref:` the DBML declares is emitted in the CREATE
+statement, so the database enforces them rather than the site discovering a dangling id at
+render time. `categories.slug` gets a UNIQUE the DBML does not declare, because the column
+itself is an amendment and a duplicate slug would break the deep links it exists for.
+
+That makes a COPY the integrity gate: a NULL in a `[not null]` column, a duplicate key or an
+unresolvable reference aborts the load, the staging schema is discarded and the live schema
+stays exactly where it was. Failing there is the point — the alternative is a serving layer
+that answers with a foreign key pointing at nothing.
+
+`SITE_TABLES` is therefore ordered parents-first: every table's referents are created and
+filled before it is. `tests/test_publish_neon.py` asserts that order against the declared
+references rather than trusting the dict's shape.
+
 ## Enums are enforced, never coerced
 
-The eight enums are created in the schema and the payload's values are mapped onto them by
+The five enums are created in the schema and the payload's values are mapped onto them by
 `ENUM_MAPS`. A value with no mapping raises `UnmappedValue` and fails the load naming the
 value and the column — a serving layer that silently coerced an unknown vocabulary item to
 something adjacent would be worse than one that stopped.
+
+The DBML declares eight. `health_status`, `integration_type` and `gap_type` belong to the
+gallery tables, which are not here (see "What the CMS owns" below), so the types are not
+created either: an enum no column can reference is dead metadata, and one created *here*
+would be worse than dead, because a CMS table referencing it would acquire a dependency on a
+schema this publisher renames out from under it on every load. The vocabulary stays declared
+in the DBML, which is the contract with the designers.
 
 One mapping is lossy and worth knowing about. `capability.relation` in the payload is
 `at` / `one_above` / `one_below` / `two_below`, a signed distance; the target enum is
@@ -62,12 +85,25 @@ it is looking at, so `publish_runs.schema_version` carries `SCHEMA_VERSION` — 
 same commit as any change to a group-B table, column, or enum. Once something outside this
 repo depends on the shape, this is the point where a real migration path replaces the swap.
 
-## Empty on purpose
+## What the CMS owns, and why it cannot live here
 
-`gallery`, `gallery_products` and `gallery_gaps` are created and left empty: gallery content
-is authored CMS-side (the `payload` schema), not derived from the map's data, so there is
-nothing here to fill them with and a table that exists is what lets the site's queries
-compile before the content lands.
+The DBML's `gallery`, `gallery_products` and `gallery_gaps` are **not** in this module. They
+were, created and left empty so the site's queries would compile, and that was a hazard
+rather than a courtesy: this publisher drops and recreates its schema on every load, so the
+first gallery row an editor wrote would be deleted by the next push to `main` with nothing
+raising anywhere. `--check` would still print `gallery 0 rows` and the read-back would still
+report `| gallery | 0 |`, so the loss was invisible in every artifact the publish produced.
+
+A schema rebuilt from source can only hold rows it produced. Gallery content is authored, so
+it belongs either in the CMS's own `payload` schema or in a separate `os-ai-map_cms` schema —
+which this publisher never creates, never drops and never grants on. The site joins across
+schemas; both are on the same database, so that costs a qualified name and nothing else.
+
+Note for whoever builds it: a **view** in that schema over a table in `os-ai-map` will not
+survive, because the cutover renames the schema and a view binds to the table it was created
+over by OID, not by name. `publish_neon.reclaim_previous` detects exactly that dependency and
+refuses to run rather than dropping the view — so the failure is loud, but it is still a
+failure. Read the map's tables directly, or materialize a copy on the CMS side.
 """
 
 from __future__ import annotations
@@ -83,8 +119,12 @@ from build.vocabulary import axes
 ROOT = Path(__file__).resolve().parents[1]
 PAYLOAD_PATH = ROOT / "build" / "notebook_data.json"
 
-# Bump on any change to a group-B table, column, or enum. Recorded on every publish_runs row.
-SCHEMA_VERSION = 1
+# Bump on any change to a group-B table, column, constraint or enum. Recorded on every
+# publish_runs row.
+#   1: the initial load.
+#   2: the gallery tables and their three enums removed (CMS-owned); the DBML's primary keys,
+#      NOT NULLs, uniques and foreign keys emitted for the first time.
+SCHEMA_VERSION = 2
 
 # Group A's tables keep their serializer names, prefixed, because both groups share a schema.
 REGISTRY_PREFIX = "registry_"
@@ -96,6 +136,8 @@ class UnmappedValue(ValueError):
 
 # --- enums ----------------------------------------------------------------------------
 
+# The DBML's `health_status`, `integration_type` and `gap_type` are absent on purpose: they
+# belong to the gallery tables, which the CMS owns. See the module docstring.
 ENUMS: dict[str, tuple[str, ...]] = {
     "alias_kind": ("product", "organization"),
     "freshness_basis": ("commit", "verified"),
@@ -104,9 +146,6 @@ ENUMS: dict[str, tuple[str, ...]] = {
     # The three scored axes, from the score schema rather than restated here — a fourth axis
     # must not reach a serving layer whose enum silently rejects it.
     "metric_name": axes(),
-    "health_status": ("healthy", "partial", "gap"),
-    "integration_type": ("known_build", "documented_component", "similarity"),
-    "gap_type": ("structural", "weak_layer"),
 }
 
 # Payload vocabulary -> enum value, per enum. Identity where the two already agree; spelled
@@ -164,12 +203,30 @@ def enum_type(name: str) -> str:
 # --- helpers --------------------------------------------------------------------------
 
 
+def references(column: str, table: str, target: str) -> str:
+    """A table-level FOREIGN KEY clause. `{schema}` is filled in at DDL time.
+
+    Qualified with the schema being built, because the staging schema is never on the search
+    path — the same reason `enum_type` qualifies an enum.
+    """
+    return (
+        f'FOREIGN KEY ("{column}") REFERENCES {{schema}}."{table}" ("{target}")'
+    )
+
+
 @dataclass(frozen=True)
 class SiteTable:
-    """One group-B table: its typed columns and how to get its rows from the payload."""
+    """One group-B table: its columns, its table-level constraints, and its rows.
+
+    A column's second element is its full definition after the name, so it carries `NOT NULL`
+    where the DBML declares one — Postgres has no table-level form of it. Keys, uniques and
+    foreign keys are table-level and live in `constraints`, which reads closer to the DBML
+    than an inline `[pk]` would and keeps composite cases expressible.
+    """
 
     columns: tuple[tuple[str, str], ...]
     rows: Callable[[dict], list[dict]]
+    constraints: tuple[str, ...] = ()
 
     @property
     def column_names(self) -> tuple[str, ...]:
@@ -510,33 +567,51 @@ def _long_tail_counts(payload: dict) -> list[dict]:
     return [{"count": value, "type": key} for key, value in sorted(counts.items())]
 
 
-def _empty(_payload: dict) -> list[dict]:
-    """Created, never filled. See "Empty on purpose" in the module docstring."""
-    return []
-
-
 # --- group B table set ----------------------------------------------------------------
 
 SITE_TABLES: dict[str, SiteTable] = {
-    "layers": SiteTable((("id", "INTEGER"), ("label", "VARCHAR")), _layers),
-    "stages": SiteTable(
-        (("id", "INTEGER"), ("label", "VARCHAR"), ("desc", "TEXT")), _stages
+    "layers": SiteTable(
+        (("id", "INTEGER"), ("label", "VARCHAR")),
+        _layers,
+        constraints=('PRIMARY KEY ("id")',),
     ),
-    "gaps": SiteTable((("id", "INTEGER"), ("label", "VARCHAR"), ("desc", "TEXT")), _gaps),
+    "stages": SiteTable(
+        (("id", "INTEGER"), ("label", "VARCHAR"), ("desc", "TEXT")),
+        _stages,
+        constraints=('PRIMARY KEY ("id")',),
+    ),
+    "gaps": SiteTable(
+        (("id", "INTEGER"), ("label", "VARCHAR"), ("desc", "TEXT")),
+        _gaps,
+        constraints=('PRIMARY KEY ("id")',),
+    ),
     "categories": SiteTable(
         (
             ("id", "INTEGER"),
-            ("slug", "VARCHAR"),
+            # NOT NULL as well as UNIQUE: a nullable unique column admits any number of
+            # NULLs, which would defeat the deep links the amendment exists for.
+            ("slug", "VARCHAR NOT NULL"),
             ("label", "VARCHAR"),
             ("arc", "VARCHAR"),
-            ("layer", "INTEGER"),
+            ("layer", "INTEGER NOT NULL"),
             ("description", "TEXT"),
-            ("stage", "INTEGER"),
+            ("stage", "INTEGER NOT NULL"),
         ),
         _categories,
+        constraints=(
+            'PRIMARY KEY ("id")',
+            'UNIQUE ("slug")',
+            references("layer", "layers", "id"),
+            references("stage", "stages", "id"),
+        ),
     ),
     "gaps_categories": SiteTable(
-        (("cat_id", "INTEGER"), ("gap_id", "INTEGER")), _gaps_categories
+        (("cat_id", "INTEGER NOT NULL"), ("gap_id", "INTEGER NOT NULL")),
+        _gaps_categories,
+        constraints=(
+            references("cat_id", "categories", "id"),
+            references("gap_id", "gaps", "id"),
+        ),
     ),
     "organizations": SiteTable(
         (
@@ -548,16 +623,17 @@ SITE_TABLES: dict[str, SiteTable] = {
             ("country", "VARCHAR"),
         ),
         _organizations,
+        constraints=('PRIMARY KEY ("slug")',),
     ),
     "products": SiteTable(
         (
             ("id", "INTEGER"),
-            ("slug", "VARCHAR"),
-            ("org_slug", "VARCHAR"),
+            ("slug", "VARCHAR NOT NULL"),
+            ("org_slug", "VARCHAR NOT NULL"),
             ("name", "VARCHAR"),
             ("org", "VARCHAR"),
             ("type", "VARCHAR"),
-            ("category", "INTEGER"),
+            ("category", "INTEGER NOT NULL"),
             ("description", "TEXT"),
             ("maturity", "REAL"),
             ("mature", "BOOLEAN"),
@@ -566,6 +642,12 @@ SITE_TABLES: dict[str, SiteTable] = {
             ("freshness_basis", enum_type("freshness_basis")),
         ),
         _products,
+        constraints=(
+            'PRIMARY KEY ("id")',
+            'UNIQUE ("slug")',
+            references("org_slug", "organizations", "slug"),
+            references("category", "categories", "id"),
+        ),
     ),
     "openness": SiteTable(
         (
@@ -580,6 +662,8 @@ SITE_TABLES: dict[str, SiteTable] = {
             ("governing_release", "VARCHAR"),
         ),
         _openness,
+        # `ref: -` in the DBML: one row per product, so the FK column is also the key.
+        constraints=('PRIMARY KEY ("product_id")', references("product_id", "products", "id")),
     ),
     "adoption": SiteTable(
         (
@@ -592,6 +676,7 @@ SITE_TABLES: dict[str, SiteTable] = {
             ("last_verified", "DATE"),
         ),
         _adoption,
+        constraints=('PRIMARY KEY ("product_id")', references("product_id", "products", "id")),
     ),
     "capability": SiteTable(
         (
@@ -607,6 +692,7 @@ SITE_TABLES: dict[str, SiteTable] = {
             ("relation", enum_type("capability_relation")),
         ),
         _capability,
+        constraints=('PRIMARY KEY ("product_id")', references("product_id", "products", "id")),
     ),
     "sources": SiteTable(
         (
@@ -615,23 +701,26 @@ SITE_TABLES: dict[str, SiteTable] = {
             ("shows", "TEXT"),
             ("notes", "TEXT"),
             ("accessed", "DATE"),
-            ("product_id", "INTEGER"),
-            ("metric_type", enum_type("metric_name")),
+            ("product_id", "INTEGER NOT NULL"),
+            ("metric_type", enum_type("metric_name") + " NOT NULL"),
         ),
         _sources,
+        constraints=('PRIMARY KEY ("id")', references("product_id", "products", "id")),
     ),
     "product_lineage": SiteTable(
         (
             ("id", "INTEGER"),
-            ("product_id", "INTEGER"),
+            ("product_id", "INTEGER NOT NULL"),
             ("relation", enum_type("lineage_relation")),
             ("target", "VARCHAR"),
         ),
         _product_lineage,
+        constraints=('PRIMARY KEY ("id")', references("product_id", "products", "id")),
     ),
     "aliases": SiteTable(
         (("alias", "VARCHAR"), ("kind", enum_type("alias_kind")), ("canonical", "VARCHAR")),
         _aliases,
+        constraints=('PRIMARY KEY ("alias")',),
     ),
     "long_tail_top": SiteTable(
         (
@@ -642,38 +731,11 @@ SITE_TABLES: dict[str, SiteTable] = {
             ("description", "TEXT"),
         ),
         _long_tail_top,
+        constraints=('PRIMARY KEY ("id")',),
     ),
+    # No key in the DBML, and none to invent: the grain is one row per product type.
     "long_tail_counts": SiteTable(
         (("count", "INTEGER"), ("type", "VARCHAR")), _long_tail_counts
-    ),
-    # CMS-side content. Created so the site's queries compile; never filled from here.
-    "gallery": SiteTable(
-        (
-            ("id", "INTEGER"),
-            ("slug", "VARCHAR"),
-            ("title", "VARCHAR"),
-            ("health", enum_type("health_status")),
-            ("description", "TEXT"),
-        ),
-        _empty,
-    ),
-    "gallery_products": SiteTable(
-        (
-            ("gallery_id", "INTEGER"),
-            ("product_id", "INTEGER"),
-            ("integration", enum_type("integration_type")),
-        ),
-        _empty,
-    ),
-    "gallery_gaps": SiteTable(
-        (
-            ("id", "INTEGER"),
-            ("gallery_id", "INTEGER"),
-            ("type", enum_type("gap_type")),
-            ("title", "VARCHAR"),
-            ("description", "TEXT"),
-        ),
-        _empty,
     ),
 }
 

--- a/build/neon_schema.py
+++ b/build/neon_schema.py
@@ -1,0 +1,698 @@
+"""What the Neon serving layer holds — the one place to change the table set.
+
+`build/publish_neon.py` is a generic CSV-to-Postgres loader with an atomic schema swap. It
+knows nothing about the gap map. This module is the map half: which tables exist, which
+enums, what every column is, and where each row comes from.
+
+Group B is the designers' target model, transcribed in
+`Current-AI-Initial-Schema.pdf` (Laith, CLEVER FRANKE) with Carl's amendments. This load
+exists to deprecate `build/notebook_data.json` as the site's transport, so every group-B row
+is derived from that payload's semantics — the same content the front end reads today, at a
+grain a query can use. Rows come from the file rather than from a fresh `build_payload`
+because it is the repo's build artifact and its gate contract: what Postgres serves is
+byte-for-byte what the repo published, not a second derivation that could disagree with it.
+
+Group A is the registry surface: exactly `build.publish_registry.TABLES`, the four
+serializers' declared sets, read from that module rather than from a glob over
+`build/registry/`, so Neon and the OSO warehouse carry the same tables by construction.
+Group A names are prefixed `registry_` in Postgres, because both groups share one schema and
+both have a `products`, a `categories` and an `organizations`.
+
+## Keys are natural where the payload has one
+
+`products.id` exists for the FK shape the designers specified, but it is assigned by sorted
+slug order on every load, so the same corpus produces the same ids and a diff of two loads
+is readable. The real key is `slug`, which is what a deep link carries. Organizations key on
+`slug`, aliases on `alias`, categories carry a `slug` alongside their id (the PDF omitted it
+and the site needs it). Ids for `sources` and `product_lineage` are positional over a
+deterministic walk, for the same reason.
+
+## Enums are enforced, never coerced
+
+The eight enums are created in the schema and the payload's values are mapped onto them by
+`ENUM_MAPS`. A value with no mapping raises `UnmappedValue` and fails the load naming the
+value and the column — a serving layer that silently coerced an unknown vocabulary item to
+something adjacent would be worse than one that stopped.
+
+One mapping is lossy and worth knowing about. `capability.relation` in the payload is
+`at` / `one_above` / `one_below` / `two_below`, a signed distance; the target enum is
+`peer` / `tier_above` / `tier_below` / `anchor`, which has no distance. So `one_below` and
+`two_below` both arrive as `tier_below`, and the exact distance is only in
+`capability.notes`. `anchor` is in the enum and unused by the payload.
+
+## The three dates, which are three different questions
+
+| Where | Column | Question it answers |
+|---|---|---|
+| `publish_runs` | `built_at` | When was this data built? The payload's `generated`. |
+| `publish_runs` | `released_at` | When was the release cut? The payload's `released`, which `build/serialize.py::release_date` reads from `CHANGELOG.md`. |
+| `products` | `freshness_date`, `freshness_basis` | When was this product's score last confirmed, and how? |
+| `openness` / `adoption` / `capability` | `last_verified` | Same question asked of one axis. |
+
+`docs/reference/evidence-and-freshness.md` is normative for what a freshness date means and how it is
+derived. `basis` is `verified` when a human confirmed the axis and `commit` when the date
+falls back to the score file's last commit.
+
+## Migrations: the swap is the migration
+
+There is no migration tool and no need for one yet. Every publish rebuilds the schema from
+this module and swaps it into place atomically, so a shape change here becomes live on the
+next load with no ALTER anywhere. What that costs is a reader's ability to tell which shape
+it is looking at, so `publish_runs.schema_version` carries `SCHEMA_VERSION` — bump it in the
+same commit as any change to a group-B table, column, or enum. Once something outside this
+repo depends on the shape, this is the point where a real migration path replaces the swap.
+
+## Empty on purpose
+
+`gallery`, `gallery_products` and `gallery_gaps` are created and left empty: gallery content
+is authored CMS-side (the `payload` schema), not derived from the map's data, so there is
+nothing here to fill them with and a table that exists is what lets the site's queries
+compile before the content lands.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from build.publish_registry import TABLES as REGISTRY_TABLES
+
+ROOT = Path(__file__).resolve().parents[1]
+PAYLOAD_PATH = ROOT / "build" / "notebook_data.json"
+
+# Bump on any change to a group-B table, column, or enum. Recorded on every publish_runs row.
+SCHEMA_VERSION = 1
+
+# Group A's tables keep their serializer names, prefixed, because both groups share a schema.
+REGISTRY_PREFIX = "registry_"
+
+
+class UnmappedValue(ValueError):
+    """A payload value with no place in the target enum. Fails the load, names the value."""
+
+
+# --- enums ----------------------------------------------------------------------------
+
+ENUMS: dict[str, tuple[str, ...]] = {
+    "alias_kind": ("product", "organization"),
+    "freshness_basis": ("commit", "verified"),
+    "lineage_relation": ("derived_from", "curated_with", "trains"),
+    "capability_relation": ("tier_below", "tier_above", "peer", "anchor"),
+    "metric_name": ("openness", "adoption", "capability"),
+    "health_status": ("healthy", "partial", "gap"),
+    "integration_type": ("known_build", "documented_component", "similarity"),
+    "gap_type": ("structural", "weak_layer"),
+}
+
+# Payload vocabulary -> enum value, per enum. Identity where the two already agree; spelled
+# out anyway so a new payload value is a KeyError here rather than a silent pass-through.
+ENUM_MAPS: dict[str, dict[str, str]] = {
+    "alias_kind": {"products": "product", "organizations": "organization"},
+    "freshness_basis": {"verified": "verified", "commit": "commit"},
+    "lineage_relation": {
+        "derived_from": "derived_from",
+        "curated_with": "curated_with",
+        "trains": "trains",
+    },
+    # Lossy by construction: the payload carries a signed distance and the enum does not.
+    # See the module docstring.
+    "capability_relation": {
+        "at": "peer",
+        "one_above": "tier_above",
+        "one_below": "tier_below",
+        "two_below": "tier_below",
+        "anchor": "anchor",
+    },
+    "metric_name": {"openness": "openness", "adoption": "adoption", "capability": "capability"},
+}
+
+
+def enum_value(enum: str, value, *, column: str) -> str | None:
+    """Map a payload value onto its enum, or fail naming the value and the column."""
+    if value in (None, ""):
+        return None
+    mapping = ENUM_MAPS.get(enum)
+    if mapping is None:
+        raise UnmappedValue(f"{column}: enum {enum!r} has no payload mapping at all")
+    if value not in mapping:
+        raise UnmappedValue(
+            f"{column}: {value!r} is not a value of enum {enum} "
+            f"(known: {', '.join(sorted(mapping))}). Add a mapping in build/neon_schema.py "
+            f"or extend the enum; the load will not coerce it."
+        )
+    return mapping[value]
+
+
+def enum_type(name: str) -> str:
+    """A column type naming an enum in whichever schema is being built.
+
+    `{schema}` is substituted at DDL time by `publish_neon.create_table_sql`. Enum types are
+    schema-scoped, so they are created inside the staging schema and travel with the rename;
+    that also means a column referencing one must qualify it, since the staging schema is
+    not on the search path.
+    """
+    if name not in ENUMS:
+        raise KeyError(f"no such enum: {name}")
+    return '{schema}."' + name + '"'
+
+
+# --- helpers --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SiteTable:
+    """One group-B table: its typed columns and how to get its rows from the payload."""
+
+    columns: tuple[tuple[str, str], ...]
+    rows: Callable[[dict], list[dict]]
+
+    @property
+    def column_names(self) -> tuple[str, ...]:
+        return tuple(name for name, _type in self.columns)
+
+
+def load_payload(path: Path = PAYLOAD_PATH) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _axis(row: dict, axis: str) -> dict:
+    value = row.get(axis)
+    return value if isinstance(value, dict) else {}
+
+
+def _pg_array(values) -> str:
+    """A Postgres array literal for a `varchar[]` column, every element quoted.
+
+    Quoted unconditionally rather than only when it contains a delimiter: a URL with a comma
+    in it is rare enough to be exactly the case nobody tests.
+    """
+    if not values:
+        return "{}"
+    if isinstance(values, str):
+        values = [values]
+    inner = ",".join('"' + str(v).replace("\\", "\\\\").replace('"', '\\"') + '"' for v in values)
+    return "{" + inner + "}"
+
+
+def product_ids(payload: dict) -> dict[str, int]:
+    """slug -> id, assigned by sorted slug so a load is reproducible and a diff is readable."""
+    slugs = sorted(
+        {p["slug"] for cid in payload.get("order") or [] for p in payload["categories"][cid]["products"]}
+    )
+    return {slug: index for index, slug in enumerate(slugs, start=1)}
+
+
+def category_ids(payload: dict) -> dict[str, int]:
+    """slug -> id, in the map's own curated `order`."""
+    return {cid: index for index, cid in enumerate(payload.get("order") or [], start=1)}
+
+
+def layer_ids(payload: dict) -> dict[str, int]:
+    return {layer: index for index, layer in enumerate(payload.get("layer_order") or [], start=1)}
+
+
+def gap_ids(payload: dict) -> dict[str, int]:
+    """Gap kind -> id, over the legend rather than over what categories happen to carry.
+
+    A gap kind that no category currently has is still a kind the site renders a label for.
+    """
+    legend = (payload.get("descriptions") or {}).get("gaps") or {}
+    return {kind: index for index, kind in enumerate(sorted(legend), start=1)}
+
+
+def _walk_products(payload: dict):
+    """(category_slug, product) over the curated order — the payload's own iteration."""
+    for cid in payload.get("order") or []:
+        for product in payload["categories"][cid]["products"]:
+            yield cid, product
+
+
+def _by_slug(payload: dict) -> list[tuple[str, str, dict]]:
+    """(slug, category_slug, product), sorted by slug. The deterministic walk for ids."""
+    rows = [(product["slug"], cid, product) for cid, product in _walk_products(payload)]
+    rows.sort(key=lambda row: row[0])
+    return rows
+
+
+# --- group B row builders -------------------------------------------------------------
+
+
+def _products(payload: dict) -> list[dict]:
+    ids = product_ids(payload)
+    cats = category_ids(payload)
+    seen: set[str] = set()
+    out = []
+    for slug, cid, product in _by_slug(payload):
+        if slug in seen:
+            # `products.category` is a single FK, so a product in two categories has no
+            # representation in this model. The payload has none today; if one appears it is
+            # a schema question, not something to resolve by picking a category.
+            raise UnmappedValue(
+                f"product {slug!r} appears in more than one category, which "
+                f"products.category (a single FK) cannot represent"
+            )
+        seen.add(slug)
+        freshness = _axis(product, "freshness")
+        out.append(
+            {
+                "id": ids[slug],
+                "slug": slug,
+                "org_slug": product.get("org_slug") or "",
+                "name": product.get("product") or "",
+                "org": product.get("org") or "",
+                "type": product.get("type") or "",
+                "category": cats[cid],
+                "description": product.get("description") or "",
+                # The payload ships `overall_score` and `maturity` as the same number under
+                # two names during the rename; the target model has one column.
+                "maturity": product.get("overall_score", product.get("maturity")),
+                "mature": product.get("mature"),
+                "version_note": product.get("version_note") or "",
+                "freshness_date": freshness.get("date") or "",
+                "freshness_basis": enum_value(
+                    "freshness_basis", freshness.get("basis"), column="products.freshness_basis"
+                ),
+            }
+        )
+    return out
+
+
+def _organizations(payload: dict) -> list[dict]:
+    return [
+        {
+            "slug": slug,
+            "display_name": org.get("display_name") or "",
+            "type": org.get("type") or "",
+            "homepage": org.get("homepage") or "",
+            "github": _pg_array(org.get("github")),
+            "country": org.get("country") or "",
+        }
+        for slug, org in sorted((payload.get("organizations") or {}).items())
+    ]
+
+
+def _aliases(payload: dict) -> list[dict]:
+    out = []
+    for group, entries in sorted((payload.get("aliases") or {}).items()):
+        kind = enum_value("alias_kind", group, column="aliases.kind")
+        for alias, canonical in sorted((entries or {}).items()):
+            out.append({"alias": alias, "kind": kind, "canonical": canonical})
+    return out
+
+
+def _openness(payload: dict) -> list[dict]:
+    ids = product_ids(payload)
+    out = []
+    for slug, _cid, product in _by_slug(payload):
+        axis = _axis(product, "openness")
+        out.append(
+            {
+                "product_id": ids[slug],
+                "score": axis.get("score"),
+                "class": axis.get("class") or "",
+                "components": axis.get("components") or "",
+                "confidence": axis.get("confidence") or "",
+                "notes": axis.get("note") or "",
+                "bucket": axis.get("bucket") or "",
+                "last_verified": axis.get("last_verified") or "",
+                "governing_release": axis.get("governing_release") or "",
+            }
+        )
+    return out
+
+
+def _adoption(payload: dict) -> list[dict]:
+    ids = product_ids(payload)
+    out = []
+    for slug, _cid, product in _by_slug(payload):
+        axis = _axis(product, "adoption")
+        out.append(
+            {
+                "product_id": ids[slug],
+                "level": axis.get("level"),
+                "reach": axis.get("reach") or "",
+                "signal_type": axis.get("signal_type") or "",
+                "confidence": axis.get("confidence") or "",
+                "notes": axis.get("note") or "",
+                "last_verified": axis.get("last_verified") or "",
+            }
+        )
+    return out
+
+
+def _capability(payload: dict) -> list[dict]:
+    ids = product_ids(payload)
+    out = []
+    for slug, _cid, product in _by_slug(payload):
+        axis = _axis(product, "capability")
+        out.append(
+            {
+                "product_id": ids[slug],
+                "score": axis.get("score"),
+                "basis": axis.get("basis") or "",
+                "basis_detail": axis.get("basis_detail") or "",
+                "value": axis.get("value") or "",
+                "confidence": axis.get("confidence") or "",
+                "notes": axis.get("note") or "",
+                "last_verified": axis.get("last_verified") or "",
+                "relative_to": axis.get("relative_to") or "",
+                "relation": enum_value(
+                    "capability_relation", axis.get("relation"), column="capability.relation"
+                ),
+            }
+        )
+    return out
+
+
+def _sources(payload: dict) -> list[dict]:
+    """Every source on every axis, one row each, in the deterministic walk order.
+
+    The target model has a `notes` column the payload has no field for; the payload's
+    `establishes`, `content_sha256` and `http_status` have no column. `shows` is the one that
+    maps, and `notes` stays NULL rather than being filled with an adjacent field.
+    """
+    ids = product_ids(payload)
+    out = []
+    next_id = 1
+    for slug, _cid, product in _by_slug(payload):
+        for metric in ("openness", "adoption", "capability"):
+            for source in _axis(product, metric).get("sources") or []:
+                if not isinstance(source, dict):
+                    continue
+                out.append(
+                    {
+                        "id": next_id,
+                        "url": source.get("url") or "",
+                        "shows": source.get("shows") or "",
+                        "notes": "",
+                        "accessed": source.get("accessed") or "",
+                        "product_id": ids[slug],
+                        "metric_type": enum_value(
+                            "metric_name", metric, column="sources.metric_type"
+                        ),
+                    }
+                )
+                next_id += 1
+    return out
+
+
+def _product_lineage(payload: dict) -> list[dict]:
+    ids = product_ids(payload)
+    out = []
+    next_id = 1
+    for slug, _cid, product in _by_slug(payload):
+        lineage = product.get("lineage")
+        if not isinstance(lineage, dict):
+            continue
+        for relation, targets in lineage.items():
+            mapped = enum_value("lineage_relation", relation, column="product_lineage.relation")
+            for target in targets or []:
+                out.append(
+                    {
+                        "id": next_id,
+                        "product_id": ids[slug],
+                        "relation": mapped,
+                        "target": target if isinstance(target, str) else str(target),
+                    }
+                )
+                next_id += 1
+    return out
+
+
+def _categories(payload: dict) -> list[dict]:
+    cats = category_ids(payload)
+    layers = layer_ids(payload)
+    legend = (payload.get("descriptions") or {}).get("categories") or {}
+    out = []
+    for cid, index in cats.items():
+        category = payload["categories"][cid]
+        layer = category.get("layer") or ""
+        if layer not in layers:
+            raise UnmappedValue(
+                f"category {cid!r} names layer {layer!r}, which is not in layer_order"
+            )
+        out.append(
+            {
+                "id": index,
+                # Not in the PDF. Added because every deep link and every join from the
+                # registry group is by slug, and an id assigned by curated order changes
+                # whenever the order does.
+                "slug": cid,
+                "label": category.get("label") or "",
+                "arc": category.get("arc") or "",
+                "layer": layers[layer],
+                "description": legend.get(cid) or "",
+                "stage": (category.get("stage") or {}).get("num"),
+            }
+        )
+    return out
+
+
+def _layers(payload: dict) -> list[dict]:
+    return [{"id": index, "label": layer} for layer, index in layer_ids(payload).items()]
+
+
+def _stages(payload: dict) -> list[dict]:
+    """The stage ladder, id = stage number. Names and descriptions are methodology constants."""
+    from build.serialize import _STAGE_NAMES
+
+    legend = (payload.get("descriptions") or {}).get("stages") or {}
+    return [
+        {"id": num, "label": name, "desc": legend.get(str(num)) or ""}
+        for num, name in sorted(_STAGE_NAMES.items())
+    ]
+
+
+def _gaps(payload: dict) -> list[dict]:
+    legend = (payload.get("descriptions") or {}).get("gaps") or {}
+    return [
+        {"id": index, "label": kind, "desc": legend.get(kind) or ""}
+        for kind, index in gap_ids(payload).items()
+    ]
+
+
+def _gaps_categories(payload: dict) -> list[dict]:
+    cats = category_ids(payload)
+    gaps = gap_ids(payload)
+    out = []
+    for cid, index in cats.items():
+        for kind in payload["categories"][cid].get("gaps") or []:
+            if kind not in gaps:
+                raise UnmappedValue(
+                    f"category {cid!r} carries gap {kind!r}, which the payload's gap legend "
+                    f"does not describe"
+                )
+            out.append({"cat_id": index, "gap_id": gaps[kind]})
+    return out
+
+
+def _long_tail_top(payload: dict) -> list[dict]:
+    top = (payload.get("long_tail") or {}).get("top") or []
+    return [
+        {
+            "id": index,
+            "name": row.get("name") or "",
+            "type": row.get("type") or "",
+            "usage_label": row.get("usage_label") or "",
+            "description": row.get("description") or "",
+        }
+        for index, row in enumerate(top, start=1)
+    ]
+
+
+def _long_tail_counts(payload: dict) -> list[dict]:
+    counts = (payload.get("long_tail") or {}).get("counts") or {}
+    return [{"count": value, "type": key} for key, value in sorted(counts.items())]
+
+
+def _empty(_payload: dict) -> list[dict]:
+    """Created, never filled. See "Empty on purpose" in the module docstring."""
+    return []
+
+
+# --- group B table set ----------------------------------------------------------------
+
+SITE_TABLES: dict[str, SiteTable] = {
+    "layers": SiteTable((("id", "INTEGER"), ("label", "VARCHAR")), _layers),
+    "stages": SiteTable(
+        (("id", "INTEGER"), ("label", "VARCHAR"), ("desc", "TEXT")), _stages
+    ),
+    "gaps": SiteTable((("id", "INTEGER"), ("label", "VARCHAR"), ("desc", "TEXT")), _gaps),
+    "categories": SiteTable(
+        (
+            ("id", "INTEGER"),
+            ("slug", "VARCHAR"),
+            ("label", "VARCHAR"),
+            ("arc", "VARCHAR"),
+            ("layer", "INTEGER"),
+            ("description", "TEXT"),
+            ("stage", "INTEGER"),
+        ),
+        _categories,
+    ),
+    "gaps_categories": SiteTable(
+        (("cat_id", "INTEGER"), ("gap_id", "INTEGER")), _gaps_categories
+    ),
+    "organizations": SiteTable(
+        (
+            ("slug", "VARCHAR"),
+            ("display_name", "VARCHAR"),
+            ("type", "VARCHAR"),
+            ("homepage", "VARCHAR"),
+            ("github", "VARCHAR[]"),
+            ("country", "VARCHAR"),
+        ),
+        _organizations,
+    ),
+    "products": SiteTable(
+        (
+            ("id", "INTEGER"),
+            ("slug", "VARCHAR"),
+            ("org_slug", "VARCHAR"),
+            ("name", "VARCHAR"),
+            ("org", "VARCHAR"),
+            ("type", "VARCHAR"),
+            ("category", "INTEGER"),
+            ("description", "TEXT"),
+            ("maturity", "REAL"),
+            ("mature", "BOOLEAN"),
+            ("version_note", "TEXT"),
+            ("freshness_date", "DATE"),
+            ("freshness_basis", enum_type("freshness_basis")),
+        ),
+        _products,
+    ),
+    "openness": SiteTable(
+        (
+            ("product_id", "INTEGER"),
+            ("score", "INTEGER"),
+            ("class", "VARCHAR"),
+            ("components", "TEXT"),
+            ("confidence", "VARCHAR"),
+            ("notes", "TEXT"),
+            ("bucket", "VARCHAR"),
+            ("last_verified", "DATE"),
+            ("governing_release", "VARCHAR"),
+        ),
+        _openness,
+    ),
+    "adoption": SiteTable(
+        (
+            ("product_id", "INTEGER"),
+            ("level", "INTEGER"),
+            ("reach", "VARCHAR"),
+            ("signal_type", "VARCHAR"),
+            ("confidence", "VARCHAR"),
+            ("notes", "TEXT"),
+            ("last_verified", "DATE"),
+        ),
+        _adoption,
+    ),
+    "capability": SiteTable(
+        (
+            ("product_id", "INTEGER"),
+            ("score", "INTEGER"),
+            ("basis", "VARCHAR"),
+            ("basis_detail", "TEXT"),
+            ("value", "TEXT"),
+            ("confidence", "VARCHAR"),
+            ("notes", "TEXT"),
+            ("last_verified", "DATE"),
+            ("relative_to", "VARCHAR"),
+            ("relation", enum_type("capability_relation")),
+        ),
+        _capability,
+    ),
+    "sources": SiteTable(
+        (
+            ("id", "INTEGER"),
+            ("url", "TEXT"),
+            ("shows", "TEXT"),
+            ("notes", "TEXT"),
+            ("accessed", "DATE"),
+            ("product_id", "INTEGER"),
+            ("metric_type", enum_type("metric_name")),
+        ),
+        _sources,
+    ),
+    "product_lineage": SiteTable(
+        (
+            ("id", "INTEGER"),
+            ("product_id", "INTEGER"),
+            ("relation", enum_type("lineage_relation")),
+            ("target", "VARCHAR"),
+        ),
+        _product_lineage,
+    ),
+    "aliases": SiteTable(
+        (("alias", "VARCHAR"), ("kind", enum_type("alias_kind")), ("canonical", "VARCHAR")),
+        _aliases,
+    ),
+    "long_tail_top": SiteTable(
+        (
+            ("id", "INTEGER"),
+            ("name", "VARCHAR"),
+            ("type", "VARCHAR"),
+            ("usage_label", "VARCHAR"),
+            ("description", "TEXT"),
+        ),
+        _long_tail_top,
+    ),
+    "long_tail_counts": SiteTable(
+        (("count", "INTEGER"), ("type", "VARCHAR")), _long_tail_counts
+    ),
+    # CMS-side content. Created so the site's queries compile; never filled from here.
+    "gallery": SiteTable(
+        (
+            ("id", "INTEGER"),
+            ("slug", "VARCHAR"),
+            ("title", "VARCHAR"),
+            ("health", enum_type("health_status")),
+            ("description", "TEXT"),
+        ),
+        _empty,
+    ),
+    "gallery_products": SiteTable(
+        (
+            ("gallery_id", "INTEGER"),
+            ("product_id", "INTEGER"),
+            ("integration", enum_type("integration_type")),
+        ),
+        _empty,
+    ),
+    "gallery_gaps": SiteTable(
+        (
+            ("id", "INTEGER"),
+            ("gallery_id", "INTEGER"),
+            ("type", enum_type("gap_type")),
+            ("title", "VARCHAR"),
+            ("description", "TEXT"),
+        ),
+        _empty,
+    ),
+}
+
+# Group A's names as they appear in Postgres.
+REGISTRY_TABLE_NAMES: tuple[str, ...] = tuple(f"{REGISTRY_PREFIX}{n}" for n in REGISTRY_TABLES)
+# The full surface, group B then group A, in a stable load order. Group B first so a failure
+# in the part the site actually reads is the first thing a log shows.
+ALL_TABLES: tuple[str, ...] = tuple(SITE_TABLES) + REGISTRY_TABLE_NAMES
+
+
+def build_site_tables(payload: dict) -> dict[str, list[dict]]:
+    """Every group-B table's rows, keyed by table name."""
+    return {name: spec.rows(payload) for name, spec in SITE_TABLES.items()}
+
+
+def write_site_csvs(payload: dict, out_dir: Path) -> None:
+    """Write one CSV per group-B table, so the same loader handles both groups.
+
+    Group A arrives as CSVs the serializers wrote; rendering group B the same way means
+    there is one COPY path, one type story and one place a quoting bug could live.
+    """
+    from build.serialize_registry import write_tables
+
+    spec = {name: table.column_names for name, table in SITE_TABLES.items()}
+    write_tables(build_site_tables(payload), out_dir, spec=spec)

--- a/build/neon_status.py
+++ b/build/neon_status.py
@@ -63,6 +63,27 @@ FROM {schema}.{table}
 ORDER BY published_at DESC
 """
 
+# Constraints as the database actually holds them, not as the DDL asked for them. The map
+# group's keys and foreign keys are the load's integrity gate, so a swap that quietly created
+# tables without them is the thing worth catching — and `information_schema` is the reader's
+# own view of it. CHECK is excluded: Postgres materializes one per NOT NULL column, which
+# would swamp the count with something already visible in the column list.
+CONSTRAINTS_SQL = """
+SELECT constraint_type, count(*) AS n
+FROM information_schema.table_constraints
+WHERE constraint_schema = {schema}
+  AND constraint_type <> 'CHECK'
+GROUP BY constraint_type
+ORDER BY 1
+"""
+
+
+def constraints_sql(schema: str):
+    """The per-type constraint tally, with the schema composed in as a literal."""
+    from psycopg import sql
+
+    return sql.SQL(CONSTRAINTS_SQL).format(schema=sql.Literal(schema))
+
 
 def counts_sql(schema: str):
     """The per-table `count(*)` query with the schema composed in as a literal.
@@ -90,6 +111,16 @@ def report(dsn: str, schema: str) -> str:
             lines.append(f"| `{name}` | {count:,} |")
         total = sum(count for name, count in rows if name != RUN_TABLE)
         lines.append(f"\n{len(rows)} tables, {total:,} rows outside `{RUN_TABLE}`.\n")
+
+        cursor.execute(constraints_sql(schema))
+        constraints = cursor.fetchall()
+        total_constraints = sum(n for _type, n in constraints)
+        lines.append(f"### Constraints in `{schema}` — {total_constraints} total\n")
+        lines.append("| constraint | count |")
+        lines.append("|---|---:|")
+        for constraint_type, count in constraints:
+            lines.append(f"| {constraint_type} | {count} |")
+        lines.append("")
 
         cursor.execute(RUNS_SQL.format(schema=quote_schema(schema), table=f'"{RUN_TABLE}"'))
         runs = cursor.fetchall()

--- a/build/neon_status.py
+++ b/build/neon_status.py
@@ -17,8 +17,12 @@ is how the first CI run of this module failed. Doubling it to `%%I` would work, 
 parameters keep being passed: drop them and psycopg stops unescaping, so `%%I` reaches
 Postgres and `format()` reads it as a literal `%` followed by `I`. So the schema is composed
 into the query as a literal with `psycopg.sql` and no parameters are passed at all. With
-`params=None` psycopg does not scan for placeholders, and `%I` reaches the server as written
-whatever anyone does to this module later.
+`params=None` psycopg does not scan for placeholders, so `%I` reaches the server as written.
+
+That holds only as long as no caller passes parameters. `counts_sql` and `constraints_sql`
+compose the one value each query needs, so there is nothing left to parameterize — but adding
+a `params` argument at either `execute` below would reintroduce the failure, and no test pins
+that property of the call site.
 
 Environment:
     NEON_DATABASE_URL   required

--- a/build/neon_status.py
+++ b/build/neon_status.py
@@ -1,0 +1,117 @@
+"""Read back what a Neon publish actually landed, as a markdown report.
+
+The verification half of `build/publish_neon.py`. A publish that returns 0 has swapped a
+schema into place; this connects independently and asks the database what is there — every
+table in the schema with its row count, and the `publish_runs` log. Written for
+`$GITHUB_STEP_SUMMARY`, so the output is markdown and carries no part of the DSN.
+
+Row counts come through `query_to_xml`, which runs a real `count(*)` per table inside one
+statement. The alternative, `pg_class.reltuples`, is an estimate maintained by ANALYZE and
+reads as `-1` on a table that has just been created — precisely the state every table is in
+after a swap.
+
+Environment:
+    NEON_DATABASE_URL   required
+
+Usage:
+    uv run python -m build.neon_status                 # markdown to stdout
+    uv run python -m build.neon_status >> "$GITHUB_STEP_SUMMARY"
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from build.publish_neon import (
+    DEFAULT_SCHEMA,
+    DSN_ENV,
+    RUN_TABLE,
+    quote_schema,
+    require_ssl,
+    scrub,
+)
+
+COUNTS_SQL = """
+SELECT table_name,
+       (xpath('/row/c/text()',
+              query_to_xml(
+                  format('select count(*) as c from %I.%I', table_schema, table_name),
+                  false, true, '')))[1]::text::int AS rows
+FROM information_schema.tables
+WHERE table_schema = %s
+ORDER BY 1
+"""
+
+RUNS_SQL = """
+SELECT run_id, published_at, schema_version, built_at, released_at,
+       source_git_sha, declaration_version_id, table_count, row_counts
+FROM {schema}.{table}
+ORDER BY published_at DESC
+"""
+
+
+def report(dsn: str, schema: str) -> str:
+    import psycopg
+
+    lines: list[str] = []
+    with psycopg.connect(require_ssl(dsn)) as connection, connection.cursor() as cursor:
+        cursor.execute(COUNTS_SQL, (schema,))
+        rows = cursor.fetchall()
+        lines.append(f"### `{schema}` tables after the load\n")
+        lines.append("| table | rows |")
+        lines.append("|---|---:|")
+        for name, count in rows:
+            lines.append(f"| `{name}` | {count:,} |")
+        total = sum(count for name, count in rows if name != RUN_TABLE)
+        lines.append(f"\n{len(rows)} tables, {total:,} rows outside `{RUN_TABLE}`.\n")
+
+        cursor.execute(RUNS_SQL.format(schema=quote_schema(schema), table=f'"{RUN_TABLE}"'))
+        runs = cursor.fetchall()
+        lines.append(f"### `{schema}.{RUN_TABLE}` — {len(runs)} row(s), newest first\n")
+        lines.append(
+            "| published_at | run_id | schema_version | built_at | released_at "
+            "| source_git_sha | tables |"
+        )
+        lines.append("|---|---|---:|---|---|---|---:|")
+        for row in runs:
+            (
+                run_id,
+                published_at,
+                schema_version,
+                built_at,
+                released_at,
+                git_sha,
+                _version_id,
+                table_count,
+                _counts,
+            ) = row
+            lines.append(
+                f"| {published_at:%Y-%m-%d %H:%M:%SZ} | `{run_id[:12]}` | {schema_version} "
+                f"| {built_at or '-'} | {released_at or '-'} "
+                f"| `{(git_sha or '-')[:12]}` | {table_count} |"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dsn-env", default=DSN_ENV)
+    parser.add_argument("--schema", default=DEFAULT_SCHEMA)
+    args = parser.parse_args()
+
+    dsn = os.environ.get(args.dsn_env)
+    if not dsn:
+        print(f"{args.dsn_env} is not set; nothing to read", file=sys.stderr)
+        return 2
+    try:
+        sys.stdout.write(report(dsn, args.schema))
+    except Exception as error:  # noqa: BLE001 - scrubbed; the driver quotes the host
+        print(f"could not read the schema back: {scrub(str(error), dsn)}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build/neon_status.py
+++ b/build/neon_status.py
@@ -10,6 +10,16 @@ statement. The alternative, `pg_class.reltuples`, is an estimate maintained by A
 reads as `-1` on a table that has just been created — precisely the state every table is in
 after a swap.
 
+That query contains Postgres's own `format('... %I.%I', ...)`, and `%` is also psycopg's
+client-side placeholder marker. psycopg scans the whole query for placeholders whenever
+parameters are passed, and rejects `%I` before the statement ever leaves the process — which
+is how the first CI run of this module failed. Doubling it to `%%I` would work, but only while
+parameters keep being passed: drop them and psycopg stops unescaping, so `%%I` reaches
+Postgres and `format()` reads it as a literal `%` followed by `I`. So the schema is composed
+into the query as a literal with `psycopg.sql` and no parameters are passed at all. With
+`params=None` psycopg does not scan for placeholders, and `%I` reaches the server as written
+whatever anyone does to this module later.
+
 Environment:
     NEON_DATABASE_URL   required
 
@@ -33,6 +43,8 @@ from build.publish_neon import (
     scrub,
 )
 
+# `{schema}` is filled by `counts_sql`, not by a query parameter. See the module docstring:
+# the `%I` below is Postgres's, and passing parameters would make psycopg claim it.
 COUNTS_SQL = """
 SELECT table_name,
        (xpath('/row/c/text()',
@@ -40,7 +52,7 @@ SELECT table_name,
                   format('select count(*) as c from %I.%I', table_schema, table_name),
                   false, true, '')))[1]::text::int AS rows
 FROM information_schema.tables
-WHERE table_schema = %s
+WHERE table_schema = {schema}
 ORDER BY 1
 """
 
@@ -52,12 +64,24 @@ ORDER BY published_at DESC
 """
 
 
+def counts_sql(schema: str):
+    """The per-table `count(*)` query with the schema composed in as a literal.
+
+    A literal rather than a parameter, so the statement carries no placeholders and psycopg
+    leaves Postgres's `%I` alone. `sql.Literal` quotes and escapes the value, so this is not
+    string interpolation into SQL.
+    """
+    from psycopg import sql
+
+    return sql.SQL(COUNTS_SQL).format(schema=sql.Literal(schema))
+
+
 def report(dsn: str, schema: str) -> str:
     import psycopg
 
     lines: list[str] = []
     with psycopg.connect(require_ssl(dsn)) as connection, connection.cursor() as cursor:
-        cursor.execute(COUNTS_SQL, (schema,))
+        cursor.execute(counts_sql(schema))
         rows = cursor.fetchall()
         lines.append(f"### `{schema}` tables after the load\n")
         lines.append("| table | rows |")

--- a/build/publish_neon.py
+++ b/build/publish_neon.py
@@ -1,42 +1,69 @@
-"""Load the serialized registry CSVs into Neon (Postgres) as the site's serving layer.
+"""Load the gap map into Neon (Postgres) as the site's serving layer.
 
-The third publisher of the same declarations. `build/publish_registry.py` pushes them to
-OSO so they can be queried and joined against warehouse measurements; this one pushes them
-to Postgres so the front end can read them at request time without going through the
-warehouse. `build/notebook_data.json` stays what it was — the repo's build artifact and the
-gate contract — and nothing here reads or replaces it.
+The third publisher of the same content. `build/publish_registry.py` pushes the
+declarations to OSO so they can be joined against warehouse measurements; this one pushes
+them to Postgres so the site can read products, scores and freshness dates at request time
+instead of loading `build/notebook_data.json`. That file stays exactly what it was — the
+repo's build artifact and its gate contract — and is the *input* to the site tables here,
+never replaced by them.
 
-Only the *declarative* layer travels: whatever CSVs the serializers have written into
-`build/registry/`. Computed openness lives in `currentai.scores` and is not mirrored here;
-see `docs/reference/where-scores-live.md`.
+This module is a generic CSV-to-Postgres loader with an atomic schema swap. It knows nothing
+about the gap map: the tables, enums, grain, keys and column types all live in
+`build/neon_schema.py`, which is the one place to change when the data model moves. Two
+groups today — the designers' target model, built from the payload, and the registry tables
+`publish_registry` publishes, prefixed `registry_` so the two surfaces cannot collide.
+
+Nothing computed is here. `scores.openness_facts` and `scores.openness_computed` stay on
+OSO, and no table in this schema recomputes an axis. See
+`docs/reference/where-scores-live.md`.
+
+One difference from the OSO publisher: an empty table is loaded as an empty table rather
+than dropped. OSO has no way to represent a static model with no rows (dlt infers the schema
+from records, so zero records is zero tables), which is why `publish_registry` deletes the
+model instead. Postgres has a perfectly good empty table, and a serving layer that answers
+"no rows" is better than one that answers "no such table".
+
+## The schema, which shares an instance
+
+The Neon instance is shared: `drizzle`, `payload` and `public` belong to other parts of the
+site, and `os-ai-map` is the gap map's. So this touches exactly two schemas — its target and
+`<target>_staging` — creates and drops nothing else, and refuses outright to run against a
+schema on `PROTECTED_SCHEMAS`. The default target's name carries a hyphen, which is why
+schema identifiers are quoted everywhere and have their own validator.
 
 ## Atomicity, because a reader is always mid-request
 
 Site readers query this database continuously, so a load must never be observable
-half-finished. Rows go into `gapmap_staging`, which is dropped and recreated on every run,
+half-finished. Rows go into `<target>_staging`, which is dropped and recreated on every run,
 and the cutover is three renames in one transaction:
 
-    DROP SCHEMA IF EXISTS gapmap_previous CASCADE      -- a prior run that died mid-swap
-    ALTER SCHEMA gapmap RENAME TO gapmap_previous
-    ALTER SCHEMA gapmap_staging RENAME TO gapmap
-    DROP SCHEMA gapmap_previous CASCADE
+    DROP SCHEMA IF EXISTS "os-ai-map_previous" CASCADE   -- a run that died mid-swap
+    ALTER SCHEMA "os-ai-map" RENAME TO "os-ai-map_previous"
+    ALTER SCHEMA "os-ai-map_staging" RENAME TO "os-ai-map"
+    DROP SCHEMA "os-ai-map_previous" CASCADE
 
-A reader sees the old schema or the new one. On the first run there is no `gapmap` to
-rename, so the swap is the single `gapmap_staging` -> `gapmap` rename; that case is decided
-by reading `information_schema.schemata`, not by catching an error.
+A reader sees the old schema or the new one. On the first run there is no target to rename,
+so the swap is the single staging rename; that case is decided by reading
+`information_schema.schemata`, not by catching an error.
 
 Grants are applied to the staging schema *before* the swap. A rename carries privileges
 with it, so the new schema is readable the instant it becomes visible rather than after a
 follow-up statement that could fail on its own.
 
-## Column types are inferred conservatively
+## Column types: declared for the target model, inferred for the registry
 
-TEXT is the default and the fallback. A column becomes BOOLEAN, INTEGER/BIGINT, DOUBLE
-PRECISION or DATE only when every non-empty value in it parses as one, and identity columns
-(`slug`, anything ending `_slug` or `_id`) are pinned to TEXT whatever they look like — a
+`neon_schema.SITE_TABLES` declares its own types and its enums, because that module defines
+the shape.
+The serializers declare column *names* only, so a registry column's type is inferred:
+TEXT by default and as the fallback, and BOOLEAN, INTEGER/BIGINT, DOUBLE PRECISION or DATE
+only when every non-empty value in the column parses as one. Identity columns (`slug`,
+anything ending `_slug` or `_id`) are pinned to TEXT whatever they look like — a
 numeric-looking artifact id is a string with digits in it, and letting one run of the data
 decide otherwise would change the column type from under a query the next time a
 non-numeric id arrives.
+
+In CSV mode an unquoted empty field is NULL, so an absent value arrives as NULL rather than
+as an empty string, on both groups.
 
 Environment:
     NEON_DATABASE_URL   required for a publish (not for --check)
@@ -61,12 +88,31 @@ from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
+from build.neon_schema import (
+    ENUMS,
+    PAYLOAD_PATH,
+    REGISTRY_PREFIX,
+    SCHEMA_VERSION,
+    SITE_TABLES,
+    load_payload,
+    write_site_csvs,
+)
+from build.publish_registry import TABLES as PUBLISHED_TABLES
 from build.serialize_registry import OUT_DIR
 from build.serialize_registry import TABLES as REGISTRY_TABLES
 from build.serialize_registry import build_registry, write_tables
 
 ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_SCHEMA = "gapmap"
+# The gap map's own schema on a shared Neon instance. Hyphenated, hence quoted everywhere.
+DEFAULT_SCHEMA = "os-ai-map"
+# Not ours, on the same instance. Refused rather than validated against, because the cost of
+# being wrong is dropping someone else's schema with CASCADE.
+PROTECTED_SCHEMAS = frozenset(
+    {"drizzle", "payload", "public", "information_schema", "pg_catalog", "pg_toast"}
+)
+# Where the site tables' CSVs are rendered. Separate from build/registry/, which belongs to
+# the serializers and is published to OSO from.
+SITE_DIR = ROOT / "build" / "neon"
 DSN_ENV = "NEON_DATABASE_URL"
 READ_ROLE_ENV = "NEON_READ_ROLE"
 
@@ -77,6 +123,14 @@ RUN_TABLE = "publish_runs"
 RUN_COLUMNS: tuple[tuple[str, str], ...] = (
     ("run_id", "TEXT"),
     ("published_at", "TIMESTAMPTZ"),
+    # The shape this load was built to. There is no migration tool: the swap rebuilds the
+    # schema every time, so this is how a reader tells which shape it is looking at. See
+    # "Migrations" in build/neon_schema.py.
+    ("schema_version", "INTEGER"),
+    # When the payload was built, and when the release it belongs to was cut. The third
+    # date — when a product's score was last confirmed — is per product, on `products`.
+    ("built_at", "DATE"),
+    ("released_at", "DATE"),
     ("source_git_sha", "TEXT"),
     ("declaration_version_id", "TEXT"),
     ("table_count", "INTEGER"),
@@ -137,26 +191,49 @@ class TablePlan:
     path: Path
 
 
-def plan_table(path: Path) -> TablePlan:
+def plan_table(
+    path: Path,
+    declared: tuple[tuple[str, str], ...] | None = None,
+    name: str | None = None,
+) -> TablePlan:
+    """Plan one CSV. `declared` supplies the column types; without it they are inferred.
+
+    `name` is the destination table, which is not always the file's stem: group A's tables
+    are prefixed so they cannot collide with group B's `products`/`categories`/`organizations`
+    in the shared schema.
+
+    A declared spec is still checked against the file's header, because a spec that has
+    drifted from the CSV it describes would otherwise COPY values into the wrong columns —
+    which Postgres would accept wherever the types happened to line up.
+    """
     with path.open(newline="", encoding="utf-8") as handle:
         reader = csv.reader(handle)
         header = next(reader, [])
         rows = list(reader)
-    columns = tuple(
-        (name, infer_column_type(name, [row[index] if index < len(row) else "" for row in rows]))
-        for index, name in enumerate(header)
+    if declared is not None:
+        expected = [name for name, _type in declared]
+        if header != expected:
+            raise ValueError(
+                f"{path.name}: header {header} does not match the declared columns {expected}"
+            )
+        columns = declared
+    else:
+        columns = tuple(
+            (name, infer_column_type(name, [row[index] if index < len(row) else "" for row in rows]))
+            for index, name in enumerate(header)
+        )
+    return TablePlan(
+        name=name or path.stem, columns=columns, row_count=len(rows), path=path
     )
-    return TablePlan(name=path.stem, columns=columns, row_count=len(rows), path=path)
 
 
-def ensure_csvs(directory: Path) -> None:
-    """Regenerate the registry CSVs when they are absent.
+def ensure_registry_csvs(directory: Path) -> None:
+    """Regenerate the registry serializer's own CSVs when they are absent.
 
-    Only the registry serializer's own tables are regenerated. The rubric, routing and
-    scores serializers write into the same directory and are published from it too, so
-    whatever they have left there is loaded as well — but this module does not run them,
-    because each has its own preconditions and a publisher silently invoking four
-    serializers hides which one produced a surprising table.
+    Only that one. The rubric, routing and scores serializers each have their own
+    preconditions, and a publisher that silently invoked all four would hide which one
+    produced a surprising table — so their absence is reported by `plan` rather than
+    papered over here.
     """
     if all((directory / f"{name}.csv").exists() for name in REGISTRY_TABLES):
         return
@@ -171,10 +248,38 @@ def ensure_csvs(directory: Path) -> None:
     write_tables(tables, directory)
 
 
-def plan(directory: Path = OUT_DIR) -> list[TablePlan]:
-    """Every CSV in the directory, as a table plan, in a stable order."""
-    ensure_csvs(directory)
-    return [plan_table(path) for path in sorted(directory.glob("*.csv"))]
+def plan(
+    directory: Path = OUT_DIR,
+    site_dir: Path = SITE_DIR,
+    payload_path: Path = PAYLOAD_PATH,
+) -> tuple[list[TablePlan], list[str]]:
+    """(plans, missing) over both groups, group A first, each in its declared order.
+
+    Never a glob. `missing` names the declared tables whose CSV has not been written, which
+    a real publish refuses and `--check` reports — a table is absent because a serializer
+    has not run, and loading the rest would publish a partial map that looks complete.
+
+    The site tables are rendered to CSV here from `build/notebook_data.json`, so both groups
+    reach the database through one COPY path.
+    """
+    ensure_registry_csvs(directory)
+    plans: list[TablePlan] = []
+    missing: list[str] = []
+
+    if payload_path.exists():
+        write_site_csvs(load_payload(payload_path), site_dir)
+        for name, spec in SITE_TABLES.items():
+            plans.append(plan_table(site_dir / f"{name}.csv", declared=spec.columns))
+    else:
+        missing.extend(SITE_TABLES)
+
+    for name in PUBLISHED_TABLES:
+        path = directory / f"{name}.csv"
+        if path.exists():
+            plans.append(plan_table(path, name=f"{REGISTRY_PREFIX}{name}"))
+        else:
+            missing.append(f"{REGISTRY_PREFIX}{name}")
+    return plans, missing
 
 
 def quote_ident(name: str) -> str:
@@ -189,25 +294,97 @@ def quote_ident(name: str) -> str:
     return f'"{name}"'
 
 
+def quote_schema(name: str) -> str:
+    """Double-quote a schema name, allowing the hyphen `os-ai-map` carries.
+
+    Its own validator rather than a looser `quote_ident`: a hyphen is fine in a schema
+    chosen by a maintainer and is not something a serializer should ever be able to put in
+    a table or column name. Anything that would need escaping to survive quoting — a quote
+    character, a backslash, whitespace — is refused, because a schema name reaches
+    `DROP SCHEMA ... CASCADE`.
+    """
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_-]*", name):
+        raise ValueError(f"not a usable schema name: {name!r}")
+    return f'"{name}"'
+
+
+def check_schema_is_ours(schema: str) -> None:
+    """Refuse a schema that belongs to another part of the site.
+
+    This publisher drops and renames whole schemas with CASCADE, and the Neon instance is
+    shared with `drizzle`, `payload` and `public`. A typo in `--schema` must not be able to
+    take one of those with it.
+    """
+    quote_schema(schema)
+    if schema.lower() in PROTECTED_SCHEMAS:
+        raise ValueError(
+            f"{schema!r} belongs to another part of the site and this publisher drops "
+            f"schemas with CASCADE; refusing. The gap map's schema is {DEFAULT_SCHEMA!r}."
+        )
+    if schema.lower().endswith(("_staging", "_previous")):
+        raise ValueError(
+            f"{schema!r} names a schema this publisher manages itself; pass the target "
+            f"schema (default {DEFAULT_SCHEMA!r}), not its staging or previous form."
+        )
+
+
 def create_table_sql(schema: str, columns: tuple[tuple[str, str], ...], name: str) -> str:
-    body = ",\n  ".join(f"{quote_ident(column)} {sql_type}" for column, sql_type in columns)
-    return f"CREATE TABLE {quote_ident(schema)}.{quote_ident(name)} (\n  {body}\n)"
+    """DDL for one table. An enum column's type carries `{schema}`, filled in here.
+
+    Enum types are schema-scoped and are created inside the staging schema so they travel
+    with the rename, which means a column referencing one has to qualify it — the staging
+    schema is never on the search path.
+    """
+    quoted_schema = quote_schema(schema)
+    body = ",\n  ".join(
+        f"{quote_ident(column)} {sql_type.format(schema=quoted_schema)}"
+        for column, sql_type in columns
+    )
+    return f"CREATE TABLE {quoted_schema}.{quote_ident(name)} (\n  {body}\n)"
+
+
+def create_enum_sql(schema: str) -> list[str]:
+    """One CREATE TYPE per enum, inside the schema being built."""
+    return [
+        f"CREATE TYPE {quote_schema(schema)}.{quote_ident(name)} AS ENUM ("
+        + ", ".join(f"'{value}'" for value in values)
+        + ")"
+        for name, values in ENUMS.items()
+    ]
 
 
 def copy_sql(schema: str, plan_: TablePlan) -> str:
     names = ", ".join(quote_ident(column) for column, _type in plan_.columns)
     return (
-        f"COPY {quote_ident(schema)}.{quote_ident(plan_.name)} ({names}) "
+        f"COPY {quote_schema(schema)}.{quote_ident(plan_.name)} ({names}) "
         f"FROM STDIN WITH (FORMAT csv, HEADER true)"
     )
+
+
+def stream_bytes(path: Path, write, chunk_size: int = 1 << 16) -> int:
+    """Feed a file to `write` in chunks, byte for byte. Returns the bytes written.
+
+    The CSV is handed to `COPY ... FROM STDIN WITH (FORMAT csv)` verbatim, so Postgres's own
+    CSV parser does the quoting — this must not reformat, re-encode or line-split anything.
+    A quoted field can hold a newline (several `strapline` and `note` values do), so a
+    chunked read that respected line boundaries, or a text-mode read that translated them,
+    would corrupt exactly those rows. Bytes in, bytes out, and the chunk boundary is allowed
+    to fall anywhere.
+    """
+    written = 0
+    with path.open("rb") as handle:
+        while chunk := handle.read(chunk_size):
+            write(chunk)
+            written += len(chunk)
+    return written
 
 
 def grant_sql(schema: str, role: str | None) -> list[str]:
     """USAGE on the schema plus SELECT on its tables, for PUBLIC or a named role."""
     grantee = "PUBLIC" if not role else quote_ident(role)
     return [
-        f"GRANT USAGE ON SCHEMA {quote_ident(schema)} TO {grantee}",
-        f"GRANT SELECT ON ALL TABLES IN SCHEMA {quote_ident(schema)} TO {grantee}",
+        f"GRANT USAGE ON SCHEMA {quote_schema(schema)} TO {grantee}",
+        f"GRANT SELECT ON ALL TABLES IN SCHEMA {quote_schema(schema)} TO {grantee}",
     ]
 
 
@@ -221,12 +398,12 @@ def swap_sql(schema: str, live_exists: bool) -> list[str]:
     staging = f"{schema}_staging"
     previous = f"{schema}_previous"
     if not live_exists:
-        return [f"ALTER SCHEMA {quote_ident(staging)} RENAME TO {quote_ident(schema)}"]
+        return [f"ALTER SCHEMA {quote_schema(staging)} RENAME TO {quote_schema(schema)}"]
     return [
-        f"DROP SCHEMA IF EXISTS {quote_ident(previous)} CASCADE",
-        f"ALTER SCHEMA {quote_ident(schema)} RENAME TO {quote_ident(previous)}",
-        f"ALTER SCHEMA {quote_ident(staging)} RENAME TO {quote_ident(schema)}",
-        f"DROP SCHEMA {quote_ident(previous)} CASCADE",
+        f"DROP SCHEMA IF EXISTS {quote_schema(previous)} CASCADE",
+        f"ALTER SCHEMA {quote_schema(schema)} RENAME TO {quote_schema(previous)}",
+        f"ALTER SCHEMA {quote_schema(staging)} RENAME TO {quote_schema(schema)}",
+        f"DROP SCHEMA {quote_schema(previous)} CASCADE",
     ]
 
 
@@ -279,14 +456,24 @@ def declaration_identity() -> tuple[str | None, str | None]:
 
 
 def publish(dsn: str, plans: list[TablePlan], schema: str, read_role: str | None) -> dict:
-    """Load every plan into the staging schema and swap it into place. Returns the run record."""
+    """Load every plan into the staging schema and swap it into place. Returns the run record.
+
+    The only two schemas touched are `schema` and `<schema>_staging` (plus `<schema>_previous`,
+    which exists only between two statements of the swap). `check_schema_is_ours` runs first,
+    because the instance is shared and the cutover drops schemas with CASCADE.
+    """
     import psycopg
 
+    check_schema_is_ours(schema)
     staging = f"{schema}_staging"
     git_sha, version_id = declaration_identity()
+    payload = load_payload() if PAYLOAD_PATH.exists() else {}
     record = {
         "run_id": uuid.uuid4().hex,
         "published_at": datetime.now(UTC),
+        "schema_version": SCHEMA_VERSION,
+        "built_at": payload.get("generated") or None,
+        "released_at": payload.get("released") or None,
         "source_git_sha": git_sha,
         "declaration_version_id": version_id,
         "table_count": len(plans),
@@ -295,26 +482,30 @@ def publish(dsn: str, plans: list[TablePlan], schema: str, read_role: str | None
 
     with psycopg.connect(require_ssl(dsn), autocommit=True) as connection:
         with connection.cursor() as cursor:
-            cursor.execute(f"DROP SCHEMA IF EXISTS {quote_ident(staging)} CASCADE")
-            cursor.execute(f"CREATE SCHEMA {quote_ident(staging)}")
+            cursor.execute(f"DROP SCHEMA IF EXISTS {quote_schema(staging)} CASCADE")
+            cursor.execute(f"CREATE SCHEMA {quote_schema(staging)}")
+            # Enums first: a table referencing one cannot be created before the type exists,
+            # and the types live inside the staging schema so the rename carries them.
+            for statement in create_enum_sql(staging):
+                cursor.execute(statement)
             for plan_ in plans:
                 cursor.execute(create_table_sql(staging, plan_.columns, plan_.name))
-                with (
-                    plan_.path.open("rb") as handle,
-                    cursor.copy(copy_sql(staging, plan_)) as copy,
-                ):
-                    while chunk := handle.read(1 << 16):
-                        copy.write(chunk)
+                with cursor.copy(copy_sql(staging, plan_)) as copy:
+                    stream_bytes(plan_.path, copy.write)
                 print(f"  {plan_.name:<24} {plan_.row_count:>6} rows")
 
             cursor.execute(create_table_sql(staging, RUN_COLUMNS, RUN_TABLE))
             cursor.execute(
-                f"INSERT INTO {quote_ident(staging)}.{quote_ident(RUN_TABLE)} "
-                f"(run_id, published_at, source_git_sha, declaration_version_id, "
-                f"table_count, row_counts) VALUES (%s, %s, %s, %s, %s, %s)",
+                f"INSERT INTO {quote_schema(staging)}.{quote_ident(RUN_TABLE)} "
+                f"(run_id, published_at, schema_version, built_at, released_at, "
+                f"source_git_sha, declaration_version_id, table_count, row_counts) "
+                f"VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)",
                 (
                     record["run_id"],
                     record["published_at"],
+                    record["schema_version"],
+                    record["built_at"],
+                    record["released_at"],
                     record["source_git_sha"],
                     record["declaration_version_id"],
                     record["table_count"],
@@ -345,27 +536,64 @@ def main() -> int:
     parser.add_argument("--dsn-env", default=DSN_ENV, help=f"env var holding the DSN (default {DSN_ENV})")
     parser.add_argument("--schema", default=DEFAULT_SCHEMA, help=f"target schema (default {DEFAULT_SCHEMA})")
     parser.add_argument("--dir", type=Path, default=OUT_DIR, help="directory of serialized CSVs")
+    parser.add_argument(
+        "--site-dir", type=Path, default=SITE_DIR, help="where the site tables' CSVs are rendered"
+    )
     args = parser.parse_args()
 
-    plans = plan(args.dir)
-    if not plans:
-        print(f"no CSVs in {args.dir}", file=sys.stderr)
+    try:
+        check_schema_is_ours(args.schema)
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
         return 2
 
+    plans, missing = plan(args.dir, args.site_dir)
+
     if args.check:
-        print(f"would load {len(plans)} tables into {args.schema}_staging, then swap to {args.schema}:")
+        # A plan, not a gate on completeness: on a PR only the registry serializer's CSVs
+        # exist, because the check job validates the other three without writing. So the
+        # unwritten tables are reported as pending rather than failed.
+        total_declared = len(PUBLISHED_TABLES) + len(SITE_TABLES)
+        print(
+            f"would load {total_declared} tables into {args.schema}_staging, "
+            f"then swap to {args.schema}:"
+        )
         for plan_ in plans:
-            print(f"  {plan_.name:<24} {plan_.row_count:>6} rows  {len(plan_.columns)} columns")
+            group = "map" if plan_.name in SITE_TABLES else "registry"
+            print(
+                f"  {plan_.name:<28} {plan_.row_count:>6} rows  "
+                f"{len(plan_.columns):>2} columns  [{group}]"
+            )
+        print(f"  {len(ENUMS)} enums: {', '.join(ENUMS)}")
+        # Only the inferred types are worth printing. The map group's are declared in
+        # build/neon_schema.py, where a reader can see them next to the grain they describe;
+        # the registry group's are a guess this run made about the data, which is the thing
+        # a reviewer needs to see change.
         for plan_ in plans:
+            if plan_.name in SITE_TABLES:
+                continue
             for column, sql_type in plan_.columns:
                 if sql_type != "TEXT":
-                    print(f"    {plan_.name}.{column} -> {sql_type}")
-        print(f"  {RUN_TABLE:<24} {1:>6} row   {len(RUN_COLUMNS)} columns")
+                    print(f"    inferred {plan_.name}.{column} -> {sql_type}")
+        print(f"  {RUN_TABLE:<28} {1:>6} row   {len(RUN_COLUMNS):>2} columns  [run record]")
+        for name in missing:
+            print(f"  {name:<28}  pending: not serialized yet")
         return 0
 
+    # Configuration before inputs: with no DSN there is nowhere to publish whatever the
+    # inputs turn out to be, and that is the more useful thing to be told first.
     dsn = os.environ.get(args.dsn_env)
     if not dsn:
         print(f"{args.dsn_env} is not set; nothing to publish to", file=sys.stderr)
+        return 2
+
+    if missing:
+        print(
+            f"missing tables: {missing}. Run build.serialize_registry, build.serialize_rubric, "
+            f"build.serialize_routing and build.serialize_scores first — loading the rest "
+            f"would publish a partial map that looks complete.",
+            file=sys.stderr,
+        )
         return 2
 
     read_role = os.environ.get(READ_ROLE_ENV) or None

--- a/build/publish_neon.py
+++ b/build/publish_neon.py
@@ -26,10 +26,19 @@ model instead. Postgres has a perfectly good empty table, and a serving layer th
 ## The schema, which shares an instance
 
 The Neon instance is shared: `drizzle`, `payload` and `public` belong to other parts of the
-site, and `os-ai-map` is the gap map's. So this touches exactly two schemas — its target and
-`<target>_staging` — creates and drops nothing else, and refuses outright to run against a
-schema on `PROTECTED_SCHEMAS`. The default target's name carries a hyphen, which is why
-schema identifiers are quoted everywhere and have their own validator.
+site, and `os-ai-map` is the gap map's. So this touches exactly three schemas — its target,
+`<target>_staging` and `<target>_previous` — creates and drops nothing else, and refuses
+outright to run against a schema on `PROTECTED_SCHEMAS`. The default target's name carries a
+hyphen, which is why schema identifiers are quoted everywhere and have their own validator.
+
+All three are steady-state names, not transients. `<target>_staging` exists while a load is
+running; `<target>_previous` exists *between* runs, holding the whole previous corpus —
+tables, rows, enum types and the `SELECT` grant that travelled with the rename. So the
+instance normally carries two readable copies of the map, and the previous one is only
+reclaimed at the start of the next publish. Two consequences worth knowing: the storage is
+roughly double, and anything with `SELECT` on the map can still read the superseded corpus
+under the `_previous` name until the next load. Nothing is meant to read it, and the swap
+does not stop anything from trying.
 
 ## Atomicity, because a reader is always mid-request
 
@@ -284,7 +293,7 @@ def plan(
     site_dir: Path = SITE_DIR,
     payload_path: Path = PAYLOAD_PATH,
 ) -> tuple[list[TablePlan], list[str]]:
-    """(plans, missing) over both groups, group A first, each in its declared order.
+    """(plans, missing) over both groups, group B first, each in its declared order.
 
     Never a glob. `missing` names the declared tables whose CSV has not been written, which
     a real publish refuses and `--check` reports — a table is absent because a serializer
@@ -466,21 +475,38 @@ def working_schemas(schema: str) -> list[str]:
     return [schema, f"{schema}_staging", f"{schema}_previous"]
 
 
-# Dependents of the previous schema's relations that live somewhere else on the instance.
-# Two shapes, because those are the two a CASCADE would silently take with it: a view or
-# materialized view selecting from one of our tables (via pg_rewrite), and a foreign key
-# pointing into one (via pg_constraint). Both are reported with the schema, the relation and
-# how it depends, because the message has to be actionable by someone who did not write this.
+# Dependents of the previous schema that live somewhere else on the instance. Three shapes,
+# because those are the three a CASCADE would silently take with it, and each is reported with
+# the schema, the relation and how it depends — the message has to be actionable by someone
+# who did not write this.
+#
+#   1. a view or materialized view selecting from one of our tables (pg_rewrite);
+#   2. a foreign key pointing into one (pg_constraint);
+#   3. a column anywhere else typed as one of our enums (pg_attribute -> pg_type).
+#
+# The third is easy to miss because the hazard is not a table at all. The enum types are
+# created inside the staging schema so they travel with the rename, which means they travel
+# into `_previous` too — so a CMS column declared `os-ai-map.health_status` ends up typed by a
+# type in `_previous`, and reclaiming would drop the type and the column with it. Composite
+# types (relkind 'c') are excluded: every table has one, so they would report each of our own
+# tables as a dependent of itself.
 DEPENDENTS_SQL = """
-WITH previous AS (
+WITH previous_relations AS (
     SELECT c.oid
     FROM pg_class c
     JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE n.nspname = %(previous)s
+),
+previous_types AS (
+    SELECT t.oid, t.typname
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = %(previous)s
+      AND t.typtype <> 'c'
 )
 SELECT DISTINCT n.nspname AS schema_name, c.relname AS relation, 'view or rule' AS via
 FROM pg_depend d
-JOIN previous p ON p.oid = d.refobjid
+JOIN previous_relations p ON p.oid = d.refobjid
 JOIN pg_rewrite r ON r.oid = d.objid AND d.classid = 'pg_rewrite'::regclass
 JOIN pg_class c ON c.oid = r.ev_class
 JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -488,10 +514,19 @@ WHERE NOT (n.nspname = ANY(%(working)s))
 UNION
 SELECT DISTINCT n.nspname, c.relname, 'foreign key ' || co.conname
 FROM pg_constraint co
-JOIN previous p ON p.oid = co.confrelid
+JOIN previous_relations p ON p.oid = co.confrelid
 JOIN pg_class c ON c.oid = co.conrelid
 JOIN pg_namespace n ON n.oid = c.relnamespace
 WHERE NOT (n.nspname = ANY(%(working)s))
+UNION
+SELECT DISTINCT n.nspname, c.relname || '.' || a.attname, 'column typed ' || t.typname
+FROM pg_attribute a
+JOIN previous_types t ON t.oid = a.atttypid
+JOIN pg_class c ON c.oid = a.attrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE NOT (n.nspname = ANY(%(working)s))
+  AND a.attnum > 0
+  AND NOT a.attisdropped
 ORDER BY 1, 2
 """
 
@@ -508,7 +543,12 @@ def schema_exists(cursor, schema: str) -> bool:
 
 
 def external_dependents(cursor, schema: str) -> list[tuple[str, str, str]]:
-    """(schema, relation, how) for every dependent of `<schema>_previous` we do not own."""
+    """(schema, relation, how) for every dependent of `<schema>_previous` we do not own.
+
+    Covers tables and the enum types, which is not the same question: the types are created
+    in the staging schema so they travel with the rename, so a column elsewhere declared with
+    one of ours is typed by a type that is now in `_previous`.
+    """
     cursor.execute(
         DEPENDENTS_SQL,
         {"previous": f"{schema}_previous", "working": working_schemas(schema)},

--- a/build/publish_neon.py
+++ b/build/publish_neon.py
@@ -35,16 +35,40 @@ schema identifiers are quoted everywhere and have their own validator.
 
 Site readers query this database continuously, so a load must never be observable
 half-finished. Rows go into `<target>_staging`, which is dropped and recreated on every run,
-and the cutover is three renames in one transaction:
+and the cutover is two renames in one transaction:
 
-    DROP SCHEMA IF EXISTS "os-ai-map_previous" CASCADE   -- a run that died mid-swap
     ALTER SCHEMA "os-ai-map" RENAME TO "os-ai-map_previous"
     ALTER SCHEMA "os-ai-map_staging" RENAME TO "os-ai-map"
-    DROP SCHEMA "os-ai-map_previous" CASCADE
 
 A reader sees the old schema or the new one. On the first run there is no target to rename,
 so the swap is the single staging rename; that case is decided by reading
 `information_schema.schemata`, not by catching an error.
+
+Nothing is dropped inside that transaction, which is deliberate on both counts. `DROP SCHEMA
+… CASCADE` takes `AccessExclusiveLock` on every table it removes, so a drop in the cutover
+would hold the applied-but-uncommitted renames behind any in-flight site query, and new
+readers would then queue behind the pending exclusive lock — one slow reader stalling every
+reader for as long as it runs. Pure catalog renames take no table locks at all. `lock_timeout`
+is still set on the session and the transaction is retried, because the schema's own catalog
+row can be contended.
+
+## Reclaiming the previous schema, which is where the blast radius is
+
+The old schema is left in place as `<target>_previous` and reclaimed at the *start* of the
+next run, not at the end of this one. Before dropping it, `pg_depend` is checked for
+dependents outside the three schemas this publisher manages, and if any exist the run fails
+listing them instead of dropping.
+
+That check is the point. `PROTECTED_SCHEMAS` stops the publisher naming someone else's
+schema, but CASCADE follows dependencies, not schema membership: a view in `payload` over
+`os-ai-map.products`, or a foreign key from a CMS table into it, still depends on that table
+after the rename, because a rename does not detach dependents. A CASCADE would drop the
+dependent object too, in its own schema, silently, on every publish — the same accident
+`PROTECTED_SCHEMAS` exists to prevent, one indirection out.
+
+A rename-based cutover cannot carry such a dependent forward, so failing loudly is the whole
+of the remedy available here. See "What the CMS owns" in `build/neon_schema.py` for what to
+build instead.
 
 Grants are applied to the staging schema *before* the swap. A rename carries privileges
 with it, so the new schema is readable the instant it becomes visible rather than after a
@@ -82,6 +106,7 @@ import json
 import os
 import re
 import sys
+import time
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -183,18 +208,20 @@ def infer_column_type(name: str, values: list[str]) -> str:
 
 @dataclass(frozen=True)
 class TablePlan:
-    """One CSV, resolved to a table: its name, its typed columns, and its row count."""
+    """One CSV, resolved to a table: its name, columns, constraints and row count."""
 
     name: str
     columns: tuple[tuple[str, str], ...]
     row_count: int
     path: Path
+    constraints: tuple[str, ...] = ()
 
 
 def plan_table(
     path: Path,
     declared: tuple[tuple[str, str], ...] | None = None,
     name: str | None = None,
+    constraints: tuple[str, ...] = (),
 ) -> TablePlan:
     """Plan one CSV. `declared` supplies the column types; without it they are inferred.
 
@@ -223,7 +250,11 @@ def plan_table(
             for index, name in enumerate(header)
         )
     return TablePlan(
-        name=name or path.stem, columns=columns, row_count=len(rows), path=path
+        name=name or path.stem,
+        columns=columns,
+        row_count=len(rows),
+        path=path,
+        constraints=constraints,
     )
 
 
@@ -269,7 +300,13 @@ def plan(
     if payload_path.exists():
         write_site_csvs(load_payload(payload_path), site_dir)
         for name, spec in SITE_TABLES.items():
-            plans.append(plan_table(site_dir / f"{name}.csv", declared=spec.columns))
+            plans.append(
+                plan_table(
+                    site_dir / f"{name}.csv",
+                    declared=spec.columns,
+                    constraints=spec.constraints,
+                )
+            )
     else:
         missing.extend(SITE_TABLES)
 
@@ -328,18 +365,31 @@ def check_schema_is_ours(schema: str) -> None:
         )
 
 
-def create_table_sql(schema: str, columns: tuple[tuple[str, str], ...], name: str) -> str:
-    """DDL for one table. An enum column's type carries `{schema}`, filled in here.
+def create_table_sql(
+    schema: str,
+    columns: tuple[tuple[str, str], ...],
+    name: str,
+    constraints: tuple[str, ...] = (),
+) -> str:
+    """DDL for one table. An enum type or a FK target carries `{schema}`, filled in here.
 
     Enum types are schema-scoped and are created inside the staging schema so they travel
     with the rename, which means a column referencing one has to qualify it — the staging
-    schema is never on the search path.
+    schema is never on the search path. A foreign key's target is qualified for the same
+    reason, so the reference resolves inside the schema being built rather than against
+    whatever `os-ai-map` happens to hold at the time.
+
+    `constraints` is empty for the registry group: the serializers declare column names only,
+    so there is nothing to derive a key from, and inventing one would be this module guessing
+    at another module's grain.
     """
     quoted_schema = quote_schema(schema)
-    body = ",\n  ".join(
+    parts = [
         f"{quote_ident(column)} {sql_type.format(schema=quoted_schema)}"
         for column, sql_type in columns
-    )
+    ]
+    parts += [clause.format(schema=quoted_schema) for clause in constraints]
+    body = ",\n  ".join(parts)
     return f"CREATE TABLE {quoted_schema}.{quote_ident(name)} (\n  {body}\n)"
 
 
@@ -389,22 +439,165 @@ def grant_sql(schema: str, role: str | None) -> list[str]:
 
 
 def swap_sql(schema: str, live_exists: bool) -> list[str]:
-    """The cutover, as the statements to run inside one transaction.
+    """The cutover, as the statements to run inside one transaction. Renames only.
 
     `live_exists` decides the shape rather than an exception: on the first run there is no
     live schema to rename, and renaming a schema that is not there is a different error
     from every other reason a rename fails.
+
+    Nothing is dropped here. The old schema is left as `<schema>_previous` for the next run
+    to reclaim, because a `DROP SCHEMA … CASCADE` in this transaction would both take
+    `AccessExclusiveLock` on every table it removes — stalling the cutover behind any
+    in-flight reader — and follow dependencies out of this schema. See `reclaim_previous`.
     """
     staging = f"{schema}_staging"
     previous = f"{schema}_previous"
     if not live_exists:
         return [f"ALTER SCHEMA {quote_schema(staging)} RENAME TO {quote_schema(schema)}"]
     return [
-        f"DROP SCHEMA IF EXISTS {quote_schema(previous)} CASCADE",
         f"ALTER SCHEMA {quote_schema(schema)} RENAME TO {quote_schema(previous)}",
         f"ALTER SCHEMA {quote_schema(staging)} RENAME TO {quote_schema(schema)}",
-        f"DROP SCHEMA {quote_schema(previous)} CASCADE",
     ]
+
+
+# Objects in these schemas may depend on the previous schema's tables: they are ours, and the
+# dependency is one this publisher created (a foreign key inside the map group, an index).
+def working_schemas(schema: str) -> list[str]:
+    return [schema, f"{schema}_staging", f"{schema}_previous"]
+
+
+# Dependents of the previous schema's relations that live somewhere else on the instance.
+# Two shapes, because those are the two a CASCADE would silently take with it: a view or
+# materialized view selecting from one of our tables (via pg_rewrite), and a foreign key
+# pointing into one (via pg_constraint). Both are reported with the schema, the relation and
+# how it depends, because the message has to be actionable by someone who did not write this.
+DEPENDENTS_SQL = """
+WITH previous AS (
+    SELECT c.oid
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = %(previous)s
+)
+SELECT DISTINCT n.nspname AS schema_name, c.relname AS relation, 'view or rule' AS via
+FROM pg_depend d
+JOIN previous p ON p.oid = d.refobjid
+JOIN pg_rewrite r ON r.oid = d.objid AND d.classid = 'pg_rewrite'::regclass
+JOIN pg_class c ON c.oid = r.ev_class
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE NOT (n.nspname = ANY(%(working)s))
+UNION
+SELECT DISTINCT n.nspname, c.relname, 'foreign key ' || co.conname
+FROM pg_constraint co
+JOIN previous p ON p.oid = co.confrelid
+JOIN pg_class c ON c.oid = co.conrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE NOT (n.nspname = ANY(%(working)s))
+ORDER BY 1, 2
+"""
+
+
+class ExternalDependents(RuntimeError):
+    """Something outside this publisher's schemas depends on the schema about to be dropped."""
+
+
+def schema_exists(cursor, schema: str) -> bool:
+    cursor.execute(
+        "SELECT 1 FROM information_schema.schemata WHERE schema_name = %s", (schema,)
+    )
+    return cursor.fetchone() is not None
+
+
+def external_dependents(cursor, schema: str) -> list[tuple[str, str, str]]:
+    """(schema, relation, how) for every dependent of `<schema>_previous` we do not own."""
+    cursor.execute(
+        DEPENDENTS_SQL,
+        {"previous": f"{schema}_previous", "working": working_schemas(schema)},
+    )
+    return [tuple(row) for row in cursor.fetchall()]
+
+
+def reclaim_previous(cursor, schema: str) -> bool:
+    """Drop `<schema>_previous` if it is safe to. Returns whether anything was dropped.
+
+    Runs at the start of a publish, before the staging build, so a run that cannot safely
+    reclaim fails before it has done any work rather than after loading 18,000 rows.
+
+    Raises `ExternalDependents` rather than dropping when anything outside the three working
+    schemas depends on it. A rename-based cutover has nowhere to carry such a dependent
+    forward, so this cannot be repaired here — but dropping someone else's view to get on
+    with a publish is not a trade this publisher is allowed to make on its own.
+    """
+    previous = f"{schema}_previous"
+    if not schema_exists(cursor, previous):
+        return False
+    dependents = external_dependents(cursor, schema)
+    if dependents:
+        listed = "\n".join(
+            f"  {dep_schema}.{relation}  ({via})" for dep_schema, relation, via in dependents
+        )
+        raise ExternalDependents(
+            f"{len(dependents)} object(s) outside {schema!r} depend on {previous!r}, which "
+            f"this run needs to drop:\n{listed}\n"
+            f"Dropping it would take them with it (CASCADE follows dependencies, not schema "
+            f"membership), so this run has stopped instead. A view over a table in {schema!r} "
+            f"cannot survive the cutover in any case — the rename leaves it bound to the old "
+            f"table by OID. Drop or repoint these objects, or move them to a schema that "
+            f"reads {schema!r} directly; see 'What the CMS owns' in build/neon_schema.py."
+        )
+    cursor.execute(f"DROP SCHEMA IF EXISTS {quote_schema(previous)} CASCADE")
+    return True
+
+
+# The swap contends only for the schemas' own catalog rows now that it drops nothing, but a
+# concurrent DDL or a long transaction holding the namespace can still block it. Five seconds
+# is far longer than a rename needs and short enough that a stalled cutover retries rather
+# than parks; three attempts, because the second failing for the same reason as the first is
+# already evidence that waiting is not the remedy.
+LOCK_TIMEOUT = "5s"
+SWAP_ATTEMPTS = 3
+SWAP_BACKOFF = (1.0, 3.0)
+# 55P03 lock_not_available (our lock_timeout firing), 40P01 deadlock_detected.
+RETRYABLE_SQLSTATES = frozenset({"55P03", "40P01"})
+
+
+def is_retryable(error: Exception) -> bool:
+    """Whether a failed swap is worth another attempt. Reads the SQLSTATE, never the message.
+
+    A driver-independent predicate: psycopg exposes `sqlstate`, and a test can raise anything
+    carrying the attribute without standing up a database.
+    """
+    return getattr(error, "sqlstate", None) in RETRYABLE_SQLSTATES
+
+
+def swap_in_place(
+    connection,
+    schema: str,
+    live_exists: bool,
+    *,
+    attempts: int = SWAP_ATTEMPTS,
+    sleep=time.sleep,
+) -> int:
+    """Run the cutover in one transaction, retrying a lock timeout. Returns the attempt count.
+
+    Each attempt is its own transaction: a lock timeout aborts it, so retrying inside the
+    failed transaction would be retrying inside an aborted one.
+    """
+    for attempt in range(1, attempts + 1):
+        try:
+            with connection.transaction(), connection.cursor() as cursor:
+                for statement in swap_sql(schema, live_exists):
+                    cursor.execute(statement)
+            return attempt
+        except Exception as error:
+            if attempt == attempts or not is_retryable(error):
+                raise
+            delay = SWAP_BACKOFF[min(attempt, len(SWAP_BACKOFF)) - 1]
+            print(
+                f"  swap attempt {attempt} could not take its lock; retrying in {delay:g}s",
+                file=sys.stderr,
+            )
+            sleep(delay)
+    raise AssertionError("unreachable: the loop returns or raises")
 
 
 def require_ssl(dsn: str) -> str:
@@ -458,9 +651,13 @@ def declaration_identity() -> tuple[str | None, str | None]:
 def publish(dsn: str, plans: list[TablePlan], schema: str, read_role: str | None) -> dict:
     """Load every plan into the staging schema and swap it into place. Returns the run record.
 
-    The only two schemas touched are `schema` and `<schema>_staging` (plus `<schema>_previous`,
-    which exists only between two statements of the swap). `check_schema_is_ours` runs first,
-    because the instance is shared and the cutover drops schemas with CASCADE.
+    The only schemas touched are `schema`, `<schema>_staging` and `<schema>_previous`, which
+    holds the last load until this one reclaims it. `check_schema_is_ours` runs first, because
+    the instance is shared and reclaiming drops a schema with CASCADE.
+
+    Order matters: the previous schema is reclaimed before the staging build, so a run that
+    cannot safely drop it fails before loading anything, and the swap has a free name to
+    rename the live schema to.
     """
     import psycopg
 
@@ -482,6 +679,12 @@ def publish(dsn: str, plans: list[TablePlan], schema: str, read_role: str | None
 
     with psycopg.connect(require_ssl(dsn), autocommit=True) as connection:
         with connection.cursor() as cursor:
+            # Session-wide, so it covers the swap transaction and every statement here. A
+            # rename needs milliseconds; anything that waits five seconds for a lock is
+            # contended, and waiting longer inside a cutover is the failure mode to avoid.
+            cursor.execute(f"SET lock_timeout = '{LOCK_TIMEOUT}'")
+            if reclaim_previous(cursor, schema):
+                print(f"  reclaimed {schema}_previous from the last load")
             cursor.execute(f"DROP SCHEMA IF EXISTS {quote_schema(staging)} CASCADE")
             cursor.execute(f"CREATE SCHEMA {quote_schema(staging)}")
             # Enums first: a table referencing one cannot be created before the type exists,
@@ -489,7 +692,9 @@ def publish(dsn: str, plans: list[TablePlan], schema: str, read_role: str | None
             for statement in create_enum_sql(staging):
                 cursor.execute(statement)
             for plan_ in plans:
-                cursor.execute(create_table_sql(staging, plan_.columns, plan_.name))
+                cursor.execute(
+                    create_table_sql(staging, plan_.columns, plan_.name, plan_.constraints)
+                )
                 with cursor.copy(copy_sql(staging, plan_)) as copy:
                     stream_bytes(plan_.path, copy.write)
                 print(f"  {plan_.name:<24} {plan_.row_count:>6} rows")
@@ -515,15 +720,12 @@ def publish(dsn: str, plans: list[TablePlan], schema: str, read_role: str | None
             for statement in grant_sql(staging, read_role):
                 cursor.execute(statement)
 
-            cursor.execute(
-                "SELECT 1 FROM information_schema.schemata WHERE schema_name = %s", (schema,)
-            )
-            live_exists = cursor.fetchone() is not None
+            live_exists = schema_exists(cursor, schema)
 
         # One transaction, so no reader ever sees the schema absent or half-renamed.
-        with connection.transaction(), connection.cursor() as cursor:
-            for statement in swap_sql(schema, live_exists):
-                cursor.execute(statement)
+        attempts = swap_in_place(connection, schema, live_exists)
+        if attempts > 1:
+            print(f"  swap committed on attempt {attempts}")
 
     return record
 
@@ -560,11 +762,16 @@ def main() -> int:
         )
         for plan_ in plans:
             group = "map" if plan_.name in SITE_TABLES else "registry"
+            keys = f"{len(plan_.constraints):>2} constraints" if plan_.constraints else ""
             print(
                 f"  {plan_.name:<28} {plan_.row_count:>6} rows  "
-                f"{len(plan_.columns):>2} columns  [{group}]"
+                f"{len(plan_.columns):>2} columns  [{group}] {keys}"
             )
         print(f"  {len(ENUMS)} enums: {', '.join(ENUMS)}")
+        print(
+            f"  {sum(len(p.constraints) for p in plans)} table constraints "
+            f"(primary keys, uniques and foreign keys, on the map group)"
+        )
         # Only the inferred types are worth printing. The map group's are declared in
         # build/neon_schema.py, where a reader can see them next to the grain they describe;
         # the registry group's are a guess this run made about the data, which is the thing

--- a/build/publish_neon.py
+++ b/build/publish_neon.py
@@ -1,0 +1,388 @@
+"""Load the serialized registry CSVs into Neon (Postgres) as the site's serving layer.
+
+The third publisher of the same declarations. `build/publish_registry.py` pushes them to
+OSO so they can be queried and joined against warehouse measurements; this one pushes them
+to Postgres so the front end can read them at request time without going through the
+warehouse. `build/notebook_data.json` stays what it was — the repo's build artifact and the
+gate contract — and nothing here reads or replaces it.
+
+Only the *declarative* layer travels: whatever CSVs the serializers have written into
+`build/registry/`. Computed openness lives in `currentai.scores` and is not mirrored here;
+see `docs/reference/where-scores-live.md`.
+
+## Atomicity, because a reader is always mid-request
+
+Site readers query this database continuously, so a load must never be observable
+half-finished. Rows go into `gapmap_staging`, which is dropped and recreated on every run,
+and the cutover is three renames in one transaction:
+
+    DROP SCHEMA IF EXISTS gapmap_previous CASCADE      -- a prior run that died mid-swap
+    ALTER SCHEMA gapmap RENAME TO gapmap_previous
+    ALTER SCHEMA gapmap_staging RENAME TO gapmap
+    DROP SCHEMA gapmap_previous CASCADE
+
+A reader sees the old schema or the new one. On the first run there is no `gapmap` to
+rename, so the swap is the single `gapmap_staging` -> `gapmap` rename; that case is decided
+by reading `information_schema.schemata`, not by catching an error.
+
+Grants are applied to the staging schema *before* the swap. A rename carries privileges
+with it, so the new schema is readable the instant it becomes visible rather than after a
+follow-up statement that could fail on its own.
+
+## Column types are inferred conservatively
+
+TEXT is the default and the fallback. A column becomes BOOLEAN, INTEGER/BIGINT, DOUBLE
+PRECISION or DATE only when every non-empty value in it parses as one, and identity columns
+(`slug`, anything ending `_slug` or `_id`) are pinned to TEXT whatever they look like — a
+numeric-looking artifact id is a string with digits in it, and letting one run of the data
+decide otherwise would change the column type from under a query the next time a
+non-numeric id arrives.
+
+Environment:
+    NEON_DATABASE_URL   required for a publish (not for --check)
+    NEON_READ_ROLE      optional; the role granted SELECT. Defaults to PUBLIC.
+
+Usage:
+    uv run python -m build.publish_neon --check     # plan only, no connection
+    uv run python -m build.publish_neon            # load and swap
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import sys
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+from build.serialize_registry import OUT_DIR
+from build.serialize_registry import TABLES as REGISTRY_TABLES
+from build.serialize_registry import build_registry, write_tables
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SCHEMA = "gapmap"
+DSN_ENV = "NEON_DATABASE_URL"
+READ_ROLE_ENV = "NEON_READ_ROLE"
+
+# The run record. Its own table rather than a column on every table: the identity of a
+# publish belongs to the publish, and repeating it 4,000 times would make every table's
+# grain depend on how it got here.
+RUN_TABLE = "publish_runs"
+RUN_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("run_id", "TEXT"),
+    ("published_at", "TIMESTAMPTZ"),
+    ("source_git_sha", "TEXT"),
+    ("declaration_version_id", "TEXT"),
+    ("table_count", "INTEGER"),
+    ("row_counts", "JSONB"),
+)
+
+# Never inferred away from TEXT, however this run's values happen to look.
+_TEXT_NAMES = frozenset({"slug", "artifact_id", "alias", "handle", "pattern", "target"})
+
+_INT = re.compile(r"^-?\d+$")
+_INT32 = 2**31 - 1
+_TRUE_FALSE = frozenset({"true", "false"})
+
+
+def is_text_column(name: str) -> bool:
+    """Identity columns stay TEXT. Slugs and ids are strings that sometimes hold digits."""
+    return name in _TEXT_NAMES or name.endswith("_slug") or name.endswith("_id")
+
+
+def _all_parse(values: list[str], parse) -> bool:
+    for value in values:
+        try:
+            parse(value)
+        except (TypeError, ValueError):
+            return False
+    return True
+
+
+def infer_column_type(name: str, values: list[str]) -> str:
+    """The narrowest type every non-empty value in the column satisfies, else TEXT.
+
+    An all-empty column is TEXT: nothing in the data argues for anything narrower, and a
+    guess would be reversed by the first real value.
+    """
+    if is_text_column(name):
+        return "TEXT"
+    present = [v for v in values if v != ""]
+    if not present:
+        return "TEXT"
+    if all(v.lower() in _TRUE_FALSE for v in present):
+        return "BOOLEAN"
+    if all(_INT.match(v) for v in present):
+        return "INTEGER" if all(abs(int(v)) <= _INT32 for v in present) else "BIGINT"
+    if _all_parse(present, float):
+        return "DOUBLE PRECISION"
+    if _all_parse(present, lambda v: datetime.strptime(v, "%Y-%m-%d")):
+        return "DATE"
+    return "TEXT"
+
+
+@dataclass(frozen=True)
+class TablePlan:
+    """One CSV, resolved to a table: its name, its typed columns, and its row count."""
+
+    name: str
+    columns: tuple[tuple[str, str], ...]
+    row_count: int
+    path: Path
+
+
+def plan_table(path: Path) -> TablePlan:
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.reader(handle)
+        header = next(reader, [])
+        rows = list(reader)
+    columns = tuple(
+        (name, infer_column_type(name, [row[index] if index < len(row) else "" for row in rows]))
+        for index, name in enumerate(header)
+    )
+    return TablePlan(name=path.stem, columns=columns, row_count=len(rows), path=path)
+
+
+def ensure_csvs(directory: Path) -> None:
+    """Regenerate the registry CSVs when they are absent.
+
+    Only the registry serializer's own tables are regenerated. The rubric, routing and
+    scores serializers write into the same directory and are published from it too, so
+    whatever they have left there is loaded as well — but this module does not run them,
+    because each has its own preconditions and a publisher silently invoking four
+    serializers hides which one produced a surprising table.
+    """
+    if all((directory / f"{name}.csv").exists() for name in REGISTRY_TABLES):
+        return
+    from build.validate import load_sources
+
+    tables, errors, _warnings = build_registry(load_sources(ROOT))
+    if errors:
+        raise RuntimeError(
+            f"the registry does not serialize cleanly ({len(errors)} error(s)); "
+            f"run build.serialize_registry to see them"
+        )
+    write_tables(tables, directory)
+
+
+def plan(directory: Path = OUT_DIR) -> list[TablePlan]:
+    """Every CSV in the directory, as a table plan, in a stable order."""
+    ensure_csvs(directory)
+    return [plan_table(path) for path in sorted(directory.glob("*.csv"))]
+
+
+def quote_ident(name: str) -> str:
+    """Double-quote an identifier. Rejects anything that is not a plain name.
+
+    Table names come from filenames and column names from a serializer's header, so a
+    quoted identifier is defence against a filename rather than against a user. Refusing
+    the odd shapes outright is clearer than escaping them into something loadable.
+    """
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+        raise ValueError(f"not a usable SQL identifier: {name!r}")
+    return f'"{name}"'
+
+
+def create_table_sql(schema: str, columns: tuple[tuple[str, str], ...], name: str) -> str:
+    body = ",\n  ".join(f"{quote_ident(column)} {sql_type}" for column, sql_type in columns)
+    return f"CREATE TABLE {quote_ident(schema)}.{quote_ident(name)} (\n  {body}\n)"
+
+
+def copy_sql(schema: str, plan_: TablePlan) -> str:
+    names = ", ".join(quote_ident(column) for column, _type in plan_.columns)
+    return (
+        f"COPY {quote_ident(schema)}.{quote_ident(plan_.name)} ({names}) "
+        f"FROM STDIN WITH (FORMAT csv, HEADER true)"
+    )
+
+
+def grant_sql(schema: str, role: str | None) -> list[str]:
+    """USAGE on the schema plus SELECT on its tables, for PUBLIC or a named role."""
+    grantee = "PUBLIC" if not role else quote_ident(role)
+    return [
+        f"GRANT USAGE ON SCHEMA {quote_ident(schema)} TO {grantee}",
+        f"GRANT SELECT ON ALL TABLES IN SCHEMA {quote_ident(schema)} TO {grantee}",
+    ]
+
+
+def swap_sql(schema: str, live_exists: bool) -> list[str]:
+    """The cutover, as the statements to run inside one transaction.
+
+    `live_exists` decides the shape rather than an exception: on the first run there is no
+    live schema to rename, and renaming a schema that is not there is a different error
+    from every other reason a rename fails.
+    """
+    staging = f"{schema}_staging"
+    previous = f"{schema}_previous"
+    if not live_exists:
+        return [f"ALTER SCHEMA {quote_ident(staging)} RENAME TO {quote_ident(schema)}"]
+    return [
+        f"DROP SCHEMA IF EXISTS {quote_ident(previous)} CASCADE",
+        f"ALTER SCHEMA {quote_ident(schema)} RENAME TO {quote_ident(previous)}",
+        f"ALTER SCHEMA {quote_ident(staging)} RENAME TO {quote_ident(schema)}",
+        f"DROP SCHEMA {quote_ident(previous)} CASCADE",
+    ]
+
+
+def require_ssl(dsn: str) -> str:
+    """Append `sslmode=require` unless the DSN already says something about SSL.
+
+    Neon requires TLS, so a DSN without it fails anyway; this makes it fail nowhere rather
+    than at connect time on a machine whose libpq defaults differ.
+    """
+    parsed = urlparse(dsn)
+    if not parsed.scheme:
+        return dsn if "sslmode=" in dsn else f"{dsn} sslmode=require"
+    params = parse_qsl(parsed.query, keep_blank_values=True)
+    if any(key == "sslmode" for key, _value in params):
+        return dsn
+    params.append(("sslmode", "require"))
+    return urlunparse(parsed._replace(query=urlencode(params)))
+
+
+def scrub(text: str, dsn: str) -> str:
+    """Remove the DSN, its password and its host from a message before it is printed.
+
+    A libpq failure quotes the host it could not reach, and a URL-shaped DSN carries the
+    password one delimiter away from it. Neither belongs in a CI log, so every message
+    that could have come from the driver goes through here.
+    """
+    out = text.replace(dsn, "[redacted]")
+    parsed = urlparse(dsn)
+    for secret in (parsed.password, parsed.hostname, parsed.username):
+        if secret:
+            out = out.replace(secret, "[redacted]")
+    return out
+
+
+def declaration_identity() -> tuple[str | None, str | None]:
+    """(source_git_sha, declaration_version_id) for the run record, or (None, None).
+
+    `allow_dirty=True` because this records what was published, not what may be trusted as
+    reproducible — a dirty tree is a local run, and refusing to write a row would lose the
+    record of the load that actually happened. On main the tree is clean and the pair is the
+    reproducible identity of the declarations.
+    """
+    try:
+        from build.declaration_version import resolve
+
+        info = resolve(allow_dirty=True)
+        return info["source_git_sha"], info["declaration_version_id"]
+    except Exception:  # noqa: BLE001 - the run record is not worth failing a publish over
+        return None, None
+
+
+def publish(dsn: str, plans: list[TablePlan], schema: str, read_role: str | None) -> dict:
+    """Load every plan into the staging schema and swap it into place. Returns the run record."""
+    import psycopg
+
+    staging = f"{schema}_staging"
+    git_sha, version_id = declaration_identity()
+    record = {
+        "run_id": uuid.uuid4().hex,
+        "published_at": datetime.now(UTC),
+        "source_git_sha": git_sha,
+        "declaration_version_id": version_id,
+        "table_count": len(plans),
+        "row_counts": {p.name: p.row_count for p in plans},
+    }
+
+    with psycopg.connect(require_ssl(dsn), autocommit=True) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(f"DROP SCHEMA IF EXISTS {quote_ident(staging)} CASCADE")
+            cursor.execute(f"CREATE SCHEMA {quote_ident(staging)}")
+            for plan_ in plans:
+                cursor.execute(create_table_sql(staging, plan_.columns, plan_.name))
+                with (
+                    plan_.path.open("rb") as handle,
+                    cursor.copy(copy_sql(staging, plan_)) as copy,
+                ):
+                    while chunk := handle.read(1 << 16):
+                        copy.write(chunk)
+                print(f"  {plan_.name:<24} {plan_.row_count:>6} rows")
+
+            cursor.execute(create_table_sql(staging, RUN_COLUMNS, RUN_TABLE))
+            cursor.execute(
+                f"INSERT INTO {quote_ident(staging)}.{quote_ident(RUN_TABLE)} "
+                f"(run_id, published_at, source_git_sha, declaration_version_id, "
+                f"table_count, row_counts) VALUES (%s, %s, %s, %s, %s, %s)",
+                (
+                    record["run_id"],
+                    record["published_at"],
+                    record["source_git_sha"],
+                    record["declaration_version_id"],
+                    record["table_count"],
+                    json.dumps(record["row_counts"]),
+                ),
+            )
+            for statement in grant_sql(staging, read_role):
+                cursor.execute(statement)
+
+            cursor.execute(
+                "SELECT 1 FROM information_schema.schemata WHERE schema_name = %s", (schema,)
+            )
+            live_exists = cursor.fetchone() is not None
+
+        # One transaction, so no reader ever sees the schema absent or half-renamed.
+        with connection.transaction(), connection.cursor() as cursor:
+            for statement in swap_sql(schema, live_exists):
+                cursor.execute(statement)
+
+    return record
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check", action="store_true", help="plan only: print the tables and row counts, connect to nothing"
+    )
+    parser.add_argument("--dsn-env", default=DSN_ENV, help=f"env var holding the DSN (default {DSN_ENV})")
+    parser.add_argument("--schema", default=DEFAULT_SCHEMA, help=f"target schema (default {DEFAULT_SCHEMA})")
+    parser.add_argument("--dir", type=Path, default=OUT_DIR, help="directory of serialized CSVs")
+    args = parser.parse_args()
+
+    plans = plan(args.dir)
+    if not plans:
+        print(f"no CSVs in {args.dir}", file=sys.stderr)
+        return 2
+
+    if args.check:
+        print(f"would load {len(plans)} tables into {args.schema}_staging, then swap to {args.schema}:")
+        for plan_ in plans:
+            print(f"  {plan_.name:<24} {plan_.row_count:>6} rows  {len(plan_.columns)} columns")
+        for plan_ in plans:
+            for column, sql_type in plan_.columns:
+                if sql_type != "TEXT":
+                    print(f"    {plan_.name}.{column} -> {sql_type}")
+        print(f"  {RUN_TABLE:<24} {1:>6} row   {len(RUN_COLUMNS)} columns")
+        return 0
+
+    dsn = os.environ.get(args.dsn_env)
+    if not dsn:
+        print(f"{args.dsn_env} is not set; nothing to publish to", file=sys.stderr)
+        return 2
+
+    read_role = os.environ.get(READ_ROLE_ENV) or None
+    print(f"loading {len(plans)} tables into {args.schema}_staging:")
+    try:
+        record = publish(dsn, plans, args.schema, read_role)
+    except Exception as error:  # noqa: BLE001 - re-raised scrubbed; the driver quotes the host
+        print(f"publish failed: {scrub(str(error), dsn)}", file=sys.stderr)
+        return 1
+
+    total = sum(record["row_counts"].values())
+    print(
+        f"swapped {args.schema} in place: {record['table_count']} tables, {total:,} rows, "
+        f"run {record['run_id']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/operations/deploy-models.md
+++ b/docs/operations/deploy-models.md
@@ -80,6 +80,7 @@ holds it against the `cron:` lines it quotes.
 | What | When (UTC) | Where the cron lives |
 |---|---|---|
 | `registry` static models | every push to `main` touching `sources/**` | `.github/workflows/registry.yml`, no cron |
+| `gapmap` schema in Neon (the site's serving layer) | same push, one step after the OSO publish | `.github/workflows/registry.yml`, no cron |
 | `identity` dataset | Sunday 05:30 | dataset cron, timezone UTC |
 | `evidence` dataset | Monday 03:00 | dataset cron, timezone UTC |
 | `scores` dataset | Monday 04:00 | dataset cron, timezone UTC |
@@ -127,6 +128,8 @@ Pushing the declarations is step 1, not the whole job:
 ```bash
 # push the repo's declarations and wait for the static models to materialize
 uv run python -m build.serialize_rubric && uv run python -m build.publish_registry
+# load the same declarations into Neon, which is what the site reads
+uv run python -m build.publish_neon           # --check to plan without connecting
 # then walk the chain above, in order, and prove it with check_parity
 ```
 
@@ -215,6 +218,11 @@ newer revision is released and the mirror describes code that no longer runs, or
 released yet and the resync is cheap now. What the check cannot do is confirm that the revision
 it found is the one a run would materialize; that is the same gap as the missing
 revision-versus-release assertion noted above.
+The Neon step needs `NEON_DATABASE_URL` (in CI, the repository secret of that name; locally,
+the value in `.env`). It loads into `gapmap_staging` and swaps that into `gapmap` in one
+transaction, so it is safe to re-run and a reader never sees a half-loaded schema. See
+`docs/reference/where-scores-live.md` for what the schema holds and what it deliberately does
+not.
 
 ## The parity gate
 

--- a/docs/operations/deploy-models.md
+++ b/docs/operations/deploy-models.md
@@ -80,7 +80,7 @@ holds it against the `cron:` lines it quotes.
 | What | When (UTC) | Where the cron lives |
 |---|---|---|
 | `registry` static models | every push to `main` touching `sources/**` | `.github/workflows/registry.yml`, no cron |
-| `gapmap` schema in Neon (the site's serving layer) | same push, one step after the OSO publish | `.github/workflows/registry.yml`, no cron |
+| `os-ai-map` schema in Neon (the site's serving layer) | same push, one step after the OSO publish | `.github/workflows/registry.yml`, no cron |
 | `identity` dataset | Sunday 05:30 | dataset cron, timezone UTC |
 | `evidence` dataset | Monday 03:00 | dataset cron, timezone UTC |
 | `scores` dataset | Monday 04:00 | dataset cron, timezone UTC |
@@ -219,10 +219,21 @@ released yet and the resync is cheap now. What the check cannot do is confirm th
 it found is the one a run would materialize; that is the same gap as the missing
 revision-versus-release assertion noted above.
 The Neon step needs `NEON_DATABASE_URL` (in CI, the repository secret of that name; locally,
-the value in `.env`). It loads into `gapmap_staging` and swaps that into `gapmap` in one
-transaction, so it is safe to re-run and a reader never sees a half-loaded schema. See
-`docs/reference/where-scores-live.md` for what the schema holds and what it deliberately does
-not.
+the value in `.env`). It loads into `os-ai-map_staging` and swaps that into `os-ai-map` in one
+transaction, so it is safe to re-run and a reader never sees a half-loaded schema. The instance
+is shared with the rest of the site, and the publisher refuses to run against `drizzle`,
+`payload` or `public`.
+
+To verify a change to the load before it reaches `main`, dispatch the workflow on the branch
+with `neon_only`, which skips the OSO publish (the static models are org-wide and a branch must
+not overwrite them) and writes the resulting table counts to the run summary:
+
+```bash
+gh workflow run registry.yml --ref <branch> -f neon_only=true
+```
+
+See `docs/reference/where-scores-live.md` for what the schema holds, the three dates it
+carries, and what it deliberately does not have.
 
 ## The parity gate
 

--- a/docs/operations/deploy-models.md
+++ b/docs/operations/deploy-models.md
@@ -224,13 +224,17 @@ transaction, so it is safe to re-run and a reader never sees a half-loaded schem
 is shared with the rest of the site, and the publisher refuses to run against `drizzle`,
 `payload` or `public`.
 
-To verify a change to the load before it reaches `main`, dispatch the workflow on the branch
-with `neon_only`, which skips the OSO publish (the static models are org-wide and a branch must
-not overwrite them) and writes the resulting table counts to the run summary:
+To verify a change to the load before it reaches `main`, dispatch the workflow on the branch.
+A dispatch always skips the OSO publish — the static models are org-wide and a branch must not
+overwrite them — and writes the resulting table counts, the constraint tally and the
+`publish_runs` row to the run summary:
 
 ```bash
-gh workflow run registry.yml --ref <branch> -f neon_only=true
+gh workflow run registry.yml --ref <branch>
 ```
+
+There is no flag to remember: the OSO step is guarded on `push` to `main`, so a dispatch never
+reaches it, on any ref.
 
 See `docs/reference/where-scores-live.md` for what the schema holds, the three dates it
 carries, and what it deliberately does not have.

--- a/docs/operations/deploy-models.md
+++ b/docs/operations/deploy-models.md
@@ -236,6 +236,11 @@ gh workflow run registry.yml --ref <branch>
 There is no flag to remember: the OSO step is guarded on `push` to `main`, so a dispatch never
 reaches it, on any ref.
 
+**OSO publishing now happens only on a push to `main`.** To republish the static models without
+a new commit, re-run the push run that last published them (`gh run rerun <id>`), or push an
+empty commit — a `workflow_dispatch` will load Neon and leave OSO untouched however it is
+invoked.
+
 See `docs/reference/where-scores-live.md` for what the schema holds, the three dates it
 carries, and what it deliberately does not have.
 

--- a/docs/reference/where-scores-live.md
+++ b/docs/reference/where-scores-live.md
@@ -51,8 +51,18 @@ file itself stays the repo's build artifact and its gate contract, and is the *i
 load.
 
 The instance is shared. `drizzle`, `payload` and `public` belong to other parts of the site;
-`os-ai-map` is the gap map's, and the publisher touches only it and its own
-`os-ai-map_staging`. It refuses to run against any of the other three.
+`os-ai-map` is the gap map's, and the publisher touches only it and its own two working
+schemas, `os-ai-map_staging` and `os-ai-map_previous`. It refuses to run against any of the
+other three.
+
+Both working names are steady state, not transients. `os-ai-map_staging` exists while a load
+runs. `os-ai-map_previous` exists **between** runs and holds the entire previous corpus —
+tables, rows, enum types, and the `SELECT` grant that travelled with the rename — until the
+start of the next publish reclaims it. So the database normally carries two readable copies of
+the map: the live one and the one it replaced. Storage is roughly double, and anything that can
+read `os-ai-map` can also read the superseded corpus under `os-ai-map_previous`. Nothing is
+meant to, and the publisher does not stop anything from trying — do not build against that
+name.
 
 **Two groups of table, one schema.**
 
@@ -67,7 +77,9 @@ derived from that module rather than from a directory listing, so the two surfac
 same registry by construction. The prefix exists because both groups have a `products`, a
 `categories` and an `organizations`.
 
-Plus `publish_runs`: one row per load, carrying `run_id`, `published_at`, `schema_version`,
+Plus `publish_runs`: exactly one row, describing the load you are looking at — the swap
+replaces the table along with everything else, so it is a stamp on the current corpus and not
+an accumulating history. It carries `run_id`, `published_at`, `schema_version`,
 `built_at`, `released_at`, `source_git_sha`, `declaration_version_id`, `table_count` and a
 `row_counts` JSONB. That row is how you tell which commit and which shape the serving layer is
 showing.

--- a/docs/reference/where-scores-live.md
+++ b/docs/reference/where-scores-live.md
@@ -41,38 +41,97 @@ NULL rather than absent, so "not measured" and "no such column" cannot be confus
 `adoption_signal_type` travels with `adoption_level` deliberately: a stars band and a downloads
 band are different scales, so a query that ranks across `signal_type` is wrong.
 
-## The Neon serving layer — `gapmap`
+## The Neon serving layer — the `os-ai-map` schema
 
-The front end reads the declarations from Postgres rather than from the warehouse, because a
-page render cannot wait on a Trino query. `build/publish_neon.py` loads every CSV the
-serializers have written into `build/registry/` as a table in the `gapmap` schema, on every push
-to `main` that triggers `registry.yml` — the same trigger and the same job as the OSO publish,
-one step after it.
+The front end reads products, scores and freshness dates from Postgres rather than from the
+warehouse, because a page render cannot wait on a Trino query. `build/publish_neon.py` loads
+the `os-ai-map` schema on every push to `main` that triggers `registry.yml`, one step after the
+OSO publish. This is what deprecates `build/notebook_data.json` as the site's transport; the
+file itself stays the repo's build artifact and its gate contract, and is the *input* to the
+load.
 
-What is there: the registry tables. `products`, `organizations`, `categories`,
-`product_artifacts`, `product_categories`, `product_organizations`, `product_lineage`,
-`tail_products`, `resolution_ledger`, `product_aliases`, `org_handles`, `model_families`, plus
-`publish_runs` — one row per load, carrying `run_id`, `published_at`, `source_git_sha`,
-`declaration_version_id`, `table_count` and a `row_counts` JSONB of the per-table counts. That
-row is how you tell which commit the serving layer is showing.
+The instance is shared. `drizzle`, `payload` and `public` belong to other parts of the site;
+`os-ai-map` is the gap map's, and the publisher touches only it and its own
+`os-ai-map_staging`. It refuses to run against any of the other three.
 
-What is not there: **the warehouse recomputation**. `scores.openness_facts` and
-`scores.openness_computed` stay on OSO, and nothing in `gapmap` recomputes an axis. So a
-question about what the map *says* is answerable here, and a question about whether the
-warehouse *agrees* is not — that is `check_parity` against the tables above.
+**Two groups of table, one schema.**
 
-The load is atomic. Rows go into `gapmap_staging`, which is dropped and recreated each run, and
-the cutover is `gapmap` → `gapmap_previous`, `gapmap_staging` → `gapmap`, drop
-`gapmap_previous`, all three renames in one transaction. A reader sees the whole old schema or
-the whole new one, never a table that has loaded next to one that has not. Grants are applied to
-the staging schema before the swap, since a rename carries privileges with it. `NEON_READ_ROLE`
-names the role granted `SELECT`; unset means `PUBLIC`.
+*The map* — the target model from CLEVER FRANKE, with Carl's amendments: `products`,
+`organizations`, `categories`, `layers`, `stages`, `gaps`, `gaps_categories`, `openness`,
+`adoption`, `capability`, `sources`, `product_lineage`, `aliases`, `long_tail_top`,
+`long_tail_counts`, and the three `gallery*` tables. Every row is derived from
+`build/notebook_data.json`, so what Postgres serves is what the repo published.
 
-Column types are inferred from the data and deliberately timid: TEXT unless every non-empty
-value in a column parses as BOOLEAN, INTEGER, DOUBLE PRECISION or DATE, and identity columns
-(`slug`, anything ending `_slug` or `_id`) are pinned to TEXT whatever they look like. A
-digits-only artifact id is a string with digits in it, and letting one run's values decide
-otherwise would change the column type from under a query.
+*The registry*, prefixed `registry_` — the same tables `publish_registry` publishes to OSO,
+derived from that module rather than from a directory listing, so the two surfaces carry the
+same registry by construction. The prefix exists because both groups have a `products`, a
+`categories` and an `organizations`.
+
+Plus `publish_runs`: one row per load, carrying `run_id`, `published_at`, `schema_version`,
+`built_at`, `released_at`, `source_git_sha`, `declaration_version_id`, `table_count` and a
+`row_counts` JSONB. That row is how you tell which commit and which shape the serving layer is
+showing.
+
+**Keys are natural where the payload has one.** `products.id` exists for the FK shape the
+designers specified, but it is assigned by sorted slug on every load, so the same corpus gives
+the same ids and a diff of two loads is readable. The real key is `slug`. Organizations key on
+`slug`, aliases on `alias`, and `categories` carries a `slug` alongside its id — the PDF omitted
+it, and every deep link and every join from the registry group needs it.
+
+**The eight enums are enforced.** `alias_kind`, `freshness_basis`, `lineage_relation`,
+`capability_relation`, `metric_name`, `health_status`, `integration_type`, `gap_type` are
+created in the schema, and a payload value with no mapping fails the load naming the value
+rather than being coerced to something adjacent. One mapping is lossy and worth knowing:
+`capability.relation` in the payload is a signed distance (`at`, `one_above`, `one_below`,
+`two_below`) and the enum has none, so `one_below` and `two_below` both arrive as `tier_below`.
+The exact distance is only in `capability.notes`.
+
+### The three dates, which are three different questions
+
+| Where | Column | Question it answers |
+|---|---|---|
+| `publish_runs` | `built_at` | When was this data built? The payload's `generated`. |
+| `publish_runs` | `released_at` | When was the release cut? The payload's `released`, which `build/serialize.py::release_date` reads from `CHANGELOG.md`. |
+| `products` | `freshness_date`, `freshness_basis` | When was this product's score last confirmed, and how — `verified` by a human, or `commit` as the fallback to the score file's last commit. |
+| `openness`, `adoption`, `capability` | `last_verified` | The same question asked of one axis. |
+
+`docs/reference/evidence-and-freshness.md` is normative for what a freshness date means and how it is
+derived. Do not read `built_at` as a freshness date: it says when the build ran, not when
+anything was checked.
+
+### What is not there
+
+**The warehouse recomputation.** `scores.openness_facts` and `scores.openness_computed` stay
+on OSO, and no table in `os-ai-map` recomputes an axis. A question about what the map *says* is
+answerable here; whether the warehouse *agrees* is `check_parity` against the tables above.
+
+**Gallery content.** `gallery`, `gallery_products` and `gallery_gaps` are created and left
+empty. Gallery entries are authored CMS-side, in the `payload` schema, not derived from the
+map's data — the tables exist so the site's queries compile before that content lands.
+
+### The load is atomic, and the swap is the migration path
+
+Rows go into `os-ai-map_staging`, dropped and recreated each run, and the cutover is
+`os-ai-map` → `os-ai-map_previous`, `os-ai-map_staging` → `os-ai-map`, drop
+`os-ai-map_previous`, all three renames in one transaction. A reader sees the whole old schema
+or the whole new one, never a table that has loaded next to one that has not. Grants are
+applied to the staging schema before the swap, since a rename carries privileges with it;
+`NEON_READ_ROLE` names the role granted `SELECT`, and unset means `PUBLIC`.
+
+There is no migration tool, and for now there does not need to be one: every publish rebuilds
+the schema from `build/neon_schema.py`, so a shape change is live on the next load with no
+ALTER anywhere. What that costs is a reader's ability to tell which shape it has, which is why
+`publish_runs.schema_version` exists — bump `SCHEMA_VERSION` in the same commit as any change
+to a table, column or enum. Once something outside this repo depends on the shape, that is the
+point where a real migration path replaces the swap.
+
+Column types for the map group are declared in `build/neon_schema.py`, next to the grain they
+describe. The registry group's are inferred from the data, because the serializers declare
+column names and not types: TEXT unless every non-empty value in the column parses as BOOLEAN,
+INTEGER, DOUBLE PRECISION or DATE, and identity columns (`slug`, anything ending `_slug` or
+`_id`) pinned to TEXT whatever they look like. A digits-only artifact id is a string with
+digits in it. An empty CSV field loads as NULL on both groups, so "absent" and "empty" are the
+same value.
 
 ## Openness — computed and gated
 

--- a/docs/reference/where-scores-live.md
+++ b/docs/reference/where-scores-live.md
@@ -59,8 +59,8 @@ The instance is shared. `drizzle`, `payload` and `public` belong to other parts 
 *The map* — the target model from CLEVER FRANKE, with Carl's amendments: `products`,
 `organizations`, `categories`, `layers`, `stages`, `gaps`, `gaps_categories`, `openness`,
 `adoption`, `capability`, `sources`, `product_lineage`, `aliases`, `long_tail_top`,
-`long_tail_counts`, and the three `gallery*` tables. Every row is derived from
-`build/notebook_data.json`, so what Postgres serves is what the repo published.
+`long_tail_counts`. Every row is derived from `build/notebook_data.json`, so what Postgres
+serves is what the repo published.
 
 *The registry*, prefixed `registry_` — the same tables `publish_registry` publishes to OSO,
 derived from that module rather than from a directory listing, so the two surfaces carry the
@@ -78,13 +78,18 @@ the same ids and a diff of two loads is readable. The real key is `slug`. Organi
 `slug`, aliases on `alias`, and `categories` carries a `slug` alongside its id — the PDF omitted
 it, and every deep link and every join from the registry group needs it.
 
-**The eight enums are enforced.** `alias_kind`, `freshness_basis`, `lineage_relation`,
-`capability_relation`, `metric_name`, `health_status`, `integration_type`, `gap_type` are
-created in the schema, and a payload value with no mapping fails the load naming the value
-rather than being coerced to something adjacent. One mapping is lossy and worth knowing:
-`capability.relation` in the payload is a signed distance (`at`, `one_above`, `one_below`,
-`two_below`) and the enum has none, so `one_below` and `two_below` both arrive as `tier_below`.
-The exact distance is only in `capability.notes`.
+**The five enums are enforced.** `alias_kind`, `freshness_basis`, `lineage_relation`,
+`capability_relation` and `metric_name` are created in the schema, and a payload value with no
+mapping fails the load naming the value rather than being coerced to something adjacent. The
+DBML's other three (`health_status`, `integration_type`, `gap_type`) belong to the gallery
+tables and are not created here — see "What the CMS owns" below.
+
+**The DBML's constraints are real.** Every primary key, `NOT NULL`, unique and foreign key the
+target model declares is emitted in the CREATE statement, so the database enforces the model
+rather than the site discovering a dangling id at render time. `categories.slug` also gets a
+unique the DBML does not declare, because the column is an amendment and a duplicate slug
+would break the deep links it exists for. A violation aborts the COPY, the staging schema is
+discarded, and the live schema stays exactly where it was — failing there is the point.
 
 ### The three dates, which are three different questions
 
@@ -105,18 +110,61 @@ anything was checked.
 on OSO, and no table in `os-ai-map` recomputes an axis. A question about what the map *says* is
 answerable here; whether the warehouse *agrees* is `check_parity` against the tables above.
 
-**Gallery content.** `gallery`, `gallery_products` and `gallery_gaps` are created and left
-empty. Gallery entries are authored CMS-side, in the `payload` schema, not derived from the
-map's data — the tables exist so the site's queries compile before that content lands.
+### What the CMS owns
+
+**Gallery content is not in this schema.** `gallery`, `gallery_products` and `gallery_gaps`
+were here, created and left empty so the site's queries would compile. That was a hazard
+rather than a courtesy: this publisher drops and recreates its schema on every load, so the
+first gallery row an editor wrote would have been deleted by the next push to `main`, with
+nothing raising anywhere and every artifact of the publish still reporting `gallery 0 rows`.
+
+A schema rebuilt from source can only hold rows it produced. Gallery content is authored, so
+it belongs in the CMS's own `payload` schema, or in a separate `os-ai-map_cms` schema that
+this publisher never creates, never drops and never grants on. Both are on the same database,
+so a join across them costs a qualified name and nothing else.
+
+**For whoever builds that:** a *view* in the CMS schema over a table in `os-ai-map` will not
+survive a load. The cutover renames the schema, and a view binds to the table it was created
+over by OID rather than by name, so the view ends up pointing into `os-ai-map_previous` and is
+dropped when that is reclaimed. `publish_neon.reclaim_previous` detects exactly this and
+refuses to run rather than dropping the view — the failure is loud, but it is still a failure.
+Read the map's tables directly, or materialize a copy CMS-side.
+
+### Two things the designers should know about the data
+
+**`sources.notes` is always NULL.** The target model has the column and the payload has no
+field for it, so nothing here fills it. In the other direction, the payload's `establishes`,
+`content_sha256` and `http_status` have no column in the target model. `shows` is the one that
+maps.
+
+**`capability.relation` is lossy.** The payload carries a signed distance (`at`, `one_above`,
+`one_below`, `two_below`) and the target enum has none, so `one_below` and `two_below` both
+arrive as `tier_below`. The exact distance is only in `capability.notes`. `anchor` is in the
+enum and unused. If the front end needs the distance, the enum has to grow.
 
 ### The load is atomic, and the swap is the migration path
 
-Rows go into `os-ai-map_staging`, dropped and recreated each run, and the cutover is
-`os-ai-map` → `os-ai-map_previous`, `os-ai-map_staging` → `os-ai-map`, drop
-`os-ai-map_previous`, all three renames in one transaction. A reader sees the whole old schema
-or the whole new one, never a table that has loaded next to one that has not. Grants are
-applied to the staging schema before the swap, since a rename carries privileges with it;
-`NEON_READ_ROLE` names the role granted `SELECT`, and unset means `PUBLIC`.
+Rows go into `os-ai-map_staging`, dropped and recreated each run, and the cutover is two
+renames in one transaction: `os-ai-map` → `os-ai-map_previous`, then `os-ai-map_staging` →
+`os-ai-map`. A reader sees the whole old schema or the whole new one, never a table that has
+loaded next to one that has not. Grants are applied to the staging schema before the swap,
+since a rename carries privileges with it; `NEON_READ_ROLE` names the role granted `SELECT`,
+and unset means `PUBLIC`.
+
+**Nothing is dropped in that transaction.** `DROP SCHEMA … CASCADE` takes an exclusive lock on
+every table it removes, so a drop in the cutover would hold the applied-but-uncommitted
+renames behind any in-flight site query, and arriving readers would queue behind the pending
+lock — one slow reader stalling every reader for as long as it runs. Pure catalog renames take
+no table locks. `lock_timeout` is 5s on the session and the swap transaction is retried three
+times with backoff, because the schema's own catalog row can still be contended.
+
+The old schema stays as `os-ai-map_previous` and is reclaimed at the *start* of the next run,
+after `pg_depend` is checked for dependents outside the three schemas this publisher manages.
+If any exist the run fails listing them, rather than dropping. `PROTECTED_SCHEMAS` stops the
+publisher naming someone else's schema, but CASCADE follows dependencies, not schema
+membership: a view in `payload` over `os-ai-map.products`, or a foreign key from a CMS table
+into it, still depends on that table after the rename. Without the check, a CASCADE would drop
+that object too, in its own schema, silently, on every publish.
 
 There is no migration tool, and for now there does not need to be one: every publish rebuilds
 the schema from `build/neon_schema.py`, so a shape change is live on the next load with no

--- a/docs/reference/where-scores-live.md
+++ b/docs/reference/where-scores-live.md
@@ -41,6 +41,39 @@ NULL rather than absent, so "not measured" and "no such column" cannot be confus
 `adoption_signal_type` travels with `adoption_level` deliberately: a stars band and a downloads
 band are different scales, so a query that ranks across `signal_type` is wrong.
 
+## The Neon serving layer — `gapmap`
+
+The front end reads the declarations from Postgres rather than from the warehouse, because a
+page render cannot wait on a Trino query. `build/publish_neon.py` loads every CSV the
+serializers have written into `build/registry/` as a table in the `gapmap` schema, on every push
+to `main` that triggers `registry.yml` — the same trigger and the same job as the OSO publish,
+one step after it.
+
+What is there: the registry tables. `products`, `organizations`, `categories`,
+`product_artifacts`, `product_categories`, `product_organizations`, `product_lineage`,
+`tail_products`, `resolution_ledger`, `product_aliases`, `org_handles`, `model_families`, plus
+`publish_runs` — one row per load, carrying `run_id`, `published_at`, `source_git_sha`,
+`declaration_version_id`, `table_count` and a `row_counts` JSONB of the per-table counts. That
+row is how you tell which commit the serving layer is showing.
+
+What is not there: **the warehouse recomputation**. `scores.openness_facts` and
+`scores.openness_computed` stay on OSO, and nothing in `gapmap` recomputes an axis. So a
+question about what the map *says* is answerable here, and a question about whether the
+warehouse *agrees* is not — that is `check_parity` against the tables above.
+
+The load is atomic. Rows go into `gapmap_staging`, which is dropped and recreated each run, and
+the cutover is `gapmap` → `gapmap_previous`, `gapmap_staging` → `gapmap`, drop
+`gapmap_previous`, all three renames in one transaction. A reader sees the whole old schema or
+the whole new one, never a table that has loaded next to one that has not. Grants are applied to
+the staging schema before the swap, since a rename carries privileges with it. `NEON_READ_ROLE`
+names the role granted `SELECT`; unset means `PUBLIC`.
+
+Column types are inferred from the data and deliberately timid: TEXT unless every non-empty
+value in a column parses as BOOLEAN, INTEGER, DOUBLE PRECISION or DATE, and identity columns
+(`slug`, anything ending `_slug` or `_id`) are pinned to TEXT whatever they look like. A
+digits-only artifact id is a string with digits in it, and letting one run's values decide
+otherwise would change the column type from under a query.
+
 ## Openness — computed and gated
 
 | Where | What | Currency |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "huggingface-hub>=1.18.0",
     "datasets>=5.0.0",
     "markdown>=3.10.2",
+    "psycopg[binary]>=3.3.5",
 ]
 
 [dependency-groups]

--- a/tests/test_publish_neon.py
+++ b/tests/test_publish_neon.py
@@ -533,6 +533,36 @@ def test_the_foreign_keys_resolve_to_rows_that_exist():
         assert row["gap_id"] in gap_id_set
 
 
+def test_a_product_with_no_org_fails_naming_the_product():
+    """`products.org_slug` is NOT NULL and references `organizations`. Writing "" sent an
+    empty string into COPY, which CSV reads as NULL, so the load died on a constraint naming
+    the column — leaving whoever hit it to work out which of 615 products was missing an org.
+    """
+    payload = load_payload()
+    victim = next(
+        product
+        for cid in payload["order"]
+        for product in payload["categories"][cid]["products"]
+    )
+    slug = victim["slug"]
+    saved = victim.get("org_slug")
+    victim["org_slug"] = ""
+    try:
+        with pytest.raises(UnmappedValue) as error:
+            SITE_TABLES["products"].rows(payload)
+        assert slug in str(error.value)
+        assert "org_slug" in str(error.value)
+    finally:
+        victim["org_slug"] = saved
+
+
+def test_every_product_in_the_corpus_has_an_org():
+    """The guard above only helps if the corpus is clean today; a red here is a data fix."""
+    payload = load_payload()
+    rows = SITE_TABLES["products"].rows(payload)
+    assert all(row["org_slug"] for row in rows)
+
+
 def test_each_axis_has_exactly_one_row_per_product():
     payload = load_payload()
     products = SITE_TABLES["products"].rows(payload)
@@ -778,6 +808,41 @@ def test_an_external_dependent_fails_the_run_and_is_never_dropped():
     assert not any("DROP SCHEMA" in statement for statement in cursor.statements)
 
 
+def test_a_column_typed_by_one_of_our_enums_is_a_dependent_too():
+    """The hazard here is not a table. The enum types are created in the staging schema so
+    they travel with the rename, which means they travel into `_previous` — so a CMS column
+    declared `os-ai-map.health_status` ends up typed by a type in `_previous`, and reclaiming
+    would drop the type and take the column with it."""
+    cursor = _StubCursor(
+        previous_exists=True,
+        dependents=[("payload", "case_studies.health", "column typed health_status")],
+    )
+    with pytest.raises(ExternalDependents) as error:
+        reclaim_previous(cursor, DEFAULT_SCHEMA)
+    message = str(error.value)
+    assert "payload.case_studies.health" in message
+    assert "column typed health_status" in message
+    assert not any("DROP SCHEMA" in statement for statement in cursor.statements)
+
+
+def test_the_dependency_check_covers_relations_and_types_and_skips_composite_types():
+    """Three arms: views and rules, foreign keys, and columns typed by one of our enums.
+
+    Composite types are excluded because every table has one, so including them would report
+    each of our own tables as a dependent of itself.
+    """
+    cursor = _StubCursor(previous_exists=True)
+    external_dependents(cursor, DEFAULT_SCHEMA)
+    query, _params = cursor.executed[-1]
+    assert "pg_rewrite" in query
+    assert "pg_constraint" in query
+    assert "pg_attribute" in query and "pg_type" in query
+    assert "atttypid" in query
+    assert "typtype <> 'c'" in query
+    # A dropped column keeps its pg_attribute row and its atttypid.
+    assert "attisdropped" in query
+
+
 def test_the_dependency_check_asks_about_previous_and_exempts_only_our_own_schemas():
     cursor = _StubCursor(previous_exists=True)
     external_dependents(cursor, DEFAULT_SCHEMA)
@@ -976,10 +1041,15 @@ def test_every_not_null_the_dbml_declares_is_in_the_generated_ddl(table, column)
     assert f'"{column}"' in sql
 
 
-def test_no_constraint_is_declared_for_the_registry_group():
+def test_no_constraint_is_declared_for_the_registry_group(tmp_path):
     """The serializers declare column names only, so there is nothing to derive a key from,
-    and inventing one would be this module guessing at another module's grain."""
-    plans, _missing = plan()
+    and inventing one would be this module guessing at another module's grain.
+
+    `site_dir` is a tmp path because `plan` renders the map group's CSVs: writing them into
+    the real `build/neon/` would race the `--check` subprocess test under `-n 4`, and the
+    loser reads a half-written header.
+    """
+    plans, _missing = plan(site_dir=tmp_path / "site")
     for plan_ in plans:
         if plan_.name not in SITE_TABLES:
             assert plan_.constraints == ()

--- a/tests/test_publish_neon.py
+++ b/tests/test_publish_neon.py
@@ -637,6 +637,56 @@ def test_the_embedded_newline_is_not_counted_as_an_extra_row():
     assert dict(plan_.columns)["note"] == "TEXT"
 
 
+# --- the read-back query --------------------------------------------------------------
+
+
+def test_the_read_back_query_reaches_postgres_with_its_own_format_specifiers_intact():
+    """`%I` is Postgres's, and psycopg claims `%` the moment parameters are passed.
+
+    The first CI run of build/neon_status.py failed here: psycopg scanned the statement,
+    found `%I`, and refused it before connecting. The schema is composed in as a literal
+    instead, so there are no parameters and nothing scans the query.
+    """
+    from build.neon_status import counts_sql
+
+    rendered = counts_sql("os-ai-map").as_string()
+    assert "format('select count(*) as c from %I.%I', table_schema, table_name)" in rendered
+    assert "%%" not in rendered, "a doubled specifier would reach format() as a literal %"
+    assert "{schema}" not in rendered
+
+
+def test_the_read_back_query_quotes_the_schema_it_filters_on():
+    from build.neon_status import counts_sql
+
+    rendered = counts_sql("os-ai-map").as_string()
+    assert "WHERE table_schema = 'os-ai-map'" in rendered
+
+
+def test_a_schema_name_carrying_a_quote_cannot_break_out_of_the_read_back_query():
+    """`sql.Literal` escapes the value. This is not string interpolation into SQL."""
+    from build.neon_status import counts_sql
+
+    rendered = counts_sql("o'brien").as_string()
+    assert "'o''brien'" in rendered
+
+
+def test_the_runs_query_names_the_schema_and_the_run_table():
+    from build.neon_status import RUNS_SQL
+
+    rendered = RUNS_SQL.format(schema=quote_schema("os-ai-map"), table=f'"{RUN_TABLE}"')
+    assert f'FROM "os-ai-map"."{RUN_TABLE}"' in rendered
+    assert "%" not in rendered, "the runs query passes no parameters either"
+
+
+def test_the_status_report_reads_back_every_column_the_run_record_writes():
+    """A column added to RUN_COLUMNS and not to the report is a column nobody ever sees."""
+    from build.neon_status import RUNS_SQL
+
+    selected = RUNS_SQL.split("FROM")[0]
+    for column, _type in RUN_COLUMNS:
+        assert column in selected, f"{column} is written but never read back"
+
+
 # --- helpers --------------------------------------------------------------------------
 
 _TMP: dict[str, Path] = {}

--- a/tests/test_publish_neon.py
+++ b/tests/test_publish_neon.py
@@ -9,6 +9,7 @@ without connecting, and that a DSN never reaches stdout or stderr.
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -30,24 +31,32 @@ from build.neon_schema import (
 from build.publish_neon import (
     DEFAULT_SCHEMA,
     DSN_ENV,
+    LOCK_TIMEOUT,
     PROTECTED_SCHEMAS,
     PUBLISHED_TABLES,
     RUN_COLUMNS,
     RUN_TABLE,
+    SWAP_ATTEMPTS,
+    ExternalDependents,
     create_enum_sql,
     create_table_sql,
     copy_sql,
+    external_dependents,
     grant_sql,
     infer_column_type,
+    is_retryable,
     plan,
     plan_table,
     check_schema_is_ours,
     quote_ident,
     quote_schema,
+    reclaim_previous,
     require_ssl,
     scrub,
     stream_bytes,
+    swap_in_place,
     swap_sql,
+    working_schemas,
 )
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -211,6 +220,7 @@ def test_the_swap_touches_only_the_target_and_its_two_working_schemas():
         f"{DEFAULT_SCHEMA}_previous",
     }
     assert not named & PROTECTED_SCHEMAS
+    assert set(working_schemas(DEFAULT_SCHEMA)) == named
 
 
 # --- the swap -------------------------------------------------------------------------
@@ -223,19 +233,21 @@ def test_the_first_run_is_a_single_rename():
     ]
 
 
-def test_the_steady_state_swap_moves_aside_renames_and_drops_in_that_order():
+def test_the_steady_state_swap_is_two_renames_and_moves_the_live_schema_aside_first():
     assert swap_sql("gapmap", live_exists=True) == [
-        'DROP SCHEMA IF EXISTS "gapmap_previous" CASCADE',
         'ALTER SCHEMA "gapmap" RENAME TO "gapmap_previous"',
         'ALTER SCHEMA "gapmap_staging" RENAME TO "gapmap"',
-        'DROP SCHEMA "gapmap_previous" CASCADE',
     ]
 
 
-def test_the_swap_clears_a_previous_schema_left_by_a_run_that_died_mid_cutover():
-    statements = swap_sql("gapmap", live_exists=True)
-    assert statements[0].startswith('DROP SCHEMA IF EXISTS "gapmap_previous"')
-    assert statements.index('ALTER SCHEMA "gapmap" RENAME TO "gapmap_previous"') == 1
+def test_the_cutover_transaction_drops_nothing():
+    """A DROP here would take AccessExclusiveLock on every table it removes, holding the
+    applied-but-uncommitted renames behind any in-flight reader — and it would follow
+    dependencies out of this schema. Reclaiming is the next run's job."""
+    for live_exists in (True, False):
+        for statement in swap_sql("gapmap", live_exists=live_exists):
+            assert "DROP" not in statement.upper()
+            assert "CASCADE" not in statement.upper()
 
 
 def test_the_swap_never_drops_the_live_schema_by_name():
@@ -411,16 +423,16 @@ def _complete_dir(directory: Path) -> Path:
 
 # --- enums ----------------------------------------------------------------------------
 
-def test_all_eight_enums_are_declared():
+def test_the_five_enums_the_map_uses_are_declared():
+    """The DBML's other three belong to the gallery tables, which the CMS owns. An enum no
+    column can reference would be dead metadata, and one created here would be worse: a CMS
+    table referencing it would depend on a schema this publisher renames on every load."""
     assert set(ENUMS) == {
         "alias_kind",
         "freshness_basis",
         "lineage_relation",
         "capability_relation",
         "metric_name",
-        "health_status",
-        "integration_type",
-        "gap_type",
     }
 
 
@@ -530,11 +542,15 @@ def test_each_axis_has_exactly_one_row_per_product():
         assert len({row["product_id"] for row in rows}) == len(products)
 
 
-def test_the_gallery_tables_are_created_empty_because_the_content_is_cms_side():
-    payload = load_payload()
+def test_the_gallery_tables_are_not_published_at_all():
+    """They were created empty so the site's queries would compile, which was a hazard: the
+    swap rebuilds the schema, so the first row an editor wrote would be deleted by the next
+    push to main with nothing raising. A schema rebuilt from source holds only rows it
+    produced. See "What the CMS owns" in build/neon_schema.py."""
     for name in ("gallery", "gallery_products", "gallery_gaps"):
-        assert SITE_TABLES[name].rows(payload) == []
-        assert SITE_TABLES[name].columns, f"{name} still needs its columns"
+        assert name not in SITE_TABLES
+    for enum in ("health_status", "integration_type", "gap_type"):
+        assert enum not in ENUMS
 
 
 def test_the_long_tail_tables_are_filled_from_the_payload():
@@ -685,6 +701,323 @@ def test_the_status_report_reads_back_every_column_the_run_record_writes():
     selected = RUNS_SQL.split("FROM")[0]
     for column, _type in RUN_COLUMNS:
         assert column in selected, f"{column} is written but never read back"
+
+
+# --- reclaiming the previous schema ---------------------------------------------------
+
+
+class _StubCursor:
+    """Enough of a cursor to drive `reclaim_previous` without a database.
+
+    Answers by inspecting the statement rather than by position, so a reordering of the
+    function's queries does not silently change what the stub is answering.
+    """
+
+    def __init__(self, *, previous_exists: bool = True, dependents=()):
+        self.previous_exists = previous_exists
+        self.dependents = list(dependents)
+        self.executed: list[tuple[str, object]] = []
+        self._result: list[tuple] = []
+
+    def execute(self, statement, params=None):
+        text = str(statement)
+        self.executed.append((text, params))
+        if "information_schema.schemata" in text:
+            self._result = [(1,)] if self.previous_exists else []
+        elif "pg_depend" in text:
+            self._result = list(self.dependents)
+        else:
+            self._result = []
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+    def fetchall(self):
+        return list(self._result)
+
+    @property
+    def statements(self) -> list[str]:
+        return [text for text, _params in self.executed]
+
+
+def test_reclaiming_drops_the_previous_schema_when_nothing_outside_depends_on_it():
+    cursor = _StubCursor(previous_exists=True, dependents=())
+    assert reclaim_previous(cursor, DEFAULT_SCHEMA) is True
+    assert any(
+        f'DROP SCHEMA IF EXISTS "{DEFAULT_SCHEMA}_previous" CASCADE' in statement
+        for statement in cursor.statements
+    )
+
+
+def test_reclaiming_is_a_no_op_when_there_is_no_previous_schema():
+    """The first run, and any run after one that reclaimed cleanly."""
+    cursor = _StubCursor(previous_exists=False)
+    assert reclaim_previous(cursor, DEFAULT_SCHEMA) is False
+    assert not any("DROP SCHEMA" in statement for statement in cursor.statements)
+
+
+def test_an_external_dependent_fails_the_run_and_is_never_dropped():
+    """CASCADE follows dependencies, not schema membership. A view in `payload` over one of
+    our tables still depends on it after the rename, so a CASCADE would drop it — in its own
+    schema, silently, on every publish. That is the accident PROTECTED_SCHEMAS exists to
+    prevent, one indirection out."""
+    cursor = _StubCursor(
+        previous_exists=True,
+        dependents=[
+            ("payload", "gallery_view", "view or rule"),
+            ("drizzle", "case_studies", "foreign key case_studies_product_fk"),
+        ],
+    )
+    with pytest.raises(ExternalDependents) as error:
+        reclaim_previous(cursor, DEFAULT_SCHEMA)
+    message = str(error.value)
+    assert "payload.gallery_view" in message
+    assert "drizzle.case_studies" in message
+    assert "view or rule" in message
+    assert "foreign key case_studies_product_fk" in message
+    assert not any("DROP SCHEMA" in statement for statement in cursor.statements)
+
+
+def test_the_dependency_check_asks_about_previous_and_exempts_only_our_own_schemas():
+    cursor = _StubCursor(previous_exists=True)
+    external_dependents(cursor, DEFAULT_SCHEMA)
+    query, params = cursor.executed[-1]
+    assert "pg_depend" in query and "pg_constraint" in query
+    assert params["previous"] == f"{DEFAULT_SCHEMA}_previous"
+    assert params["working"] == working_schemas(DEFAULT_SCHEMA)
+    assert not set(params["working"]) & PROTECTED_SCHEMAS
+
+
+def test_the_working_schemas_are_exactly_the_three_this_publisher_manages():
+    assert working_schemas("gapmap") == ["gapmap", "gapmap_staging", "gapmap_previous"]
+
+
+# --- the swap transaction, and its retry ----------------------------------------------
+
+
+class _SqlstateError(Exception):
+    def __init__(self, sqlstate: str):
+        super().__init__(f"stub failure {sqlstate}")
+        self.sqlstate = sqlstate
+
+
+class _FakeConnection:
+    """`transaction()` and `cursor()`, enough for `swap_in_place`."""
+
+    def __init__(self, *, fail_times: int = 0, sqlstate: str = "55P03"):
+        self.fail_times = fail_times
+        self.sqlstate = sqlstate
+        self.attempts = 0
+        self.statements: list[str] = []
+
+    def transaction(self):
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _transaction():
+            self.attempts += 1
+            if self.attempts <= self.fail_times:
+                raise _SqlstateError(self.sqlstate)
+            yield
+
+        return _transaction()
+
+    def cursor(self):
+        from contextlib import contextmanager
+
+        outer = self
+
+        class _Cursor:
+            def execute(self, statement, params=None):
+                outer.statements.append(str(statement))
+
+        @contextmanager
+        def _cursor():
+            yield _Cursor()
+
+        return _cursor()
+
+
+@pytest.mark.parametrize("sqlstate,expected", [("55P03", True), ("40P01", True), ("23505", False), (None, False)])
+def test_only_a_lock_failure_is_worth_retrying(sqlstate, expected):
+    """SQLSTATE, never the message: 55P03 is our own lock_timeout firing, 40P01 a deadlock.
+    A constraint violation (23505) is the load telling us the data is wrong, and retrying it
+    would just fail again more slowly."""
+    assert is_retryable(_SqlstateError(sqlstate) if sqlstate else Exception("boom")) is expected
+
+
+def test_the_swap_commits_on_the_first_attempt_when_the_lock_is_free():
+    connection = _FakeConnection()
+    slept: list[float] = []
+    assert swap_in_place(connection, "gapmap", True, sleep=slept.append) == 1
+    assert connection.statements == swap_sql("gapmap", live_exists=True)
+    assert slept == []
+
+
+def test_a_contended_swap_is_retried_with_backoff_and_then_commits():
+    connection = _FakeConnection(fail_times=2)
+    slept: list[float] = []
+    assert swap_in_place(connection, "gapmap", True, sleep=slept.append) == 3
+    assert slept == [1.0, 3.0]
+    assert connection.statements == swap_sql("gapmap", live_exists=True)
+
+
+def test_a_swap_that_never_gets_its_lock_raises_after_the_last_attempt():
+    connection = _FakeConnection(fail_times=99)
+    with pytest.raises(_SqlstateError):
+        swap_in_place(connection, "gapmap", True, sleep=lambda _seconds: None)
+    assert connection.attempts == SWAP_ATTEMPTS
+
+
+def test_a_failure_that_is_not_about_locks_is_not_retried():
+    connection = _FakeConnection(fail_times=99, sqlstate="23505")
+    with pytest.raises(_SqlstateError):
+        swap_in_place(connection, "gapmap", True, sleep=lambda _seconds: None)
+    assert connection.attempts == 1, "a constraint violation must fail on the first attempt"
+
+
+def test_a_lock_timeout_is_set_and_is_short():
+    """Longer than a rename needs by orders of magnitude, short enough that a stalled
+    cutover retries rather than parks."""
+    assert LOCK_TIMEOUT.endswith("s")
+    assert int(LOCK_TIMEOUT.rstrip("s")) <= 10
+
+
+# --- the constraints the DBML declares ------------------------------------------------
+
+# Transcribed from plans/neon-initial-schema.dbml (Laith, CLEVER FRANKE) plus Carl's
+# amendments. Pinned rather than parsed: the DBML lives outside this repo, so a test that
+# read it would pass locally and fail in CI. Gallery tables are absent on purpose — the CMS
+# owns them.
+_DBML_CONSTRAINTS: dict[str, set[str]] = {
+    "layers": {'PRIMARY KEY ("id")'},
+    "stages": {'PRIMARY KEY ("id")'},
+    "gaps": {'PRIMARY KEY ("id")'},
+    "categories": {
+        'PRIMARY KEY ("id")',
+        'UNIQUE ("slug")',
+        'FOREIGN KEY ("layer") REFERENCES {schema}."layers" ("id")',
+        'FOREIGN KEY ("stage") REFERENCES {schema}."stages" ("id")',
+    },
+    "gaps_categories": {
+        'FOREIGN KEY ("cat_id") REFERENCES {schema}."categories" ("id")',
+        'FOREIGN KEY ("gap_id") REFERENCES {schema}."gaps" ("id")',
+    },
+    "organizations": {'PRIMARY KEY ("slug")'},
+    "products": {
+        'PRIMARY KEY ("id")',
+        'UNIQUE ("slug")',
+        'FOREIGN KEY ("org_slug") REFERENCES {schema}."organizations" ("slug")',
+        'FOREIGN KEY ("category") REFERENCES {schema}."categories" ("id")',
+    },
+    "openness": {
+        'PRIMARY KEY ("product_id")',
+        'FOREIGN KEY ("product_id") REFERENCES {schema}."products" ("id")',
+    },
+    "adoption": {
+        'PRIMARY KEY ("product_id")',
+        'FOREIGN KEY ("product_id") REFERENCES {schema}."products" ("id")',
+    },
+    "capability": {
+        'PRIMARY KEY ("product_id")',
+        'FOREIGN KEY ("product_id") REFERENCES {schema}."products" ("id")',
+    },
+    "sources": {
+        'PRIMARY KEY ("id")',
+        'FOREIGN KEY ("product_id") REFERENCES {schema}."products" ("id")',
+    },
+    "product_lineage": {
+        'PRIMARY KEY ("id")',
+        'FOREIGN KEY ("product_id") REFERENCES {schema}."products" ("id")',
+    },
+    "aliases": {'PRIMARY KEY ("alias")'},
+    "long_tail_top": {'PRIMARY KEY ("id")'},
+    "long_tail_counts": set(),
+}
+
+# Every `[not null]` in the DBML, plus categories.slug: the column is Carl's amendment and a
+# nullable unique column admits any number of NULLs.
+_DBML_NOT_NULL: tuple[tuple[str, str], ...] = (
+    ("products", "slug"),
+    ("products", "org_slug"),
+    ("products", "category"),
+    ("categories", "slug"),
+    ("categories", "layer"),
+    ("categories", "stage"),
+    ("sources", "product_id"),
+    ("sources", "metric_type"),
+    ("product_lineage", "product_id"),
+    ("gaps_categories", "cat_id"),
+    ("gaps_categories", "gap_id"),
+)
+
+
+def test_the_map_group_is_exactly_the_dbmls_tables():
+    assert set(SITE_TABLES) == set(_DBML_CONSTRAINTS)
+
+
+@pytest.mark.parametrize("table", sorted(_DBML_CONSTRAINTS))
+def test_every_constraint_the_dbml_declares_is_in_the_generated_ddl(table):
+    """The database enforces the model, rather than the site discovering a dangling id at
+    render time. A violation aborts the COPY, the staging schema is discarded and the live
+    schema stays where it was, which is the point."""
+    spec = SITE_TABLES[table]
+    sql = create_table_sql("os-ai-map_staging", spec.columns, table, spec.constraints)
+    for clause in _DBML_CONSTRAINTS[table]:
+        assert clause.format(schema='"os-ai-map_staging"') in sql, f"{table}: missing {clause}"
+
+
+@pytest.mark.parametrize("table,column", _DBML_NOT_NULL)
+def test_every_not_null_the_dbml_declares_is_in_the_generated_ddl(table, column):
+    spec = SITE_TABLES[table]
+    sql = create_table_sql("os-ai-map_staging", spec.columns, table, spec.constraints)
+    definition = dict(spec.columns)[column]
+    assert "NOT NULL" in definition, f"{table}.{column} is nullable"
+    assert f'"{column}"' in sql
+
+
+def test_no_constraint_is_declared_for_the_registry_group():
+    """The serializers declare column names only, so there is nothing to derive a key from,
+    and inventing one would be this module guessing at another module's grain."""
+    plans, _missing = plan()
+    for plan_ in plans:
+        if plan_.name not in SITE_TABLES:
+            assert plan_.constraints == ()
+
+
+def test_a_foreign_key_target_is_qualified_with_the_schema_being_built():
+    """The staging schema is never on the search path, so an unqualified reference would
+    resolve against whatever the live schema holds at the time."""
+    spec = SITE_TABLES["products"]
+    sql = create_table_sql("os-ai-map_staging", spec.columns, "products", spec.constraints)
+    assert 'REFERENCES "os-ai-map_staging"."organizations"' in sql
+    assert 'REFERENCES "organizations"' not in sql
+
+
+def test_the_tables_are_ordered_parents_first_so_every_reference_resolves():
+    """A FK can only be created after its target table exists, and the COPY into a child can
+    only succeed after the parent's rows are in. Both follow from the declared order."""
+    order = list(SITE_TABLES)
+    for position, (name, spec) in enumerate(SITE_TABLES.items()):
+        for clause in spec.constraints:
+            for referent in re.findall(r'REFERENCES \{schema\}\."([^"]+)"', clause):
+                assert referent in order, f"{name} references unknown table {referent}"
+                assert order.index(referent) <= position, (
+                    f"{name} references {referent}, which is created later"
+                )
+
+
+def test_the_constraint_tally_the_read_back_reports_is_the_one_the_ddl_asks_for():
+    """The read-back counts what `information_schema` holds, so the two numbers agreeing is
+    what proves the swap created the constraints rather than merely being asked to."""
+    from build.neon_status import constraints_sql
+
+    rendered = constraints_sql("os-ai-map").as_string()
+    assert "information_schema.table_constraints" in rendered
+    assert "constraint_schema = 'os-ai-map'" in rendered
+    # Postgres materializes a CHECK per NOT NULL column, which would swamp the tally with
+    # something the column list already shows.
+    assert "constraint_type <> 'CHECK'" in rendered
 
 
 # --- helpers --------------------------------------------------------------------------

--- a/tests/test_publish_neon.py
+++ b/tests/test_publish_neon.py
@@ -1,0 +1,260 @@
+"""The Neon publisher, without a database.
+
+Everything that decides what reaches the serving layer is a pure function here — the type
+a column gets, the DDL for a table, the statement sequence the cutover runs — so all of it
+is tested against strings rather than against a live Postgres. The two things that cannot
+be checked that way are covered by running the CLI as a subprocess: that `--check` plans
+without connecting, and that a DSN never reaches stdout or stderr.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from build.publish_neon import (
+    DSN_ENV,
+    RUN_COLUMNS,
+    RUN_TABLE,
+    create_table_sql,
+    copy_sql,
+    grant_sql,
+    infer_column_type,
+    plan_table,
+    quote_ident,
+    require_ssl,
+    scrub,
+    swap_sql,
+)
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# A DSN shaped like Neon's, with parts distinctive enough that a leak is unambiguous.
+FAKE_DSN = "postgresql://mapuser:pw-tripwire-9f31@nowhere-tripwire.example.invalid/gapmapdb"
+
+
+# --- type inference ------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("name", "values", "expected"),
+    [
+        ("weight_adopt", ["0.6", "0.3", ""], "DOUBLE PRECISION"),
+        ("table_count", ["1", "12", "300"], "INTEGER"),
+        ("big", ["9999999999"], "BIGINT"),
+        ("decided_on", ["2026-08-30", ""], "DATE"),
+        ("is_mature", ["true", "false"], "BOOLEAN"),
+        ("is_mature", ["True", "FALSE"], "BOOLEAN"),
+        ("note", ["a note", ""], "TEXT"),
+        ("mixed", ["1", "one"], "TEXT"),
+        ("blank", ["", ""], "TEXT"),
+        ("almost_date", ["2026-08-30", "August"], "TEXT"),
+    ],
+)
+def test_a_column_gets_the_narrowest_type_every_value_satisfies(name, values, expected):
+    assert infer_column_type(name, values) == expected
+
+
+@pytest.mark.parametrize(
+    "name", ["slug", "product_slug", "category_slug", "artifact_id", "declaration_version_id"]
+)
+def test_identity_columns_stay_text_however_numeric_this_run_looks(name):
+    """A digits-only artifact id is a string with digits in it.
+
+    Inferring INTEGER off one run's values would change the column type from under a query
+    the first time a non-numeric id arrives.
+    """
+    assert infer_column_type(name, ["1", "2", "3"]) == "TEXT"
+
+
+def test_an_empty_column_is_text_not_a_guess():
+    assert infer_column_type("artifact_url", []) == "TEXT"
+
+
+# --- DDL ------------------------------------------------------------------------------
+
+def test_create_table_sql_names_the_schema_and_every_typed_column():
+    sql = create_table_sql(
+        "gapmap_staging", (("slug", "TEXT"), ("weight_adopt", "DOUBLE PRECISION")), "categories"
+    )
+    assert sql.startswith('CREATE TABLE "gapmap_staging"."categories" (')
+    assert '"slug" TEXT' in sql
+    assert '"weight_adopt" DOUBLE PRECISION' in sql
+
+
+def test_copy_sql_lists_the_columns_and_reads_a_header():
+    plan = plan_table(_write_csv("products", "slug,display_name\na,A\nb,B\n"))
+    sql = copy_sql("gapmap_staging", plan)
+    assert 'COPY "gapmap_staging"."products" ("slug", "display_name")' in sql
+    assert "FORMAT csv, HEADER true" in sql
+
+
+def test_the_run_table_carries_the_publish_identity():
+    columns = dict(RUN_COLUMNS)
+    assert set(columns) == {
+        "run_id",
+        "published_at",
+        "source_git_sha",
+        "declaration_version_id",
+        "table_count",
+        "row_counts",
+    }
+    assert columns["row_counts"] == "JSONB"
+    sql = create_table_sql("gapmap_staging", RUN_COLUMNS, RUN_TABLE)
+    assert '"row_counts" JSONB' in sql
+
+
+@pytest.mark.parametrize("bad", ["products; DROP SCHEMA gapmap", "two words", "", '"quoted"'])
+def test_an_identifier_that_is_not_a_plain_name_is_refused(bad):
+    with pytest.raises(ValueError):
+        quote_ident(bad)
+
+
+def test_grants_go_to_public_by_default_and_to_a_named_role_when_given():
+    public = grant_sql("gapmap_staging", None)
+    assert public[0].endswith("TO PUBLIC")
+    assert 'GRANT SELECT ON ALL TABLES IN SCHEMA "gapmap_staging" TO PUBLIC' == public[1]
+    named = grant_sql("gapmap_staging", "site_reader")
+    assert all('"site_reader"' in statement for statement in named)
+
+
+# --- the swap -------------------------------------------------------------------------
+
+def test_the_first_run_is_a_single_rename():
+    """There is no live schema to move aside, and renaming one that is absent is a
+    different error from every other reason a rename fails."""
+    assert swap_sql("gapmap", live_exists=False) == [
+        'ALTER SCHEMA "gapmap_staging" RENAME TO "gapmap"'
+    ]
+
+
+def test_the_steady_state_swap_moves_aside_renames_and_drops_in_that_order():
+    assert swap_sql("gapmap", live_exists=True) == [
+        'DROP SCHEMA IF EXISTS "gapmap_previous" CASCADE',
+        'ALTER SCHEMA "gapmap" RENAME TO "gapmap_previous"',
+        'ALTER SCHEMA "gapmap_staging" RENAME TO "gapmap"',
+        'DROP SCHEMA "gapmap_previous" CASCADE',
+    ]
+
+
+def test_the_swap_clears_a_previous_schema_left_by_a_run_that_died_mid_cutover():
+    statements = swap_sql("gapmap", live_exists=True)
+    assert statements[0].startswith('DROP SCHEMA IF EXISTS "gapmap_previous"')
+    assert statements.index('ALTER SCHEMA "gapmap" RENAME TO "gapmap_previous"') == 1
+
+
+def test_the_swap_never_drops_the_live_schema_by_name():
+    """The live schema is renamed out of the way and the *old name's* holder is dropped.
+
+    A `DROP SCHEMA gapmap` anywhere in this sequence would be a window with no serving
+    layer at all, which is the failure the transaction exists to prevent.
+    """
+    for statement in swap_sql("gapmap", live_exists=True):
+        assert not statement.startswith('DROP SCHEMA "gapmap" ')
+        assert 'DROP SCHEMA IF EXISTS "gapmap" ' not in statement
+
+
+# --- the DSN --------------------------------------------------------------------------
+
+def test_require_ssl_appends_sslmode_when_the_url_omits_it():
+    assert "sslmode=require" in require_ssl("postgresql://u:p@host/db")
+    assert "sslmode=require" in require_ssl("postgresql://u:p@host/db?application_name=x")
+
+
+def test_require_ssl_leaves_an_explicit_sslmode_alone():
+    dsn = "postgresql://u:p@host/db?sslmode=verify-full"
+    assert require_ssl(dsn) == dsn
+
+
+def test_require_ssl_handles_a_keyword_dsn():
+    assert require_ssl("host=h dbname=d") == "host=h dbname=d sslmode=require"
+    assert require_ssl("host=h sslmode=disable") == "host=h sslmode=disable"
+
+
+def test_scrub_removes_the_dsn_its_password_and_its_host():
+    message = (
+        f'could not translate host name "nowhere-tripwire.example.invalid" to address; '
+        f"dsn was {FAKE_DSN}"
+    )
+    cleaned = scrub(message, FAKE_DSN)
+    for secret in ("pw-tripwire-9f31", "nowhere-tripwire.example.invalid", "mapuser"):
+        assert secret not in cleaned
+
+
+# --- the CLI --------------------------------------------------------------------------
+
+def _run(args: list[str], env_extra: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    import os
+
+    env = dict(os.environ)
+    env.pop(DSN_ENV, None)
+    env.update(env_extra or {})
+    return subprocess.run(
+        [sys.executable, "-m", "build.publish_neon", *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_check_plans_without_a_dsn_and_prints_the_row_counts():
+    result = _run(["--check"])
+    assert result.returncode == 0, result.stderr
+    assert "would load" in result.stdout
+    assert "products" in result.stdout
+    assert RUN_TABLE in result.stdout
+
+
+def test_a_publish_with_no_dsn_exits_2_and_says_which_variable():
+    result = _run([])
+    assert result.returncode == 2
+    assert DSN_ENV in result.stderr
+    assert "not set" in result.stderr
+
+
+def test_no_part_of_the_dsn_ever_reaches_stdout_or_stderr():
+    """The publish will fail — the host does not resolve — and the failure is the point:
+    a libpq error quotes the host, one delimiter from the password."""
+    result = _run([], {DSN_ENV: FAKE_DSN})
+    assert result.returncode == 1
+    output = result.stdout + result.stderr
+    for secret in (FAKE_DSN, "pw-tripwire-9f31", "nowhere-tripwire.example.invalid", "mapuser"):
+        assert secret not in output, f"{secret!r} leaked into the publisher's output"
+
+
+# --- helpers --------------------------------------------------------------------------
+
+_TMP: dict[str, Path] = {}
+
+
+def _write_csv(name: str, text: str) -> Path:
+    import tempfile
+
+    directory = _TMP.setdefault("dir", Path(tempfile.mkdtemp()))
+    path = directory / f"{name}.csv"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_plan_table_reads_the_header_and_counts_data_rows_only():
+    plan = plan_table(_write_csv("categories", "slug,weight_adopt\na,0.6\nb,0.3\n"))
+    assert plan.name == "categories"
+    assert plan.row_count == 2
+    assert plan.columns == (("slug", "TEXT"), ("weight_adopt", "DOUBLE PRECISION"))
+
+
+def test_a_header_only_csv_plans_as_a_real_table_with_no_rows():
+    """A serializer emits a header for every table it declares, filled or not."""
+    plan = plan_table(_write_csv("tail_products", "slug,artifact_id\n"))
+    assert plan.row_count == 0
+    assert plan.columns == (("slug", "TEXT"), ("artifact_id", "TEXT"))
+
+
+def test_a_short_row_does_not_shift_a_columns_inferred_type():
+    """csv tolerates a row with missing trailing fields; the absent value is empty, not
+    the next column's."""
+    plan = plan_table(_write_csv("ragged", "a,b\n1,2\n3\n"))
+    assert dict(plan.columns)["b"] == "INTEGER"

--- a/tests/test_publish_neon.py
+++ b/tests/test_publish_neon.py
@@ -15,18 +15,38 @@ from pathlib import Path
 
 import pytest
 
+from build.neon_schema import (
+    ALL_TABLES,
+    ENUM_MAPS,
+    ENUMS,
+    REGISTRY_PREFIX,
+    SCHEMA_VERSION,
+    SITE_TABLES,
+    UnmappedValue,
+    enum_value,
+    load_payload,
+    product_ids,
+)
 from build.publish_neon import (
+    DEFAULT_SCHEMA,
     DSN_ENV,
+    PROTECTED_SCHEMAS,
+    PUBLISHED_TABLES,
     RUN_COLUMNS,
     RUN_TABLE,
+    create_enum_sql,
     create_table_sql,
     copy_sql,
     grant_sql,
     infer_column_type,
+    plan,
     plan_table,
+    check_schema_is_ours,
     quote_ident,
+    quote_schema,
     require_ssl,
     scrub,
+    stream_bytes,
     swap_sql,
 )
 
@@ -91,19 +111,30 @@ def test_copy_sql_lists_the_columns_and_reads_a_header():
     assert "FORMAT csv, HEADER true" in sql
 
 
-def test_the_run_table_carries_the_publish_identity():
+def test_the_run_table_carries_the_publish_identity_and_the_two_payload_dates():
     columns = dict(RUN_COLUMNS)
     assert set(columns) == {
         "run_id",
         "published_at",
+        "schema_version",
+        "built_at",
+        "released_at",
         "source_git_sha",
         "declaration_version_id",
         "table_count",
         "row_counts",
     }
     assert columns["row_counts"] == "JSONB"
+    assert columns["built_at"] == columns["released_at"] == "DATE"
     sql = create_table_sql("gapmap_staging", RUN_COLUMNS, RUN_TABLE)
     assert '"row_counts" JSONB' in sql
+
+
+def test_the_schema_version_is_recorded_because_the_swap_is_the_migration():
+    """Every publish rebuilds the schema from the mapping, so nothing else tells a reader
+    which shape it is looking at."""
+    assert isinstance(SCHEMA_VERSION, int) and SCHEMA_VERSION >= 1
+    assert dict(RUN_COLUMNS)["schema_version"] == "INTEGER"
 
 
 @pytest.mark.parametrize("bad", ["products; DROP SCHEMA gapmap", "two words", "", '"quoted"'])
@@ -118,6 +149,68 @@ def test_grants_go_to_public_by_default_and_to_a_named_role_when_given():
     assert 'GRANT SELECT ON ALL TABLES IN SCHEMA "gapmap_staging" TO PUBLIC' == public[1]
     named = grant_sql("gapmap_staging", "site_reader")
     assert all('"site_reader"' in statement for statement in named)
+
+
+# --- the shared instance --------------------------------------------------------------
+
+def test_the_default_schema_is_the_gap_maps_own():
+    assert DEFAULT_SCHEMA == "os-ai-map"
+
+
+def test_a_hyphenated_schema_name_is_quoted_not_refused():
+    """The agreed Neon layout names the gap map's schema with a hyphen."""
+    assert quote_schema("os-ai-map") == '"os-ai-map"'
+    assert quote_schema("os-ai-map_staging") == '"os-ai-map_staging"'
+
+
+@pytest.mark.parametrize("bad", ['os"ai', "os ai map", "-leading", "", "os\\map", "os;drop"])
+def test_a_schema_name_that_would_need_escaping_is_refused(bad):
+    """A schema name reaches DROP SCHEMA ... CASCADE."""
+    with pytest.raises(ValueError):
+        quote_schema(bad)
+
+
+def test_a_hyphen_is_still_refused_in_a_table_or_column_name():
+    """Fine in a schema a maintainer chose; never something a serializer should produce."""
+    with pytest.raises(ValueError):
+        quote_ident("os-ai-map")
+
+
+@pytest.mark.parametrize("schema", sorted(PROTECTED_SCHEMAS))
+def test_another_part_of_the_sites_schema_is_refused(schema):
+    """drizzle, payload and public share this instance and this publisher drops schemas
+    with CASCADE. A typo in --schema must not be able to take one of them."""
+    with pytest.raises(ValueError, match="refusing"):
+        check_schema_is_ours(schema)
+
+
+@pytest.mark.parametrize("schema", ["os-ai-map_staging", "os-ai-map_previous"])
+def test_the_publishers_own_working_schemas_are_refused_as_a_target(schema):
+    with pytest.raises(ValueError, match="manages itself"):
+        check_schema_is_ours(schema)
+
+
+def test_the_gap_maps_own_schema_passes():
+    check_schema_is_ours(DEFAULT_SCHEMA)
+
+
+def test_a_protected_schema_on_the_cli_exits_2_without_connecting():
+    result = _run(["--schema", "public"], {DSN_ENV: FAKE_DSN})
+    assert result.returncode == 2
+    assert "refusing" in result.stderr
+
+
+def test_the_swap_touches_only_the_target_and_its_two_working_schemas():
+    """Nothing on the shared instance outside these three names is named in the cutover."""
+    named = set()
+    for statement in swap_sql(DEFAULT_SCHEMA, live_exists=True):
+        named.update(part.strip('"') for part in statement.split() if part.startswith('"'))
+    assert named == {
+        DEFAULT_SCHEMA,
+        f"{DEFAULT_SCHEMA}_staging",
+        f"{DEFAULT_SCHEMA}_previous",
+    }
+    assert not named & PROTECTED_SCHEMAS
 
 
 # --- the swap -------------------------------------------------------------------------
@@ -215,14 +308,333 @@ def test_a_publish_with_no_dsn_exits_2_and_says_which_variable():
     assert "not set" in result.stderr
 
 
-def test_no_part_of_the_dsn_ever_reaches_stdout_or_stderr():
+def test_no_part_of_the_dsn_ever_reaches_stdout_or_stderr(tmp_path):
     """The publish will fail — the host does not resolve — and the failure is the point:
     a libpq error quotes the host, one delimiter from the password."""
-    result = _run([], {DSN_ENV: FAKE_DSN})
-    assert result.returncode == 1
+    result = _run(
+        [
+            "--dir",
+            str(_complete_dir(tmp_path / "csv")),
+            "--site-dir",
+            str(tmp_path / "site"),
+        ],
+        {DSN_ENV: FAKE_DSN},
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
     output = result.stdout + result.stderr
     for secret in (FAKE_DSN, "pw-tripwire-9f31", "nowhere-tripwire.example.invalid", "mapuser"):
         assert secret not in output, f"{secret!r} leaked into the publisher's output"
+
+
+# --- the table set --------------------------------------------------------------------
+
+def test_the_registry_group_is_the_set_publish_registry_publishes_to_oso():
+    """Neon and the warehouse must carry the same registry surface.
+
+    Derived from `publish_registry.TABLES`, never from a glob over the output directory: a
+    glob makes the published surface depend on which serializers happened to have run, so a
+    directory left by a partial run would quietly publish a smaller map.
+    """
+    from build.publish_registry import TABLES as OSO_TABLES
+
+    assert PUBLISHED_TABLES == OSO_TABLES
+    for name in OSO_TABLES:
+        assert f"{REGISTRY_PREFIX}{name}" in ALL_TABLES
+
+
+def test_every_serializers_tables_are_in_the_set():
+    from build.serialize_registry import TABLES as REGISTRY
+    from build.serialize_routing import TABLES as ROUTING
+    from build.serialize_rubric import TABLES as RUBRIC
+    from build.serialize_scores import TABLES as SCORES
+
+    for spec in (REGISTRY, RUBRIC, ROUTING, SCORES):
+        assert set(spec).issubset(set(PUBLISHED_TABLES))
+
+
+def test_the_two_groups_do_not_collide():
+    """Both surfaces share one schema and both have a products, a categories and an
+    organizations. The prefix is what keeps them apart."""
+    assert set(SITE_TABLES) & set(PUBLISHED_TABLES), "the overlap is the reason for the prefix"
+    assert len(set(ALL_TABLES)) == len(ALL_TABLES)
+    assert not set(SITE_TABLES) & {f"{REGISTRY_PREFIX}{n}" for n in PUBLISHED_TABLES}
+
+
+def test_a_declared_table_with_no_csv_is_reported_missing_not_skipped(tmp_path):
+    """A table is absent because a serializer has not run. Loading the rest would publish
+    a partial map that looks complete.
+
+    Into an empty directory the registry serializer's own tables are regenerated, so what is
+    left missing is the rubric, routing and scores sets — exactly the ones this module will
+    not run for you.
+    """
+    from build.serialize_registry import TABLES as OWN
+
+    plans, missing = plan(tmp_path, site_dir=tmp_path / "site")
+    loaded = {p.name for p in plans if p.name not in SITE_TABLES}
+    assert loaded == {f"{REGISTRY_PREFIX}{n}" for n in OWN}
+    assert set(missing) == {
+        f"{REGISTRY_PREFIX}{n}" for n in PUBLISHED_TABLES if n not in OWN
+    }
+    assert missing, "the other three serializers have not run, so something must be missing"
+
+
+def test_plans_come_back_in_the_declared_order_map_group_first(tmp_path):
+    """The map group loads first, so a failure in the part the site reads shows up first."""
+    plans, _missing = plan(site_dir=tmp_path / "site")
+    names = [p.name for p in plans]
+    assert names == [name for name in ALL_TABLES if name in set(names)]
+    assert names[: len(SITE_TABLES)] == list(SITE_TABLES)
+
+
+def test_a_publish_missing_a_csv_exits_2_and_names_the_serializers(tmp_path):
+    result = _run(
+        ["--dir", str(tmp_path), "--site-dir", str(tmp_path / "site")], {DSN_ENV: FAKE_DSN}
+    )
+    assert result.returncode == 2
+    assert "missing tables" in result.stderr
+    assert "serialize_scores" in result.stderr
+
+
+def _complete_dir(directory: Path) -> Path:
+    """A header-only CSV per declared registry table, so the completeness gate passes.
+
+    Header-only is a real state — a serializer emits a header for every table it declares,
+    filled or not — and it lets a test exercise what happens after planning without running
+    four serializers.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    for name in PUBLISHED_TABLES:
+        (directory / f"{name}.csv").write_text("slug\n", encoding="utf-8")
+    return directory
+
+
+# --- enums ----------------------------------------------------------------------------
+
+def test_all_eight_enums_are_declared():
+    assert set(ENUMS) == {
+        "alias_kind",
+        "freshness_basis",
+        "lineage_relation",
+        "capability_relation",
+        "metric_name",
+        "health_status",
+        "integration_type",
+        "gap_type",
+    }
+
+
+def test_create_enum_sql_makes_every_enum_inside_the_schema_being_built():
+    statements = create_enum_sql("os-ai-map_staging")
+    assert len(statements) == len(ENUMS)
+    assert (
+        'CREATE TYPE "os-ai-map_staging"."alias_kind" AS ENUM (\'product\', \'organization\')'
+        in statements
+    )
+
+
+def test_an_enum_column_qualifies_its_type_with_the_schema():
+    """Enum types are schema-scoped and the staging schema is never on the search path."""
+    sql = create_table_sql("os-ai-map_staging", SITE_TABLES["aliases"].columns, "aliases")
+    assert '"kind" "os-ai-map_staging"."alias_kind"' in sql
+
+
+def test_every_mapped_value_lands_inside_its_enum():
+    for enum, mapping in ENUM_MAPS.items():
+        for source, target in mapping.items():
+            assert target in ENUMS[enum], f"{enum}: {source!r} -> {target!r} is not a value"
+
+
+def test_an_unmapped_value_fails_the_load_and_names_the_value():
+    """A serving layer that coerced an unknown vocabulary item to something adjacent would
+    be worse than one that stopped."""
+    with pytest.raises(UnmappedValue) as caught:
+        enum_value("capability_relation", "three_below", column="capability.relation")
+    assert "three_below" in str(caught.value)
+    assert "capability.relation" in str(caught.value)
+
+
+def test_an_absent_value_is_null_not_an_error():
+    for empty in (None, ""):
+        assert enum_value("capability_relation", empty, column="capability.relation") is None
+
+
+def test_the_capability_relation_mapping_is_lossy_and_says_so():
+    """The payload carries a signed distance; the target enum has no distance. Both
+    `one_below` and `two_below` arrive as `tier_below`, and that is deliberate."""
+    assert enum_value("capability_relation", "one_below", column="c") == "tier_below"
+    assert enum_value("capability_relation", "two_below", column="c") == "tier_below"
+    assert enum_value("capability_relation", "at", column="c") == "peer"
+    assert enum_value("capability_relation", "one_above", column="c") == "tier_above"
+
+
+def test_every_relation_the_payload_actually_carries_is_mapped():
+    """The guard against a new vocabulary item reaching the load unmapped."""
+    payload = load_payload()
+    for cid in payload["order"]:
+        for product in payload["categories"][cid]["products"]:
+            relation = (product.get("capability") or {}).get("relation")
+            enum_value("capability_relation", relation, column="capability.relation")
+            basis = (product.get("freshness") or {}).get("basis")
+            enum_value("freshness_basis", basis, column="products.freshness_basis")
+
+
+# --- keys -----------------------------------------------------------------------------
+
+def test_product_ids_are_assigned_by_sorted_slug_so_a_load_is_reproducible():
+    """Surrogate ids exist for the designers' FK shape, but an id that moved between loads
+    would make a diff of two loads unreadable."""
+    payload = load_payload()
+    ids = product_ids(payload)
+    assert sorted(ids.values()) == list(range(1, len(ids) + 1))
+    assert [slug for slug, _id in sorted(ids.items(), key=lambda kv: kv[1])] == sorted(ids)
+    assert product_ids(payload) == ids
+
+
+def test_categories_carry_a_slug_the_pdf_omitted():
+    """Every deep link and every join from the registry group is by slug, and an id assigned
+    by curated order changes whenever the order does."""
+    assert "slug" in dict(SITE_TABLES["categories"].columns)
+
+
+def test_the_foreign_keys_resolve_to_rows_that_exist():
+    payload = load_payload()
+    rows = {name: spec.rows(payload) for name, spec in SITE_TABLES.items()}
+    product_id_set = {row["id"] for row in rows["products"]}
+    category_id_set = {row["id"] for row in rows["categories"]}
+    layer_id_set = {row["id"] for row in rows["layers"]}
+    stage_id_set = {row["id"] for row in rows["stages"]}
+    gap_id_set = {row["id"] for row in rows["gaps"]}
+    org_slugs = {row["slug"] for row in rows["organizations"]}
+
+    for row in rows["products"]:
+        assert row["category"] in category_id_set
+        assert row["org_slug"] in org_slugs
+    for row in rows["categories"]:
+        assert row["layer"] in layer_id_set
+        assert row["stage"] in stage_id_set
+    for table in ("openness", "adoption", "capability", "sources", "product_lineage"):
+        for row in rows[table]:
+            assert row["product_id"] in product_id_set
+    for row in rows["gaps_categories"]:
+        assert row["cat_id"] in category_id_set
+        assert row["gap_id"] in gap_id_set
+
+
+def test_each_axis_has_exactly_one_row_per_product():
+    payload = load_payload()
+    products = SITE_TABLES["products"].rows(payload)
+    for axis in ("openness", "adoption", "capability"):
+        rows = SITE_TABLES[axis].rows(payload)
+        assert len(rows) == len(products)
+        assert len({row["product_id"] for row in rows}) == len(products)
+
+
+def test_the_gallery_tables_are_created_empty_because_the_content_is_cms_side():
+    payload = load_payload()
+    for name in ("gallery", "gallery_products", "gallery_gaps"):
+        assert SITE_TABLES[name].rows(payload) == []
+        assert SITE_TABLES[name].columns, f"{name} still needs its columns"
+
+
+def test_the_long_tail_tables_are_filled_from_the_payload():
+    payload = load_payload()
+    assert len(SITE_TABLES["long_tail_top"].rows(payload)) == len(payload["long_tail"]["top"])
+    assert len(SITE_TABLES["long_tail_counts"].rows(payload)) == len(
+        payload["long_tail"]["counts"]
+    )
+
+
+def test_lineage_is_relational_and_carries_every_edge():
+    payload = load_payload()
+    rows = SITE_TABLES["product_lineage"].rows(payload)
+    expected = sum(
+        len(targets or [])
+        for cid in payload["order"]
+        for product in payload["categories"][cid]["products"]
+        for targets in (product.get("lineage") or {}).values()
+    )
+    assert len(rows) == expected
+    assert {row["relation"] for row in rows} <= set(ENUMS["lineage_relation"])
+
+
+def test_aliases_carry_their_kind():
+    payload = load_payload()
+    rows = SITE_TABLES["aliases"].rows(payload)
+    kinds = {row["kind"] for row in rows}
+    assert kinds <= set(ENUMS["alias_kind"])
+    assert len(rows) == sum(len(v) for v in payload["aliases"].values())
+
+
+def test_the_amended_columns_are_all_present():
+    """Carl's amendments to the PDF: per-axis dates, governing_release, basis_detail, the
+    peer-relative pair, and the product freshness pair."""
+    products = dict(SITE_TABLES["products"].columns)
+    assert "freshness_date" in products and "freshness_basis" in products
+    assert "last_verified" in dict(SITE_TABLES["openness"].columns)
+    assert "governing_release" in dict(SITE_TABLES["openness"].columns)
+    assert "last_verified" in dict(SITE_TABLES["adoption"].columns)
+    capability = dict(SITE_TABLES["capability"].columns)
+    for column in ("last_verified", "basis_detail", "relative_to", "relation"):
+        assert column in capability
+
+
+def test_an_array_column_is_written_as_a_postgres_array_literal():
+    payload = load_payload()
+    rows = SITE_TABLES["organizations"].rows(payload)
+    assert all(row["github"].startswith("{") and row["github"].endswith("}") for row in rows)
+    with_accounts = [row for row in rows if row["github"] != "{}"]
+    assert with_accounts, "no organization declares a github account"
+    assert with_accounts[0]["github"].startswith('{"http')
+
+
+# --- the COPY payload -----------------------------------------------------------------
+
+# A quoted CSV field holding both a newline and an escaped quote. Several real `strapline`
+# and `note` values are shaped like this, and they are the rows a line-oriented or
+# text-mode read would corrupt.
+_AWKWARD = 'slug,note\nolmo-3,"a note with a ""quoted"" phrase\nand a second line"\n'
+
+
+def test_the_copy_payload_is_the_file_byte_for_byte():
+    path = _write_csv("awkward", _AWKWARD)
+    chunks: list[bytes] = []
+    written = stream_bytes(path, chunks.append)
+    assert b"".join(chunks) == path.read_bytes()
+    assert written == len(path.read_bytes())
+
+
+@pytest.mark.parametrize("chunk_size", [1, 3, 7, 4096])
+def test_a_chunk_boundary_may_fall_anywhere_including_inside_a_quoted_newline(chunk_size):
+    """Postgres's CSV parser reassembles the stream, so the split point cannot matter.
+
+    A chunked read that respected line boundaries would be a read that had to understand
+    CSV quoting, which is the bug this guards.
+    """
+    path = _write_csv("awkward", _AWKWARD)
+    chunks: list[bytes] = []
+    stream_bytes(path, chunks.append, chunk_size=chunk_size)
+    assert b"".join(chunks) == path.read_bytes()
+
+
+def test_the_awkward_value_survives_a_full_csv_round_trip():
+    """What Postgres will parse out of that payload, read back with the same dialect."""
+    path = _write_csv("awkward", _AWKWARD)
+    chunks: list[bytes] = []
+    stream_bytes(path, chunks.append, chunk_size=5)
+    import csv as _csv
+    import io
+
+    rows = list(_csv.reader(io.StringIO(b"".join(chunks).decode("utf-8"))))
+    assert rows[0] == ["slug", "note"]
+    assert rows[1] == ["olmo-3", 'a note with a "quoted" phrase\nand a second line']
+    assert len(rows) == 2, "the embedded newline must not read as a row boundary"
+
+
+def test_the_embedded_newline_is_not_counted_as_an_extra_row():
+    plan_ = plan_table(_write_csv("awkward", _AWKWARD))
+    assert plan_.row_count == 1
+    assert dict(plan_.columns)["note"] == "TEXT"
 
 
 # --- helpers --------------------------------------------------------------------------

--- a/tests/test_registry_triggers.py
+++ b/tests/test_registry_triggers.py
@@ -68,6 +68,44 @@ def test_every_module_the_serializers_reach_triggers_the_workflow(event: str):
     )
 
 
+def publish_steps() -> list[dict]:
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    return doc["jobs"]["publish"]["steps"]
+
+
+def step_named(name: str) -> dict:
+    for step in publish_steps():
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"no step named {name!r} in the publish job")
+
+
+def test_the_oso_publish_runs_only_on_a_push_to_main():
+    """The static models are org-wide. The guard used to be a `neon_only` dispatch input
+    defaulting to false, so forgetting `-f neon_only=true` published a branch's declarations
+    over them — an invariant the comments asserted and nothing enforced. The event and the
+    ref cannot be forgotten."""
+    guard = step_named("Publish to OSO")["if"]
+    assert "push" in guard
+    assert "refs/heads/main" in guard
+    assert "github.event_name" in guard and "github.ref" in guard
+
+
+def test_a_dispatch_reaches_the_neon_steps_on_any_ref():
+    """That is what the dispatch is for: the Neon schema is swapped atomically and
+    re-loadable, so a branch run costs nothing beyond a reload."""
+    for name in ("Publish to Neon", "Report what Neon is serving"):
+        assert "if" not in step_named(name), f"{name} must not be guarded by event or ref"
+
+
+def test_no_input_decides_whether_oso_is_published():
+    """A flag that defaults to the safe value is still a flag someone forgets."""
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    triggers = doc.get("on") or doc.get(True)
+    assert not (triggers.get("workflow_dispatch") or {}).get("inputs")
+    assert "inputs." not in WORKFLOW.read_text()
+
+
 def test_the_closure_is_actually_walking_transitively():
     """Guard on the guard: if the walk stopped at the seeds, the test above would pass
     vacuously the moment someone trimmed the trigger list back to three entries."""

--- a/uv.lock
+++ b/uv.lock
@@ -1016,6 +1016,7 @@ dependencies = [
     { name = "markdown" },
     { name = "pandas" },
     { name = "plotly" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pyoso" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -1037,6 +1038,7 @@ requires-dist = [
     { name = "markdown", specifier = ">=3.10.2" },
     { name = "pandas" },
     { name = "plotly" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.3.5" },
     { name = "pyoso" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.34.2" },
@@ -1261,6 +1263,64 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
     { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
     { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/73/8fb739d0f6bba247b9b93c9840c402a4f88545be5f1d4b02b23366371c00/psycopg-3.3.5.tar.gz", hash = "sha256:d0a3d9ccf5788af054cbd745278cb02401b5c312aeaafbf2c6144460aec47da4", size = 166508, upload-time = "2026-08-31T22:45:43.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/2e/d0a645bcaadde68bd6d93c43f02f14b0191bdda367ce3f7722abe3da744a/psycopg-3.3.5-py3-none-any.whl", hash = "sha256:ce5aa5cdb4f9379f00f487590e5890bfa7df9a164648c969ffa628505e21af4e", size = 213598, upload-time = "2026-08-31T22:39:02.184Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/83/ba396428a4fb6b70f0dd41315ad86a2c14441b7214afd47b2d49cb450b78/psycopg_binary-3.3.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25105f9b46bdf2a30fcb67f56976ed66f6855941ae16bc024192609b917d493c", size = 4700169, upload-time = "2026-08-31T22:41:39.712Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/56/b23c5978e55cf4effdc5a3e13a17d69a580a487993e01b7c3768dd24281c/psycopg_binary-3.3.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0249c3e960cdee686000eb77169fb6590105c05bacc37e057ccdffdcd8e6ebde", size = 4763037, upload-time = "2026-08-31T22:41:47.571Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d8/b41108bfe194b4098076c8b873b05ec2ca9582445eccfd9075970d7b948e/psycopg_binary-3.3.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5698ab5941a4d138c30fef858588e651fe7d583280cd6e41832825ad9e747750", size = 5546232, upload-time = "2026-08-31T22:41:55.817Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d1/0f244dfef389e52e9dc3056f2a9033d1f6901e97d24d9a9c8b836e32ab6b/psycopg_binary-3.3.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:682a17a57415c3ca1731eec018ed031f012ffcb81ba74806eb219cb396065672", size = 5227752, upload-time = "2026-08-31T22:42:03.776Z" },
+    { url = "https://files.pythonhosted.org/packages/31/88/a4781365f09807fb91435e2d00096f3f6ae5d06bce15ef3c3c385dc22772/psycopg_binary-3.3.5-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d2a61e8147902771df7efe14062a3c8736347850d0d8befcf048235752504f2e", size = 6824658, upload-time = "2026-08-31T22:42:13.263Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f1/072c4a46287644694731b3e40fab120ebacf6d153cce7ebf7a5b208f5561/psycopg_binary-3.3.5-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f7e1e45aad410e20de45df2b159df68ff6c8dbf47a3501f806c4489b27f4ad2b", size = 5061439, upload-time = "2026-08-31T22:42:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d6/1776a95c16941b8bbce89407cc7cf9ea3fd557efb503a40873c9e2b6394f/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c09775c549b40b274206e1b043c5e5b5af39666e85c98382a30bd05d23ab677b", size = 4588586, upload-time = "2026-08-31T22:42:25.23Z" },
+    { url = "https://files.pythonhosted.org/packages/82/64/44ec87b9a74faebe966856307b65c0d35ee6321ce509cdd0e8d6a3f5338b/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:cf0e5e63ee86098299c673992053d556c489ba9ae6aca6cb6e24d16a8e0b09e6", size = 4265161, upload-time = "2026-08-31T22:42:31.864Z" },
+    { url = "https://files.pythonhosted.org/packages/24/88/cf181df5651395a80afc520f5fefac72beb035c0c9d58ab7fcc880c9b221/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c065531e8c1815276f50dbfa283e3a7f022671414cdda6fa9a16794dd53b28f9", size = 3998727, upload-time = "2026-08-31T22:42:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1e/c72a1107647db4bb3f534c7fe1b57b1957d9c099e795f5aa81f4a2e0c312/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:df9853b832b7b916e02ef68e0d5403a7dab2d5c1ddfe94f22b1b155eb862622f", size = 4310119, upload-time = "2026-08-31T22:42:46.403Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8d/452620608cafff164737e20b42ebffee8151b865ee171ba0d6692a560a44/psycopg_binary-3.3.5-cp312-cp312-win_amd64.whl", hash = "sha256:35885e333020fc152d27bea1a494bef13b2e68f6fd92b6229015e93539152008", size = 3648197, upload-time = "2026-08-31T22:42:51.575Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/1c/e718752cc63cf4e99e4a10fd36e3a3364dabdd0819484a24c0d79fbb9685/psycopg_binary-3.3.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6e85d50b87257fb117675a19ee59daa7bf9a57f6431500adf7059df799232ef4", size = 4704421, upload-time = "2026-08-31T22:42:59.564Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cf/a0e748e27c09b92738e4460582d121ba1908be3e36791e150f435e54b332/psycopg_binary-3.3.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e5becd311f9af8d180bad372f51fb2252fd02cb2073056e2b170c9274f95fe7f", size = 4765054, upload-time = "2026-08-31T22:43:05.421Z" },
+    { url = "https://files.pythonhosted.org/packages/39/62/0cbac0266d56c94dd1f702d9af2b5d54bf80b6e658048f4f2c5bd63dd7e3/psycopg_binary-3.3.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:19e5bf9872dbd164c220567fd385ba2309c7d9df1541f78343510c6b0f36a1b7", size = 5547137, upload-time = "2026-08-31T22:43:11.768Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/3a/73c6f8871f38fc07a9c0b4cbc9467beb116a2783cecf87dfa53900a396dc/psycopg_binary-3.3.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cb3b3bffebfe07110730626e76238161124f35ac87b748d663316a28d22f58b0", size = 5227577, upload-time = "2026-08-31T22:43:20.767Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/9f17b9f4d297b774dc574199c4dcd02dadc32a00c4056265918de5c70635/psycopg_binary-3.3.5-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2111f880add40fb03c60556069ad68e884a0908a74d2debafc603caf93b73552", size = 6824606, upload-time = "2026-08-31T22:43:33.698Z" },
+    { url = "https://files.pythonhosted.org/packages/94/86/d84dadd94a004dbbb43ce0579f1f766fdc6b8cbef745090e24bea77b5283/psycopg_binary-3.3.5-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:40505676b1526b9ea387dace034040a8c8b0bcf984cd6bd4720a2ab15e813586", size = 5060854, upload-time = "2026-08-31T22:43:42.258Z" },
+    { url = "https://files.pythonhosted.org/packages/30/d0/e5078be2c7d2490c0d6cd4cb7b3601aec44be2fa8b3fe927e9419b06004f/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5816472e3bb05615f33a741e0835043d1f4bf9709ff30d2f4aed71815cfc6b5e", size = 4589511, upload-time = "2026-08-31T22:43:50.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/01/08dfb5b18fa482e025864fd91a022310d0782c42e4cf5dda5d0e010b6790/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:358748fc4c8ccdc0e2bdf55420494930e19c3ade586ea9c3a6de3dad1f897311", size = 4268144, upload-time = "2026-08-31T22:43:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b9/cb01dc1d63f3241b49b2ca7fb9f98d0f5c76127f0dbb9440635a6ad0233e/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1ef2e498be47800f6202b9a2304c22646325ca6d54001b7c785bcfdb24a1e8ab", size = 4001036, upload-time = "2026-08-31T22:44:04.429Z" },
+    { url = "https://files.pythonhosted.org/packages/95/49/7c17dd832c05b380562ff2ff5f6ab2bcaeca8b7fff2c2b355854368a5bdb/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:88e01aa2e938a45655a8a5213fc3a44ba78cb4cab8a569b3e0bcb3d1d0eaba16", size = 4313112, upload-time = "2026-08-31T22:44:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/2c/b0b2f887185d6a2ec0b3bef948cc07656d2d1a5d96fa7f2bb03f6ef06ca4/psycopg_binary-3.3.5-cp313-cp313-win_amd64.whl", hash = "sha256:ba466011569297114449df9d523438e1adeedf3e4f31ffb78e897ec3fef3076b", size = 3647313, upload-time = "2026-08-31T22:44:19.139Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7f/4e2395da194558533bd9c31f35e4dc58ecbbae6a7176b0d2f72d629e8a51/psycopg_binary-3.3.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f8b132c7243ef5f503f0b6f986bf16d38a51b0df1c6ba2577743f128be03e3", size = 4712612, upload-time = "2026-08-31T22:44:25.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/94/fdb2093c8ccd7048449156db526ad746740cf34fe9c01e5dc1b7a7a8b257/psycopg_binary-3.3.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c0cac998b9b1e82dec853d2e53b3d34d56a525cf231f9441a636cfd5992929a9", size = 4775139, upload-time = "2026-08-31T22:44:36.719Z" },
+    { url = "https://files.pythonhosted.org/packages/31/52/5195e87960715f7be2005761b72d56fce4e7757d5333fd40384f071c2de1/psycopg_binary-3.3.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:479b96fd78149cfa10369dc53fbfb89ee729be13146b584a23dbc7e164c0cf1e", size = 5556807, upload-time = "2026-08-31T22:44:42.668Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/42/2d616210a91e1327516ed5ae71961aaa31bb740e4a61d7190f2221685a40/psycopg_binary-3.3.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f45d77e398542ce0937d9fa3cd9d84e9c5fc6b34c50a66404ae840bada312750", size = 5236206, upload-time = "2026-08-31T22:44:47.943Z" },
+    { url = "https://files.pythonhosted.org/packages/08/2e/e54b0d4cc263b3526e3728bb50a69660d5e79e52255ccd2a1a71e40e6f9a/psycopg_binary-3.3.5-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98a388509306e5e08a4203253ac52846bc1b034e5cbd0ae6da1211593cc28594", size = 6838066, upload-time = "2026-08-31T22:44:55.701Z" },
+    { url = "https://files.pythonhosted.org/packages/77/80/ec22a110f81a44c411965982097efeee86006bdd5a1f51f628318106c84c/psycopg_binary-3.3.5-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ab39e2794b95af61a2ff69e33e5ab6ac5df36e9ffea9a3b18e38b2aaca8c5ad5", size = 5072036, upload-time = "2026-08-31T22:45:02.838Z" },
+    { url = "https://files.pythonhosted.org/packages/93/55/7bc3c3ac769ab4fe0c619f2179b4aab3ae043f4d478283dd8279d24c0be4/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9c071bf78e5c2e6efa40bc9089a954d7b41221347a72f35c6bf2d8c96e632f75", size = 4604058, upload-time = "2026-08-31T22:45:10.444Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/8e7414f7dc10b2959e664330cdcf393e412f67355975dafa876cef265264/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:14fdfd65a96ecbd8b586d14546105641f4a6ac7cbe335c786830ea4de94bbe60", size = 4284766, upload-time = "2026-08-31T22:45:17.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/72/33f293c1d3ee9114f47e9ef4880f31c9de864e84a9b09454c26e106c25ed/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:8dbd694f3741dd4ac5bc60b70e17f7841aefb3f0f38cef4d2756de270e03af43", size = 4011958, upload-time = "2026-08-31T22:45:24.792Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c9/8e38840e5a7d006987bbc9acb29951912253fa50549a4db92b3aa535f089/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:14f432430fd9e1a9e7d9ab2fe14956c77f5d074ebdc556a1ad04e9a1bd3fca04", size = 4323273, upload-time = "2026-08-31T22:45:32.973Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c7/b7ebf601c307f93e7c4c4ebac0edc9db3b2729ca038efe700a18f86b5517/psycopg_binary-3.3.5-cp314-cp314-win_amd64.whl", hash = "sha256:df209e64674a34b41662c67fdc8b4e0ffd77d2136393790691d086a09f9a6cab", size = 3745885, upload-time = "2026-08-31T22:45:40.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

The gap map now lands in Neon (Postgres) as the `os-ai-map` schema, so the site can read
products, scores and freshness dates at request time instead of loading
`build/notebook_data.json`. That file is untouched: it stays the repo's build artifact and its
gate contract, and it is the *input* to this load rather than something the load replaces.

Two groups of table in one schema.

**The map** — the target model from CLEVER FRANKE (`Current-AI-Initial-Schema.pdf`, Laith) with
Carl's amendments: `products`, `organizations`, `categories`, `layers`, `stages`, `gaps`,
`gaps_categories`, `openness`, `adoption`, `capability`, `sources`, `product_lineage`,
`aliases`, `long_tail_top`, `long_tail_counts`. Every row is derived from the payload.

**The registry**, prefixed `registry_` — exactly the tables `publish_registry` pushes to OSO,
read from that module rather than from a glob over `build/registry/`, so Neon and the warehouse
carry the same registry by construction. The prefix exists because both groups have a
`products`, a `categories` and an `organizations`.

Plus `publish_runs`: one row per load, carrying `run_id`, `published_at`, `schema_version`,
`built_at`, `released_at`, `source_git_sha`, `declaration_version_id`, `table_count` and a
`row_counts` JSONB. That row is how you tell which commit and which shape the serving layer is
showing.

The table set, grain, keys and types live in `build/neon_schema.py`, which is the one place to
change when the data model moves. `build/publish_neon.py` is a generic CSV-to-Postgres loader
that knows nothing about the gap map.

### Keys, enums, dates

`products.id` exists for the FK shape the designers specified, but it is assigned by sorted slug
on every load, so the same corpus gives the same ids and a diff of two loads is readable. The
real key is `slug`. `categories` carries a `slug` alongside its id — the PDF omitted it, and
every deep link and every join from the registry group needs it.

Five enums are created in the schema and enforced. A payload value with no mapping fails the
load naming the value and the column rather than being coerced to something adjacent. One
mapping is lossy and documented: `capability.relation` in the payload is a signed distance
(`at`, `one_above`, `one_below`, `two_below`) and the target enum has none, so `one_below` and
`two_below` both arrive as `tier_below`; the exact distance stays in `capability.notes`. The
DBML's other three enums belong to the gallery tables, which are not here.

**The DBML's constraints are enforced by the database**, not just by a test over the rows: 13
primary keys, 11 foreign keys and 2 uniques, with `NOT NULL` wherever the model declares one.
`categories.slug` gets a unique the DBML omits, because the column is an amendment and a
duplicate slug would break the deep links it exists for. A violation aborts the COPY, the
staging schema is discarded and the live schema stays where it was.

Three dates, three different questions: `publish_runs.built_at` (when the payload was built),
`publish_runs.released_at` (when the release was cut), `products.freshness_date` with
`freshness_basis` (when this product's score was last confirmed, and whether by a human or by
the commit fallback), and `last_verified` on each of the three axis tables (the same question
asked of one axis).

The gallery tables are **not** published. See "Review fixes" below.

## The swap

The instance is shared — `drizzle`, `payload` and `public` belong to other parts of the site —
so the publisher touches only `os-ai-map`, `os-ai-map_staging` and `os-ai-map_previous`, and
refuses outright to run against any of the other three. The target's name carries a hyphen, so
schema identifiers are quoted everywhere and have their own validator.

All three are steady-state names. `os-ai-map_staging` exists while a load runs;
`os-ai-map_previous` exists **between** runs, holding the whole previous corpus — tables, rows,
enum types and the `SELECT` grant that travelled with the rename — until the next publish
reclaims it. So the database normally carries two readable copies of the map. Storage is
roughly double, and anything that can read `os-ai-map` can also read the superseded corpus
under `os-ai-map_previous`; nothing is meant to, and the publisher does not stop anything from
trying.

Site readers query continuously, so a load must never be observable half-finished. Rows go into
`os-ai-map_staging`, dropped and recreated each run, and the cutover is two renames in one
transaction:

```
ALTER SCHEMA "os-ai-map" RENAME TO "os-ai-map_previous"
ALTER SCHEMA "os-ai-map_staging" RENAME TO "os-ai-map"
```

A reader sees the whole old schema or the whole new one. On the first run there is nothing to
rename, so the swap is the single staging rename; that case is decided by reading
`information_schema.schemata`, not by catching an error. Grants go to the staging schema before
the swap, since a rename carries privileges with it. `NEON_READ_ROLE` names the role granted
`SELECT`; unset means `PUBLIC`.

Nothing is dropped in that transaction, and the old schema is reclaimed at the start of the
*next* run behind a `pg_depend` check. Both are review fixes; the reasoning is below.

The swap is also the migration path, which is why `publish_runs.schema_version` exists: every
publish rebuilds the schema from `build/neon_schema.py`, so a shape change is live on the next
load with no ALTER anywhere, and `SCHEMA_VERSION` is what tells a reader which shape it has.
This PR ships version 2.

The DSN is read from `NEON_DATABASE_URL`, `sslmode=require` is appended when the URL omits it,
and every message that could have come from the driver is scrubbed of the DSN, its password, its
user and its host before printing — a libpq failure quotes the host it could not reach, one
delimiter from the password.

## Workflow

`registry.yml` gains three steps and one dispatch input:

- **check job (PRs):** `build.publish_neon --check` — plans the load, prints the tables, row
  counts and every inferred non-TEXT column. Connects to nothing and needs no secret, so it runs
  on a fork PR too.
- **publish job (main):** `build.publish_neon` with
  `NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}`, after the OSO publish rather than
  instead of it.
- **publish job (main):** `build.neon_status`, which connects again and reports what a reader
  now sees to `$GITHUB_STEP_SUMMARY` and the step log.
- **`workflow_dispatch`:** runs the same job on any ref with the OSO publish skipped. That is
  how the serving layer gets verified from a branch — the Neon schema is swapped atomically and
  re-loadable, so a branch run costs nothing beyond a reload, whereas the OSO static models are
  org-wide and a branch must not overwrite them.

```bash
gh workflow run registry.yml --ref <branch>
```

The OSO step is guarded on `push` to `main`, so a dispatch never reaches it on any ref. There
is no input to forget (see "Review fixes"). One ops consequence: OSO publishing now happens
only on a push to `main`, so republishing the static models without a new commit means
re-running that push run (`gh run rerun <id>`) or pushing an empty commit.

There is deliberately no `if:` guard on the secret: an absent `NEON_DATABASE_URL` fails the step
loudly, because a publish that quietly skips leaves the site serving whatever the last successful
run left behind.

## Review fixes

Two must-fix items from the review of `0f5b6c2f`, both hazards to things outside this repo on
the shared instance rather than to the data the load produces.

**M1 — the gallery tables leave the publisher.** They were created empty so the site's queries
would compile. That was a hazard, not a courtesy: the swap rebuilds the schema on every load,
so the first row an editor wrote would have been deleted by the next push to `main` — with
nothing raising, `--check` still printing `gallery 0 rows`, and the read-back still reporting
`| gallery | 0 |`. The loss was invisible in every artifact the publish produced.

A schema rebuilt from source can only hold rows it produced. Gallery content is authored, so it
belongs in the CMS's own `payload` schema or in a separate `os-ai-map_cms` that this publisher
never creates, drops or grants on. Their three enums (`health_status`, `integration_type`,
`gap_type`) go with them: an enum no column can reference is dead metadata, and one created
*here* would be worse, because a CMS table referencing it would acquire a dependency on a
schema this publisher renames on every load. The vocabulary stays in the DBML, which is the
contract with the designers.

Noted for CLEVER FRANKE in `where-scores-live.md`, along with the trap: a **view** in the CMS
schema over a table in `os-ai-map` cannot survive a load either, because the cutover renames
the schema and a view binds to its source table by OID rather than by name. Read the map's
tables directly, or materialize a copy CMS-side.

**M2 — the cutover no longer drops anything.** `DROP SCHEMA … CASCADE` inside the transaction
was two problems. It takes `AccessExclusiveLock` on every table it removes, so the
applied-but-uncommitted renames blocked behind any in-flight site query and arriving readers
queued behind the pending lock — one slow reader stalling every reader for as long as it ran.
And CASCADE follows dependencies, not schema membership: after the live schema is renamed to
`_previous`, a view in `payload` over `os-ai-map.products` or a foreign key from a CMS table
into it still depends on it, so the CASCADE would have dropped that object too, in its own
schema, silently, on every publish. `PROTECTED_SCHEMAS` stops the publisher *naming* someone
else's schema; this was the same accident one indirection out.

The old schema is now left as `os-ai-map_previous` and reclaimed at the **start** of the next
run, after `pg_depend` is checked for dependents outside the three schemas the publisher
manages. If any exist the run fails listing them, with the schema, the relation and how it
depends, rather than dropping. Three arms, because there are three shapes a CASCADE would
take with it: a view or rule (`pg_rewrite`), a foreign key (`pg_constraint`), and a column
anywhere else typed by one of our enums (`pg_attribute` → `pg_type`). The third is the easiest
to miss, because the hazard is not a table: the enum types are created in the staging schema
so they travel with the rename, so a CMS column declared `os-ai-map.health_status` ends up
typed by a type in `_previous` and would be dropped with it. A rename-based cutover cannot carry such a dependent forward, so
failing loudly is the whole of the remedy available here. Reclaiming runs before the staging
build, so a run that cannot safely reclaim fails before loading 18,000 rows.

`lock_timeout` is 5s on the session and the swap transaction is retried up to three times with
`[1.0, 3.0]` backoff. The retry predicate reads SQLSTATE (55P03 lock timeout, 40P01 deadlock)
and never the message, so a constraint violation fails on the first attempt instead of being
retried into a slower identical failure.

**S1 — the dispatch is guarded by the ref, not by an input.** `neon_only` defaulted to `false`,
so `gh workflow run registry.yml --ref my-branch` with the flag forgotten published a branch's
declarations over the org-wide OSO static models — an invariant the comments asserted and
nothing enforced. The input is gone and the OSO step is guarded on
`github.event_name == 'push' && github.ref == 'refs/heads/main'`, so a dispatch runs the Neon
steps only, on any ref including `main`. Three tests read the workflow YAML and pin it.

**R4 — a product with no org fails naming the product.** `_products` used to write `""` for a
missing `org_slug`, which CSV reads as NULL, so the load died on `products.org_slug`'s NOT NULL
naming the *column* — leaving whoever hit it to work out which of 615 products was at fault. It
now raises before the COPY, naming the product and what to fix. A second test asserts the
corpus is clean today, so a red there is a data fix rather than a code one.

**S2 — the DBML's constraints are created.** Previously none were: no primary key, unique,
`NOT NULL` or `REFERENCES` appeared anywhere, so the data-level FK test was the only thing
standing between a dangling id and the front end, and ORMs introspecting the schema got no key
metadata. All of them are emitted now, `SITE_TABLES` is ordered parents-first, and a violation
fails the run.

Also from §3, since they were one-line fixes: `plan()`'s docstring said "group A first" where
the code, the module it reads from and its own test all say group B first; the `%I` robustness
claim is narrowed to what is actually pinned; and `publish_runs` is described as holding one row
describing *this* load rather than as accumulating history.

## Live verification — `neon_only` dispatch on this branch

[Run 33874327443](https://github.com/currentai-org/os-ai-map/actions/runs/33874327443) on
`364cb51f`, green. Row counts are unchanged from the pre-review runs at 18,696; the table count
drops 45 → 42 as the three gallery tables leave, and the constraint tally is new.

### `os-ai-map` tables after the load

| table | rows |
|---|---:|
| `adoption` | 615 |
| `aliases` | 65 |
| `capability` | 615 |
| `categories` | 18 |
| `gaps` | 6 |
| `gaps_categories` | 16 |
| `layers` | 3 |
| `long_tail_counts` | 9 |
| `long_tail_top` | 37 |
| `openness` | 615 |
| `organizations` | 347 |
| `product_lineage` | 175 |
| `products` | 615 |
| `publish_runs` | 1 |
| `registry_adoption_aggregation_rules` | 2 |
| `registry_adoption_bands` | 23 |
| `registry_adoption_route_band_sets` | 26 |
| `registry_adoption_route_scopes` | 1 |
| `registry_adoption_routes` | 9 |
| `registry_categories` | 18 |
| `registry_category_deferrals` | 5 |
| `registry_category_dimensions` | 48 |
| `registry_category_license_tiers` | 611 |
| `registry_category_scoring_rules` | 258 |
| `registry_evidence_abstentions` | 5 |
| `registry_license_aliases` | 25 |
| `registry_model_families` | 26 |
| `registry_org_handles` | 479 |
| `registry_organizations` | 347 |
| `registry_product_aliases` | 63 |
| `registry_product_artifacts` | 857 |
| `registry_product_categories` | 615 |
| `registry_product_lineage` | 175 |
| `registry_product_openness_evidence` | 2,757 |
| `registry_product_organizations` | 615 |
| `registry_product_score_sources` | 3,496 |
| `registry_product_scores` | 615 |
| `registry_products` | 615 |
| `registry_resolution_ledger` | 302 |
| `registry_tail_products` | 65 |
| `sources` | 3,496 |
| `stages` | 6 |

42 tables, 18,696 rows outside `publish_runs`.

### Constraints in `os-ai-map` — 26 total

| constraint | count |
|---|---:|
| FOREIGN KEY | 11 |
| PRIMARY KEY | 13 |
| UNIQUE | 2 |

### `os-ai-map.publish_runs` — 1 row(s), newest first

| published_at | run_id | schema_version | built_at | released_at | source_git_sha | tables |
|---|---|---:|---|---|---|---:|
| 2026-09-04 12:45:19Z | `285cfb2e656a` | 2 | 2026-09-04 | 2026-08-16 | `364cb51f49b4` | 41 |

The 26 constraints the database reports match the 26 the DDL asks for, table by table: 13
primary keys, 11 foreign keys, 2 uniques. `schema_version` is 2. Reading them back out of
`information_schema.table_constraints` rather than trusting the CREATE statements is what makes
the tally evidence rather than an assertion.

## Deliberately not included

The warehouse recomputation. `scores.openness_facts` and `scores.openness_computed` stay on OSO,
and no table in `os-ai-map` recomputes an axis, so a question about what the map says is
answerable in Neon and a question about whether the warehouse agrees is not — that is still
`check_parity`. Mirroring the computed scores is step two.

## Test plan

`tests/test_publish_neon.py`, no database: type inference including the identity-column pin and
the all-empty column, DDL and COPY generation per table, the `publish_runs` shape and that the
read-back selects every column it writes, the identifier and schema guards (a hyphen allowed in
a schema and refused in a table name, the three protected schemas, the publisher's own working
schemas), the swap sequence for both the first run and the steady state including that no
statement drops the live schema by name, `sslmode` handling for URL and keyword DSNs, and the
scrubber. On the map group: deterministic ids, every FK resolving to a row that exists, one row
per product per axis, the gallery tables and their enums absent, the enums complete and an
unmapped value failing by name, and the lossy `capability_relation` mapping asserted as lossy.
Every constraint and every `NOT NULL` the DBML declares is asserted against the generated DDL
from a pinned transcription of the model, the FK targets are asserted schema-qualified, and the
table order is checked to be parents-first by walking the declared references.
`reclaim_previous` is driven by a stubbed cursor: it drops when nothing outside depends on
`_previous`, no-ops when there is none, and raises listing the dependents without executing a
DROP when a `payload` view or a `drizzle` foreign key is present. The swap retry runs against a
fake connection — first-attempt commit, two lock timeouts then success with `[1.0, 3.0]`
backoff, exhaustion after three attempts, and a constraint violation failing on attempt one. The COPY path is covered
byte-for-byte against a field holding both an embedded newline and an escaped quote, at chunk
sizes 1, 3, 7 and 4096, plus a full CSV round trip proving the newline is not read as a row
boundary. The read-back query is covered against the psycopg failure above: `%I` intact, no
`%%`, no `{schema}` left, the schema quoted, and a schema name carrying a quote escaped rather
than breaking out. Three subprocess tests cover the CLI: `--check` plans with no DSN in the
environment, a publish with no DSN exits 2 naming the variable, and a publish against a fake DSN
leaks no part of it into stdout or stderr.

```
uv run pytest tests/test_publish_neon.py tests/test_registry_triggers.py tests/test_schedule_doc.py tests/test_docs_integrity.py -q -n 4   # 172 passed
uv run python -m build.publish_neon --check                                                                                              # 41 tables + publish_runs, 26 constraints
uv run pytest -q -n 4 -m "not serial"                                                                                                    # 1674 passed
```

Docs: the Neon serving layer section in `docs/reference/where-scores-live.md` rewritten for the
two groups, the three dates and the migration story; the schedule row, the publish command and
the `neon_only` dispatch in `docs/operations/deploy-models.md`; a CHANGELOG entry.

Refs #365
CUR-511


