### PR TITLE
Detect mirror drift against the platform's latest revisions

### DIFF
--- a/.github/workflows/mirror-drift.yml
+++ b/.github/workflows/mirror-drift.yml
@@ -1,0 +1,61 @@
+name: mirror-drift
+
+# The sentinel over `warehouse/dependencies.yaml`'s mirror blocks: does each contract still
+# describe the model the platform is actually running?
+#
+# Every other gate over those contracts reads only the repo. `build/assets.dependency_violations`
+# proves a mirror file hashes to its declared `local_sha256`, that `verified_revision` equals
+# `mirror.revision`, and that bytes and revision move together across commits — and all of that
+# stays green while the platform releases revision N+1 over a mirror of N. The repo then
+# evaluates and reviews code that is no longer what builds the table, and nothing anywhere
+# notices. This is the only check that leaves the repo to look.
+#
+# Weekly, Monday 08:30 UTC, after the identity dataset's Sunday 05:30 sweep and the Monday
+# 03:00/04:00 scoring chain have landed. This gate reads asset metadata rather than tables, so
+# it has no ordering relationship to either the chain or any other gate — the half hour is
+# there to keep it off `freshness` at 08:00 and out of its logs, which is the reason every
+# other Monday gate sits on its own minute. The cadence matches the mirrors' own, which is
+# "whenever a maintainer deploys" — weekly is a sentinel's interval, not a correctness one,
+# and the finding it reports does not go stale.
+#
+# Deliberately NOT a pull_request gate. A PR cannot reach the platform (a fork PR has no
+# OSO_API_KEY) and, more to the point, drift here is not caused by the PR: it is caused by
+# something that happened on the platform. Failing contributors' PRs for a maintainer's
+# unsynced deploy would be the fastest way to get this switched off.
+#
+# Two failing exit codes, and they mean different jobs: 1 is drift and the job is a resync, 2
+# is "nothing could be checked" and the job is to find out why. Everything that stops the check
+# happening lands in 2 — unreachable, non-200, a 200 refusing the call (what a rotated
+# OSO_API_KEY looks like), an undecodable body. Never 0: a sentinel that goes quiet when it
+# loses its only source of truth still shows a green tick, and that tick is then evidence of
+# nothing while continuing to read as evidence. See build/check_mirror_drift.py.
+
+on:
+  schedule:
+    - cron: "30 8 * * 1"
+  workflow_dispatch:
+
+jobs:
+  mirror-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Compare every mirror contract against the platform
+        env:
+          OSO_API_KEY: ${{ secrets.OSO_API_KEY }}
+        run: uv run python -m build.check_mirror_drift --report mirror-drift.json
+
+      - name: Keep the verdicts
+        # The report is the input to a resync, so it outlives a red run's log.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mirror-drift-report
+          path: mirror-drift.json
+          if-no-files-found: ignore

--- a/.github/workflows/report-failure.yml
+++ b/.github/workflows/report-failure.yml
@@ -4,7 +4,7 @@
 name: report-failure
 on:
   workflow_run:
-    workflows: [freshness, parity, artifacts, channel-authority, refetch, refresh-data, reverify, identity-eval, identity-digest]
+    workflows: [freshness, parity, artifacts, channel-authority, refetch, refresh-data, reverify, identity-eval, identity-digest, mirror-drift]
     types: [completed]
 permissions:
   issues: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
 - `build/propose_org_handles.py`, which proposes `huggingface` org handles from the namespaces of
   already declared Hugging Face artifacts, grouped by org and checked for aggregator accounts and
   ownership conflicts, for review as a GitHub issue rather than seeded silently (#365).
+- A weekly mirror-drift sentinel (`mirror-drift.yml`, Monday 08:30 UTC): every `mirror:` contract
+  in `warehouse/dependencies.yaml` is compared against the platform's latest revision, and a
+  mismatch opens a `sentinel` issue. Reports revision, hash, code and missing-model drift
+  separately, and exits 2 rather than passing whenever the platform cannot be read at all. Closes
+  the gap where the repo's own gates stay green while the platform releases past a mirror; the
+  first runs found eight of seventeen contracts behind. "Mirror resync" in
+  `docs/operations/deploy-models.md` is the runbook (#365).
+
 - An explicit `reclaimed-as-dependency` transition in the externalization receipt, so a table that
   an in-scope governed asset starts reading again moves from externalized back into the governed
   dependency graph as a recorded event instead of an edited record. The disposition history is

--- a/build/check_mirror_drift.py
+++ b/build/check_mirror_drift.py
@@ -1,0 +1,316 @@
+"""Does each mirror contract still describe the model the platform is actually running?
+
+## The gap this closes
+
+`warehouse/dependencies.yaml` records, for every platform-authored model the repo mirrors
+read-only, a `mirror:` block naming the revision, the platform's hash for it, and a
+`local_sha256` over the bytes on disk. `build/assets.dependency_violations` proves that block
+is internally honest: the file on disk is the file the contract claims, the revision matches
+the anchor, and bytes and revision move together across commits.
+
+Every one of those checks reads only the repo. None of them can tell you that the contract
+still matches the platform. A model can be revised on the platform the day after a mirror is
+synced, and the repo stays green: the file still hashes to `local_sha256`, the anchor still
+equals `mirror.revision`, and nothing anywhere compares either number to the platform. The
+repo then evaluates, reviews and reasons about revision N while revision N+1 is what builds
+the table. That is the whole failure, and it is silent in exactly the direction that matters —
+the more confident the gates look, the more stale the mirror can be.
+
+So this is a sentinel, not a validator. It reaches out to the platform once a week and asks a
+single question per contract: is the revision we wrote down still the revision you have?
+
+## What "the platform's current revision" can and cannot mean here
+
+The platform's own deploy mechanic is revision -> RELEASE -> run (see
+`docs/operations/deploy-models.md`), and a run materializes the latest *released* revision.
+Release state is not readable: `GetDataModel` returns `latestRevision` and no release field,
+and `GetAssetChangelog`'s `publishStatus` is null on every revision of every model in this
+org. There is no query that answers "which revision is released".
+
+This check therefore compares against `latestRevision`, and says so rather than calling it
+the released one. The consequence is worth being explicit about, because it decides whether a
+finding is real:
+
+  * A contract BEHIND the latest revision is always worth a human look. Either the newer
+    revision is released, in which case the mirror is describing code that no longer runs, or
+    it is not, in which case the mirror is about to be wrong and the resync is cheap now.
+  * The check cannot fire on the reverse case — a revision released without a new revision
+    being minted — because that is not a thing the platform does.
+
+Erring toward "tell a human" is the right side to err on for a once-weekly gate whose whole
+job is to notice something no other gate can see.
+
+## Three levels of drift, reported separately
+
+Given one contract and one platform node, they can disagree in three ways, and they mean
+different things:
+
+  * `revision` — the numbers differ. The plain case: the platform moved on.
+  * `hash` — the numbers agree and the platform's hash does not. Worse than a revision bump,
+    because it means the same revision number now denotes different content, and nothing in
+    the repo's own gates could ever see it.
+  * `code` — numbers and hash agree, and the deployed source does not match the mirror file's
+    body. This is the belt-and-braces check: it does not trust the hash to be a hash of the
+    code, and it is the only one of the three that a maintainer editing a mirror file by hand
+    (and dutifully updating `local_sha256`) cannot defeat.
+
+`missing` is a fourth and the loudest: the platform serves no model at that `model_id` at all,
+so the contract is anchored to something that no longer exists.
+
+## The banner
+
+Mirror files are not byte-identical to the deployed code, by design: each carries a five-line
+`PLATFORM MIRROR (read-only)` header saying nothing deploys from this copy. That header is the
+reason `mirror.local_sha256` and `mirror.hash` are different hashes of nearly the same text,
+and the reason a naive code comparison fails on all seventeen contracts. `strip_mirror_banner`
+removes it, in the `--` and `#` forms both families of mirror use.
+
+## Two exit codes, and the line between them
+
+  * **1 — drift.** Every contract was checked and at least one disagrees with the platform.
+    The maintainer's job is a resync.
+  * **2 — could not check.** Nothing was verified. The maintainer's job is to find out why,
+    and a resync would be wasted work.
+
+That line matters more than it looks, because `report-failure.yml` turns either into the same
+`sentinel` issue and the exit code is what tells a maintainer which job they have. Everything
+that stops the check from happening lands in 2: the endpoint unreachable, a non-200 response,
+a 200 carrying `isError` (which is what an expired or rotated `OSO_API_KEY` looks like — the
+server answers cheerfully and refuses the call), and a response body that will not decode.
+
+An authentication failure reported as drift would send someone to diff seventeen mirror files
+against a platform nobody can read. So `MCPCallFailed` is caught here alongside
+`MCPUnreachable` rather than being allowed to escape as a traceback, and the message names
+which of the two happened.
+
+The check never skips and never passes on a failure to read. A sentinel that goes quiet when
+it loses its only source of truth is worse than no sentinel, because the green tick is then
+evidence of nothing while still reading as evidence.
+
+Requires OSO_API_KEY. Reads platform metadata through `build/oso_mcp.py`; see that module for
+why SQL cannot answer this and for the two transport traps.
+
+Usage:
+    uv run python -m build.check_mirror_drift
+    uv run python -m build.check_mirror_drift --report mirror-drift.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import yaml
+
+from build.oso_mcp import Client, MCPCallFailed, MCPUnreachable
+
+ROOT = Path(__file__).resolve().parents[1]
+BANNER_MARKER = "PLATFORM MIRROR"
+# The banner is a comment block followed by one blank line. Held as a bound rather than a
+# pattern: if a mirror's header ever grows, the code comparison should fail loudly and be
+# looked at, not silently strip more of the model than it meant to.
+BANNER_MAX_LINES = 8
+
+
+def strip_mirror_banner(text: str) -> str:
+    """`text` without its leading `PLATFORM MIRROR` header, or unchanged if it has none.
+
+    Unchanged rather than raising, so a mirror file that has lost its banner is compared as
+    it stands and reported as code drift -- which is what it is.
+    """
+    lines = text.splitlines(keepends=True)
+    if not lines or BANNER_MARKER not in lines[0]:
+        return text
+    for index, line in enumerate(lines[:BANNER_MAX_LINES]):
+        if line.strip() == "":
+            return "".join(lines[index + 1:])
+    return text
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+@dataclass
+class Row:
+    """One contract's verdict. `status` is the finding; the rest is what it was based on."""
+
+    table: str
+    status: str
+    contract_revision: int | None
+    platform_revision: int | None
+    hash_match: bool | None
+    code_match: bool | None
+    revised_at: str | None
+    detail: str = ""
+
+    @property
+    def drifted(self) -> bool:
+        return self.status != "ok"
+
+
+def mirror_contracts(root: Path) -> list[dict]:
+    """The dependency contracts carrying a `mirror:` block, in file order.
+
+    An `oso.*` upstream anchors on a content contract instead and has no revision to compare,
+    so it is out of scope by construction rather than by exclusion.
+    """
+    doc = yaml.safe_load((root / "warehouse/dependencies.yaml").read_text()) or {}
+    return [d for d in (doc.get("dependencies") or []) if d.get("mirror")]
+
+
+def compare(contract: dict, node: dict | None, root: Path) -> Row:
+    """One contract against one platform node. Pure, so the tests can stub the client."""
+    table = contract["table"]
+    mirror = contract["mirror"]
+    contract_revision = mirror.get("revision")
+
+    if node is None:
+        return Row(
+            table=table, status="missing", contract_revision=contract_revision,
+            platform_revision=None, hash_match=None, code_match=None, revised_at=None,
+            detail=f"the platform serves no data model at model_id {mirror.get('model_id')}",
+        )
+
+    revision = node.get("latestRevision") or {}
+    platform_revision = revision.get("revisionNumber")
+    platform_hash = revision.get("hash")
+    revised_at = revision.get("createdAt")
+
+    if platform_revision != contract_revision:
+        return Row(
+            table=table, status="revision", contract_revision=contract_revision,
+            platform_revision=platform_revision, hash_match=platform_hash == mirror.get("hash"),
+            code_match=None, revised_at=revised_at,
+            detail=f"the platform's latest revision is {platform_revision}, "
+                   f"the contract records {contract_revision}",
+        )
+
+    if platform_hash != mirror.get("hash"):
+        return Row(
+            table=table, status="hash", contract_revision=contract_revision,
+            platform_revision=platform_revision, hash_match=False, code_match=None,
+            revised_at=revised_at,
+            detail=f"revision {platform_revision} on both sides, and its hash is "
+                   f"{platform_hash} against the contract's {mirror.get('hash')}",
+        )
+
+    # Numbers agree. Compare the source itself, which is the only one of the three checks a
+    # hand-edited mirror with a refreshed local_sha256 cannot get past.
+    path = root / contract["files"]["model"]
+    if not path.exists():
+        # dependency_violations already fails on this; reported here too so a drift run
+        # against a broken tree explains itself rather than raising.
+        return Row(
+            table=table, status="code", contract_revision=contract_revision,
+            platform_revision=platform_revision, hash_match=True, code_match=False,
+            revised_at=revised_at, detail=f"mirror file {contract['files']['model']} is missing",
+        )
+    local = strip_mirror_banner(path.read_text())
+    deployed = revision.get("code") or ""
+    if sha256_text(local) != sha256_text(deployed):
+        return Row(
+            table=table, status="code", contract_revision=contract_revision,
+            platform_revision=platform_revision, hash_match=True, code_match=False,
+            revised_at=revised_at,
+            detail=f"revision {platform_revision} and hash agree, and the deployed source "
+                   f"does not match {contract['files']['model']} below its banner "
+                   f"({len(deployed)} chars deployed against {len(local)} mirrored)",
+        )
+
+    return Row(
+        table=table, status="ok", contract_revision=contract_revision,
+        platform_revision=platform_revision, hash_match=True, code_match=True,
+        revised_at=revised_at,
+    )
+
+
+def check(contracts: list[dict], client, root: Path) -> list[Row]:
+    """Every contract's verdict.
+
+    A per-model *answer* is allowed to be a finding -- including "the platform has no such
+    model". A failure to read is not: `MCPUnreachable` and `MCPCallFailed` propagate out of
+    the sweep, because half a sweep is not a result and reporting it as one would publish a
+    row count that looks like coverage.
+    """
+    rows: list[Row] = []
+    for contract in contracts:
+        node = client.data_model(contract["mirror"]["model_id"])
+        rows.append(compare(contract, node, root))
+    return rows
+
+
+def render_table(rows: list[Row]) -> str:
+    def mark(value: bool | None) -> str:
+        return "-" if value is None else ("yes" if value else "NO")
+
+    header = (f"{'table':50} {'contract':>8} {'platform':>8} {'hash':>5} {'code':>5}  "
+              f"{'revised_at':20} status")
+    lines = [header, "-" * len(header)]
+    for row in rows:
+        lines.append(
+            f"{row.table:50} {str(row.contract_revision):>8} "
+            f"{str(row.platform_revision):>8} {mark(row.hash_match):>5} "
+            f"{mark(row.code_match):>5}  {(row.revised_at or '-')[:19]:20} {row.status}"
+        )
+    lines.append(
+        "\nrevised_at is when the platform's latest revision was created. The platform "
+        "exposes no\nrelease timestamp and no release marker -- see build/oso_mcp.py."
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None, root: Path | None = None, client=None) -> int:
+    root = root or ROOT
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report", type=Path, default=None,
+                        help="write the verdicts as JSON here")
+    args = parser.parse_args(argv)
+
+    contracts = mirror_contracts(root)
+    try:
+        rows = check(contracts, client or Client(), root)
+    except (MCPUnreachable, MCPCallFailed) as exc:
+        # Exit 2, loudly, with nothing claimed as checked. Both are "could not check", and
+        # the cause is named because the two send a maintainer somewhere different: a refused
+        # call is usually a rotated key, an unreachable endpoint usually is not. See the
+        # module docstring on why neither may be reported as drift.
+        cause = ("the platform refused the call (an expired or rotated OSO_API_KEY looks like "
+                 "this)" if isinstance(exc, MCPCallFailed)
+                 else "the platform could not be reached")
+        print(f"[CANNOT CHECK] {cause}: {exc}", file=sys.stderr)
+        print(f"0 of {len(contracts)} mirror contracts verified. This is not a pass, and it "
+              "is not drift -- do not resync anything on the strength of it.", file=sys.stderr)
+        return 2
+
+    print(render_table(rows))
+    drifted = [r for r in rows if r.drifted]
+    print(f"\n{len(rows) - len(drifted)} of {len(rows)} mirror contracts match the platform, "
+          f"{len(drifted)} drifted")
+    for row in drifted:
+        print(f"  x {row.table} [{row.status}]: {row.detail}")
+
+    if args.report:
+        args.report.write_text(json.dumps(
+            {"checked": len(rows), "drifted": len(drifted),
+             "rows": [asdict(r) for r in rows]}, indent=2) + "\n")
+
+    if drifted:
+        print(
+            "\nThe repo is mirroring a model the platform has moved past. Resync each one: "
+            "fetch\nthe deployed code, replace the mirror file's body below its banner, and "
+            "update the\ncontract's verified_revision, mirror.revision, mirror.hash, "
+            "mirror.local_sha256 and\nmirror.synced_at. The runbook is "
+            '"Mirror resync" in docs/operations/deploy-models.md.'
+        )
+        return 1
+    print("[OK] every mirror contract matches the platform's latest revision")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/oso_mcp.py
+++ b/build/oso_mcp.py
@@ -1,0 +1,207 @@
+"""Read-only platform METADATA over the OSO MCP server, for gates that SQL cannot answer.
+
+## Why this exists next to build/warehouse.py
+
+`build/warehouse.py` is the only supported way to read the warehouse, and it reads *data*:
+it speaks SQL to `pyoso` and every question it can answer is a question about rows. A model's
+revision number, its hash and its deployed code are not rows in any table. They are asset
+metadata, and the only thing that serves them to a CI runner holding nothing but `OSO_API_KEY`
+is the MCP server.
+
+So this module is deliberately narrow. It does not query data, it does not write anything, and
+it exposes exactly the one read `build/check_mirror_drift.py` needs. Anything wanting rows
+should use `build/warehouse.query` and get the cache-busting nonce that comes with it.
+
+## Two things that will waste an afternoon if they are not written down
+
+**A default user agent can be banned at the edge.** `mcp.oso.xyz` sits behind Cloudflare with
+a browser-signature rule. `python-urllib/3.12` came back `403 Error 1010:
+browser_signature_banned` with `"Do not retry"` in the body, and the same key worked
+immediately with a real `User-Agent`. The rule appears to be intermittent or has since
+changed — a plain `python-requests` POST was accepted in a later session — so treat this as a
+hazard rather than a certainty. `_UA` is cheap insurance either way, and worth keeping because
+of how the failure presents: a 403 reads exactly like a bad token, and would send someone to
+rotate a key that was never the problem.
+
+**Responses are SSE, not JSON, and `response.text` mangles them.** The server answers a plain
+POST with `text/event-stream`, one JSON-RPC envelope per `data:` line, and interleaves
+`notifications/message` log frames ahead of the result, so `json.loads(response.text)` fails
+on a *successful* call. Worse, `response.text` is wrong even once the frames are split out:
+the content type carries no charset, and `requests` then falls back to ISO-8859-1 for any
+`text/*`, which turns every em-dash in a model's comments into `â`. That is
+not a cosmetic problem for this module's one caller — it makes a byte comparison of deployed
+code against a mirror file fail on five of seventeen models with a two-to-six character
+difference and no visible cause. `_post` decodes `response.content` as UTF-8 itself.
+
+## The key never reaches a log
+
+Every message raised here passes through `_scrub`, which replaces the token, and the two
+raises that wrap a foreign exception use `from None` rather than `from exc` — a chained
+`requests` exception prints its own `repr` in a traceback, and a prepared request's `repr` is
+one plausible place for an `Authorization` header to surface. Neither the response body nor a
+transport error string is under this module's control, and a CI log outlives the key in it.
+
+## What the platform will and will not tell you
+
+`GetDataModel` returns `latestRevision` — its number, hash, language, code and creation time.
+It does **not** return release state, and nothing else on the tool surface does either:
+`GetAssetChangelog` has a `publishStatus` field, and it is null on every revision of every
+model in this org. There is no readable "which revision is released" fact.
+
+That shapes what a drift gate can honestly claim, and `check_mirror_drift` says so in its own
+docstring rather than quietly calling the latest revision the released one.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+# A real product name. See the module docstring: a default UA is 403'd at the CDN with an
+# error that looks like an auth failure.
+_UA = "os-ai-map-mirror-drift/1.0 (+https://github.com/currentai-org/os-ai-map)"
+DEFAULT_URL = "https://mcp.oso.xyz/mcp"
+PROTOCOL_VERSION = "2025-06-18"
+
+
+class MCPUnreachable(RuntimeError):
+    """The platform could not be reached, or answered something this module cannot parse.
+
+    Held apart from a drift finding on purpose. "The mirror is stale" and "we could not
+    tell" are different states, and a gate that reports the second as the first sends a
+    maintainer to resync a file that is already correct.
+    """
+
+
+class MCPCallFailed(RuntimeError):
+    """The server was reached, answered 200, and refused the call (`isError`).
+
+    Held apart from `MCPUnreachable` because the two send a maintainer somewhere different,
+    but they belong to the same *class* of outcome: nothing was read. An expired or rotated
+    key arrives here rather than as a 401 — the server answers cheerfully with
+    `UNAUTHENTICATED` inside a successful HTTP response — so a caller that lets this escape
+    while catching `MCPUnreachable` reports an auth failure as whatever its default exit is.
+    `build/check_mirror_drift.py` catches both and exits 2 for either.
+    """
+
+
+class Client:
+    """One MCP session. Construct it once and reuse it across models.
+
+    The handshake costs a round trip, and the drift check makes one call per contract, so a
+    per-call session would triple the gate's runtime for nothing.
+    """
+
+    def __init__(self, url: str | None = None, token: str | None = None):
+        import requests
+
+        self.url = url or os.environ.get("OSO_MCP_URL") or DEFAULT_URL
+        self.token = token or os.environ.get("OSO_API_KEY") or ""
+        if not self.token:
+            raise MCPUnreachable("OSO_API_KEY must be set to read platform metadata")
+        self._session = requests.Session()
+        self._session.headers.update({
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+            "Authorization": f"Bearer {self.token}",
+            "User-Agent": _UA,
+        })
+        self._handshaken = False
+
+    def _scrub(self, text: str) -> str:
+        """`text` with the API key replaced, for anything that might be printed.
+
+        Every message this module raises goes through here. Error text carries a response
+        body and a `requests` exception string, and neither is under our control: a proxy
+        that echoes request headers, or an SDK that puts the prepared request in its
+        `repr`, would otherwise put the key in CI logs that outlive the key. Scrubbing at
+        the one place messages are built is cheaper than auditing each of them.
+        """
+        return text.replace(self.token, "<OSO_API_KEY>") if self.token else text
+
+    def _post(self, payload: dict) -> str:
+        import requests
+
+        try:
+            response = self._session.post(self.url, data=json.dumps(payload), timeout=90)
+        except requests.RequestException as exc:
+            raise MCPUnreachable(self._scrub(f"POST {self.url} failed: {exc}")) from None
+        # Decode explicitly. See the module docstring: requests guesses ISO-8859-1 for a
+        # charset-less text/event-stream and silently corrupts every non-ASCII character.
+        body = response.content.decode("utf-8", errors="replace")
+        if response.status_code >= 400:
+            # Surface the body. A Cloudflare 1010 and an expired key are both 403 and the
+            # body is the only thing that tells them apart.
+            raise MCPUnreachable(self._scrub(
+                f"POST {self.url} returned {response.status_code}: {body[:400]}"
+            ))
+        return body
+
+    def _rpc(self, method: str, params: dict, *, notify: bool = False) -> dict | None:
+        payload: dict = {"jsonrpc": "2.0", "method": method, "params": params}
+        if not notify:
+            payload["id"] = 1
+        body = self._post(payload)
+        if notify:
+            return None
+        for line in body.splitlines():
+            if not line.startswith("data: "):
+                continue
+            try:
+                frame = json.loads(line[len("data: "):])
+            except json.JSONDecodeError:
+                # A frame that will not parse is a failure to read, and it must arrive at the
+                # caller as one. Left bare, a JSONDecodeError escapes past every handler in
+                # check_mirror_drift.main and lands on the drift exit code, which is the one
+                # outcome this module exists to keep apart from "we could not tell".
+                raise MCPUnreachable(self._scrub(
+                    f"{method} returned an unparseable frame: {line[:200]!r}")) from None
+            if frame.get("id") != 1:
+                continue  # a log notification ahead of the answer
+            if "error" in frame:
+                raise MCPUnreachable(
+                    self._scrub(f"{method} returned a JSON-RPC error: {frame['error']}"))
+            return frame.get("result") or {}
+        raise MCPUnreachable(
+            self._scrub(f"{method} returned no result frame; body began {body[:300]!r}"))
+
+    def _handshake(self) -> None:
+        if self._handshaken:
+            return
+        self._rpc("initialize", {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": {"name": "os-ai-map", "version": "1"},
+        })
+        self._rpc("notifications/initialized", {}, notify=True)
+        self._handshaken = True
+
+    def call(self, tool: str, variables: dict) -> dict:
+        """Run one MCP tool and return its decoded JSON payload.
+
+        Every OSO tool takes its arguments under a single `variables` key — a flat
+        `{"id": ...}` is rejected with a pydantic `missing_argument` on `variables`, which
+        is a confusing way to be told about one level of nesting.
+        """
+        self._handshake()
+        result = self._rpc("tools/call", {"name": tool, "arguments": {"variables": variables}})
+        content = (result or {}).get("content") or []
+        text = content[0].get("text", "") if content else ""
+        if (result or {}).get("isError"):
+            raise MCPCallFailed(self._scrub(f"{tool} failed: {text[:400]}"))
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            raise MCPUnreachable(
+                self._scrub(f"{tool} returned non-JSON content: {text[:300]!r}")) from None
+
+    def data_model(self, model_id: str) -> dict | None:
+        """The data model node for `model_id`, or None when the platform has no such model.
+
+        None is a finding, not an error: a contract naming a model id the platform does not
+        serve is drift of the worst kind — the mirror is anchored to something that no longer
+        exists — so the caller reports it rather than crashing on it.
+        """
+        payload = self.call("GetDataModel", {"id": model_id})
+        edges = ((payload or {}).get("dataModels") or {}).get("edges") or []
+        return edges[0].get("node") if edges else None

--- a/docs/operations/deploy-models.md
+++ b/docs/operations/deploy-models.md
@@ -18,7 +18,9 @@ block in `warehouse/dependencies.yaml` for the deployed revision, hash and sync 
 reflects. The identity dataset is mirrored the same way, under `warehouse/models/identity/`: after
 any `identity.*` revision is released, resync the mirror file from the platform's released code and
 update that contract's `verified_revision`, `mirror.revision`, `mirror.hash`, `mirror.local_sha256`
-and `mirror.synced_at`, or the dependency gate fails on the hash.
+and `mirror.synced_at`, or the dependency gate fails on the hash. That gate only proves the file
+matches its own contract; "Mirror resync" below covers the weekly check that the contract still
+matches the platform, and what to do when it does not.
 
 ## The deploy mechanic: revision → RELEASE → run
 
@@ -85,6 +87,7 @@ holds it against the `cron:` lines it quotes.
 | `artifacts` | Monday 07:00 | `.github/workflows/artifacts.yml` |
 | `identity-eval` (replay eval against prior human decisions; fails on a floored relation) | Monday 07:30 | `.github/workflows/identity-eval.yml` |
 | `freshness` report | Monday 08:00 | `.github/workflows/freshness.yml` |
+| `mirror-drift` (every `mirror:` contract against the platform's latest revision) | Monday 08:30 | `.github/workflows/mirror-drift.yml` |
 | `channel-authority` report | Monday 09:00 | `.github/workflows/channel-authority.yml` |
 | `reverify` (re-dates openness on the oldest 150 products where evidence is unchanged; opens one PR) | Tuesday 10:00 | `.github/workflows/reverify.yml` |
 | `identity-digest` (weekly review issue of low-confidence identity items) | Monday 09:00 | `.github/workflows/identity-digest.yml` |
@@ -126,6 +129,54 @@ Pushing the declarations is step 1, not the whole job:
 uv run python -m build.serialize_rubric && uv run python -m build.publish_registry
 # then walk the chain above, in order, and prove it with check_parity
 ```
+
+## Mirror resync, when the drift sentinel fires
+
+`build/check_mirror_drift.py` compares every `mirror:` contract in `warehouse/dependencies.yaml`
+against the platform once a week (`.github/workflows/mirror-drift.yml`, Monday 08:30 UTC), and a
+red run opens a `sentinel` issue. It exists because nothing else could see this failure: the
+dependency gate proves a mirror file matches its own contract, which stays true no matter how far
+the platform has moved on, so the repo can review revision N while N+1 builds the table.
+
+It reports four findings, and they are not the same job:
+
+- **`revision`** — the platform's latest revision number is ahead of the contract. Resync.
+- **`hash`** — same revision number, different hash. The number the repo pins now denotes
+  different content; resync, and look at why a revision was rewritten in place.
+- **`code`** — number and hash agree and the deployed source does not match the mirror file
+  below its banner. Either the mirror was hand-edited, or the hash is not a hash of the code.
+- **`missing`** — the platform serves no model at that `model_id`. Do not resync; find out
+  whether the model was deleted or recreated, because the contract's anchor is gone.
+
+To resync one contract:
+
+1. Read the deployed code. `GetDataModel` with the contract's `mirror.model_id` returns
+   `latestRevision` — `revisionNumber`, `hash`, `code` and `createdAt`.
+2. Replace the mirror file's body with that `code`, **keeping the five-line
+   `PLATFORM MIRROR (read-only)` banner**. The banner is why `mirror.local_sha256` and
+   `mirror.hash` are different hashes of nearly the same text, and the drift check strips it
+   before comparing.
+3. Update the contract: `verified_revision` and `mirror.revision` to the new revision number,
+   `mirror.hash` to the platform's hash, `mirror.local_sha256` to `sha256` of the file's bytes
+   **including** the banner, and `mirror.synced_at` to today. `model_id` does not change — a
+   changed `model_id` is a different model, and the cross-commit gate rejects it.
+4. If the schema file changed too, update `mirror.schema_sha256` the same way. A schema-only
+   edit is still a byte change and must advance the revision.
+5. Run the gates: `uv run pytest tests/test_scope_gates.py -q` for the contract's integrity,
+   then `uv run python -m build.check_mirror_drift` to confirm the sentinel is green.
+
+Resync in one commit per contract where you can. The cross-commit coherence gate reads bytes,
+revision, hash and `synced_at` as one movement, and a batch that half-lands is harder to read
+than several small ones.
+
+**The sentinel cannot see an unreleased revision, and does not pretend to.** The platform
+exposes no release marker — `GetDataModel` has no release field and `GetAssetChangelog`'s
+`publishStatus` is null on every revision in this org — so the check compares against
+`latestRevision`. A contract behind the latest revision is worth a look either way: either the
+newer revision is released and the mirror describes code that no longer runs, or it is not
+released yet and the resync is cheap now. What the check cannot do is confirm that the revision
+it found is the one a run would materialize; that is the same gap as the missing
+revision-versus-release assertion noted above.
 
 ## The parity gate
 

--- a/tests/test_check_mirror_drift.py
+++ b/tests/test_check_mirror_drift.py
@@ -1,0 +1,226 @@
+"""The mirror-drift sentinel must separate four findings from each other, and from silence.
+
+Written against a stub client rather than the platform, because the whole value of the gate
+is the distinction it draws between "the mirror is stale", "the same revision number now
+means different bytes", "the numbers agree and the code does not", and "we could not tell".
+Those are four different things a maintainer does four different things about, and only the
+last one must never be reported as a pass.
+
+The stub returns platform nodes in the shape `GetDataModel` actually returns -- a
+`latestRevision` carrying `revisionNumber`, `hash`, `code` and `createdAt` -- so the
+comparison being tested is the real one.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from build.check_mirror_drift import (
+    check,
+    compare,
+    main,
+    mirror_contracts,
+    strip_mirror_banner,
+)
+from build.oso_mcp import MCPCallFailed, MCPUnreachable
+
+ROOT = Path(__file__).resolve().parent.parent
+
+SQL_BANNER = (
+    "-- ────── PLATFORM MIRROR (read-only) ──────\n"
+    "-- A snapshot of a model that runs on the OSO platform.\n"
+    "-- The platform is the source of truth.\n"
+    "-- Nothing deploys from this copy.\n"
+    "\n"
+)
+PY_BANNER = SQL_BANNER.replace("-- ", "# ").replace("--", "#")
+DEPLOYED = "SELECT 1 AS answer\n"
+
+
+def build_tree(tmp_path: Path, body: str = DEPLOYED, banner: str = SQL_BANNER) -> dict:
+    """A one-contract repo on disk, and the contract dict that describes it."""
+    model = tmp_path / "warehouse/models/scores/thing.sql"
+    model.parent.mkdir(parents=True, exist_ok=True)
+    model.write_text(banner + body)
+    return {
+        "table": "currentai.scores.thing",
+        "files": {"model": "warehouse/models/scores/thing.sql"},
+        "mirror": {
+            "model_id": "a-model-id",
+            "revision": 4,
+            "hash": "platformhash",
+            "local_sha256": "irrelevant here -- dependency_violations owns that check",
+        },
+    }
+
+
+def node(revision: int = 4, hash_: str = "platformhash", code: str = DEPLOYED) -> dict:
+    return {"latestRevision": {"revisionNumber": revision, "hash": hash_, "code": code,
+                               "createdAt": "2026-09-01T00:00:00.000Z"}}
+
+
+class StubClient:
+    """Returns a canned node, or raises, per `data_model` call."""
+
+    def __init__(self, result):
+        self.result = result
+        self.calls: list[str] = []
+
+    def data_model(self, model_id: str):
+        self.calls.append(model_id)
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+# --- the banner, which is why a naive comparison fails on every contract ---------------
+
+def test_the_banner_is_stripped_in_both_comment_forms():
+    """SQL mirrors comment with `--` and Python mirrors with `#`; both carry the header."""
+    assert strip_mirror_banner(SQL_BANNER + DEPLOYED) == DEPLOYED
+    assert strip_mirror_banner(PY_BANNER + DEPLOYED) == DEPLOYED
+
+
+def test_a_file_with_no_banner_is_compared_as_it_stands():
+    """Not an error. A mirror that lost its header is code drift and is reported as such."""
+    assert strip_mirror_banner(DEPLOYED) == DEPLOYED
+
+
+# --- the four findings ------------------------------------------------------------------
+
+def test_a_matching_contract_is_ok(tmp_path):
+    row = compare(build_tree(tmp_path), node(), tmp_path)
+    assert row.status == "ok"
+    assert not row.drifted
+    assert (row.hash_match, row.code_match) == (True, True)
+    assert row.platform_revision == row.contract_revision == 4
+
+
+def test_a_newer_platform_revision_is_revision_drift(tmp_path):
+    row = compare(build_tree(tmp_path), node(revision=5, hash_="newhash"), tmp_path)
+    assert row.status == "revision"
+    assert row.drifted
+    assert (row.contract_revision, row.platform_revision) == (4, 5)
+    assert "latest revision is 5" in row.detail
+
+
+def test_the_same_revision_with_a_different_hash_is_hash_drift(tmp_path):
+    """The worst of the three: the number the repo pins now denotes different content."""
+    row = compare(build_tree(tmp_path), node(hash_="rewritten"), tmp_path)
+    assert row.status == "hash"
+    assert row.hash_match is False
+    assert "rewritten" in row.detail
+
+
+def test_matching_numbers_over_different_source_is_code_drift(tmp_path):
+    """The check that a hand-edited mirror with a refreshed local_sha256 cannot defeat."""
+    row = compare(build_tree(tmp_path, body="SELECT 2 AS answer\n"), node(), tmp_path)
+    assert row.status == "code"
+    assert (row.hash_match, row.code_match) == (True, False)
+
+
+def test_a_model_id_the_platform_does_not_serve_is_missing(tmp_path):
+    row = compare(build_tree(tmp_path), None, tmp_path)
+    assert row.status == "missing"
+    assert row.platform_revision is None
+    assert "a-model-id" in row.detail
+
+
+def test_a_mirror_file_that_is_gone_is_reported_not_raised(tmp_path):
+    contract = build_tree(tmp_path)
+    (tmp_path / contract["files"]["model"]).unlink()
+    row = compare(contract, node(), tmp_path)
+    assert row.status == "code"
+    assert "is missing" in row.detail
+
+
+# --- the sweep and the exit codes -------------------------------------------------------
+
+def write_dependencies(tmp_path: Path, contracts: list[dict]) -> None:
+    path = tmp_path / "warehouse/dependencies.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump({"version": 1, "dependencies": contracts}))
+
+
+def test_a_clean_sweep_exits_zero_and_writes_the_report(tmp_path, capsys):
+    contract = build_tree(tmp_path)
+    write_dependencies(tmp_path, [contract])
+    report = tmp_path / "drift.json"
+    code = main(["--report", str(report)], root=tmp_path, client=StubClient(node()))
+    assert code == 0
+    assert "[OK]" in capsys.readouterr().out
+    payload = json.loads(report.read_text())
+    assert (payload["checked"], payload["drifted"]) == (1, 0)
+    assert payload["rows"][0]["status"] == "ok"
+
+
+def test_any_drift_exits_one_and_names_the_runbook(tmp_path, capsys):
+    write_dependencies(tmp_path, [build_tree(tmp_path)])
+    code = main([], root=tmp_path, client=StubClient(node(revision=9, hash_="h9")))
+    assert code == 1
+    out = capsys.readouterr().out
+    assert "1 drifted" in out
+    assert "Mirror resync" in out
+
+
+@pytest.mark.parametrize("failure, cause", [
+    (MCPUnreachable("403 from the edge"), "could not be reached"),
+    # A 200 carrying isError -- what an expired or rotated OSO_API_KEY looks like. This one
+    # used to escape as a traceback and exit 1, the drift code, which would have sent a
+    # maintainer to diff seventeen mirror files against a platform nobody can read.
+    (MCPCallFailed("GetDataModel failed: UNAUTHENTICATED: User is not authenticated"),
+     "refused the call"),
+])
+def test_anything_that_prevents_checking_exits_two_and_names_the_cause(
+        tmp_path, capsys, failure, cause):
+    """Exit 2, never 1 and never 0. See the module docstring on why the line matters."""
+    write_dependencies(tmp_path, [build_tree(tmp_path)])
+    code = main([], root=tmp_path, client=StubClient(failure))
+    assert code == 2
+    captured = capsys.readouterr()
+    assert "[CANNOT CHECK]" in captured.err
+    assert cause in captured.err
+    assert "This is not a pass" in captured.err
+    assert "it is not drift" in captured.err
+    assert "[OK]" not in captured.out
+
+
+def test_a_report_is_not_written_when_nothing_could_be_checked(tmp_path):
+    """A stale report read as a fresh one is the failure mode a --report file invites."""
+    write_dependencies(tmp_path, [build_tree(tmp_path)])
+    report = tmp_path / "drift.json"
+    code = main(["--report", str(report)], root=tmp_path,
+                client=StubClient(MCPCallFailed("UNAUTHENTICATED")))
+    assert code == 2
+    assert not report.exists()
+
+
+def test_a_transport_failure_mid_sweep_is_not_a_partial_result(tmp_path):
+    """Half a sweep is not a result, so the exception propagates out of `check`."""
+    write_dependencies(tmp_path, [build_tree(tmp_path)])
+    with pytest.raises(MCPUnreachable):
+        check([build_tree(tmp_path)], StubClient(MCPUnreachable("timeout")), tmp_path)
+
+
+# --- the real contracts -----------------------------------------------------------------
+
+def test_every_real_mirror_contract_is_in_scope():
+    """The sweep must cover every mirror-bearing contract, and only those.
+
+    An `oso.*` upstream anchors on a content contract and has no revision to compare, so it
+    is out of scope. This asserts the split rather than a count, so adding a contract does
+    not need this test edited -- but dropping mirrors out of the sweep fails it.
+    """
+    contracts = mirror_contracts(ROOT)
+    assert contracts, "no mirror contracts found; the sweep would pass vacuously"
+    doc = yaml.safe_load((ROOT / "warehouse/dependencies.yaml").read_text())
+    expected = [d for d in doc["dependencies"] if d.get("mirror")]
+    assert [c["table"] for c in contracts] == [d["table"] for d in expected]
+    for contract in contracts:
+        assert contract["table"].startswith("currentai."), contract["table"]
+        assert contract["mirror"].get("model_id"), contract["table"]
+        assert (ROOT / contract["files"]["model"]).exists(), contract["table"]

--- a/tests/test_oso_mcp.py
+++ b/tests/test_oso_mcp.py
@@ -1,0 +1,231 @@
+"""The transport guarantees `build/check_mirror_drift.py` rests on, pinned against a fake session.
+
+Three of these exist because the obvious, idiomatic edit breaks them silently.
+
+The UTF-8 one is the sharpest. `_post` decodes `response.content` rather than reading
+`response.text`, and `response.text` is the shorter, more natural line — a comment is the only
+thing standing in the way of someone simplifying it back. Nothing would go red: the platform's
+`text/event-stream` carries no charset, `requests` then falls back to ISO-8859-1, and every
+em-dash in a model's comments becomes mojibake. Five of seventeen code comparisons reported
+false drift that way, differing by two to six characters with no visible cause, and it cost an
+afternoon to find. So the fake session below returns real UTF-8 bytes under a charset-less
+header and the test asserts the round trip.
+
+The key-redaction ones pin `_scrub`. Error text carries a response body and a transport
+exception string, neither under this module's control, and a CI log outlives the key printed
+into it.
+
+No network. `Client` imports `requests` lazily and only touches `self._session`, so a stub
+object with a `post` and a `headers` dict is a complete substitute.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import requests
+
+from build.oso_mcp import _UA, Client, MCPCallFailed, MCPUnreachable
+
+KEY = "oso_test_key_do_not_log_5551234"
+EM_DASH_TEXT = "OpenRouter model list — the release-watcher's first leg."
+
+
+class FakeResponse:
+    def __init__(self, body: bytes, status: int = 200):
+        self.content = body
+        self.status_code = status
+
+    @property
+    def text(self) -> str:
+        """What `requests` would hand back for a charset-less `text/*`: ISO-8859-1.
+
+        Defined wrongly on purpose. If `_post` ever reads `.text` again, the UTF-8 test
+        below fails instead of the bug reaching the mirror comparison.
+        """
+        return self.content.decode("iso-8859-1")
+
+
+class FakeSession:
+    """Enough of `requests.Session` for `_post`: a headers dict and a `post`."""
+
+    def __init__(self, response=None, raises: Exception | None = None):
+        self.headers: dict[str, str] = {}
+        self.response = response
+        self.raises = raises
+        self.posts: list[tuple[str, str]] = []
+
+    def post(self, url, data=None, timeout=None):
+        self.posts.append((url, data))
+        if self.raises is not None:
+            raise self.raises
+        return self.response
+
+
+def client_with(session: FakeSession, *, handshaken: bool = True) -> Client:
+    c = Client(url="https://mcp.example/mcp", token=KEY)
+    c._session = session
+    c._handshaken = handshaken
+    return c
+
+
+def sse(payload: dict) -> bytes:
+    """One `data:` frame, UTF-8 encoded, as the server sends it."""
+    return b"data: " + json.dumps(payload, ensure_ascii=False).encode("utf-8") + b"\n"
+
+
+def tool_result(text: str, is_error: bool = False) -> bytes:
+    return sse({"jsonrpc": "2.0", "id": 1,
+                "result": {"content": [{"type": "text", "text": text}],
+                           "isError": is_error}})
+
+
+# --- the decode, which is the bug that cost an afternoon ---------------------------------
+
+def test_a_charsetless_response_body_round_trips_as_utf8():
+    """An em-dash in a model's source must survive the transport unchanged.
+
+    This is the whole reason `_post` does its own decoding. Read as ISO-8859-1 the same
+    bytes come back as three mojibake characters, the deployed code stops matching the
+    mirror file, and the gate reports drift that is not there.
+    """
+    payload = json.dumps({"code": EM_DASH_TEXT}, ensure_ascii=False)
+    session = FakeSession(FakeResponse(tool_result(payload)))
+    got = client_with(session).call("GetDataModel", {"id": "x"})
+    assert got["code"] == EM_DASH_TEXT
+    assert "—" in got["code"]
+    assert "â" not in got["code"], "body was decoded as ISO-8859-1, not UTF-8"
+
+
+def test_undecodable_bytes_do_not_crash_the_sweep():
+    """`errors="replace"` keeps a malformed byte a reportable failure, not a UnicodeError."""
+    session = FakeSession(FakeResponse(b"data: {\xff\xfe not json}\n"))
+    with pytest.raises(MCPUnreachable):
+        client_with(session).call("GetDataModel", {"id": "x"})
+
+
+# --- the headers -------------------------------------------------------------------------
+
+def test_the_session_sends_a_real_user_agent_and_a_bearer_token():
+    """A default UA has been refused at the CDN with a 403 that reads like a bad key."""
+    c = Client(url="https://mcp.example/mcp", token=KEY)
+    assert c._session.headers["User-Agent"] == _UA
+    assert "python-requests" not in _UA and "urllib" not in _UA
+    assert c._session.headers["Authorization"] == f"Bearer {KEY}"
+    assert "text/event-stream" in c._session.headers["Accept"]
+
+
+def test_a_missing_key_is_refused_before_any_request(monkeypatch):
+    monkeypatch.delenv("OSO_API_KEY", raising=False)
+    with pytest.raises(MCPUnreachable, match="OSO_API_KEY"):
+        Client(url="https://mcp.example/mcp", token="")
+
+
+# --- the key never appears in anything printable ----------------------------------------
+
+@pytest.mark.parametrize("session", [
+    # A proxy that echoes the request headers back in an error body.
+    FakeSession(FakeResponse(f"upstream rejected Authorization: Bearer {KEY}".encode(), 502)),
+    # A transport exception whose own string carries the prepared request.
+    FakeSession(raises=requests.ConnectionError(f"failed sending Bearer {KEY}")),
+    # A 200 refusing the call, echoing the credential it refused.
+    FakeSession(FakeResponse(tool_result(f"UNAUTHENTICATED: {KEY}", is_error=True))),
+])
+def test_the_key_never_appears_in_an_exception_message(session):
+    with pytest.raises((MCPUnreachable, MCPCallFailed)) as caught:
+        client_with(session).call("GetDataModel", {"id": "x"})
+    assert KEY not in str(caught.value)
+    assert "<OSO_API_KEY>" in str(caught.value)
+
+
+def test_the_key_never_appears_in_a_chained_traceback():
+    """`from None`, not `from exc`: a chained exception prints its own repr in a traceback.
+
+    Walked the way a traceback walks it. `from None` leaves `__context__` set — the
+    interpreter still knows what it was handling — but sets `__suppress_context__`, which is
+    what stops the printer following it. So the assertion is about what would actually reach
+    a CI log, not about the attribute being absent.
+    """
+    session = FakeSession(raises=requests.ConnectionError(f"Bearer {KEY}"))
+    with pytest.raises(MCPUnreachable) as caught:
+        client_with(session).call("GetDataModel", {"id": "x"})
+    assert caught.value.__cause__ is None
+    assert caught.value.__suppress_context__, "a traceback would follow __context__ and print the key"
+
+    printed, exc = [], caught.value
+    while exc is not None:
+        printed.append(str(exc))
+        if exc.__cause__ is not None:
+            exc = exc.__cause__
+        elif exc.__context__ is not None and not exc.__suppress_context__:
+            exc = exc.__context__
+        else:
+            break
+    assert not any(KEY in link for link in printed), printed
+
+
+# --- the two failure classes -------------------------------------------------------------
+
+def test_a_200_carrying_iserror_is_a_call_failure_not_unreachable():
+    """What a rotated key looks like: the server answers cheerfully and refuses the call."""
+    session = FakeSession(FakeResponse(tool_result("UNAUTHENTICATED", is_error=True)))
+    with pytest.raises(MCPCallFailed, match="UNAUTHENTICATED"):
+        client_with(session).call("GetDataModel", {"id": "x"})
+
+
+def test_a_connection_error_is_unreachable():
+    session = FakeSession(raises=requests.ConnectionError("no route to host"))
+    with pytest.raises(MCPUnreachable, match="no route to host"):
+        client_with(session).call("GetDataModel", {"id": "x"})
+
+
+def test_a_non_200_is_unreachable_and_surfaces_the_body():
+    """A Cloudflare 1010 and an expired key are both 403; the body is what separates them."""
+    session = FakeSession(FakeResponse(b"error 1010: browser_signature_banned", 403))
+    with pytest.raises(MCPUnreachable, match="browser_signature_banned") as caught:
+        client_with(session).call("GetDataModel", {"id": "x"})
+    assert "403" in str(caught.value)
+
+
+def test_a_body_with_no_result_frame_is_unreachable():
+    """Only log notifications came back. Not a result, so not treated as one."""
+    session = FakeSession(FakeResponse(
+        sse({"jsonrpc": "2.0", "method": "notifications/message", "params": {}})))
+    with pytest.raises(MCPUnreachable, match="no result frame"):
+        client_with(session).call("GetDataModel", {"id": "x"})
+
+
+# --- the shapes the caller depends on ----------------------------------------------------
+
+def test_arguments_are_nested_under_variables():
+    """A flat `{"id": ...}` is rejected with a pydantic `missing_argument` on `variables`."""
+    session = FakeSession(FakeResponse(tool_result('{"dataModels": {"edges": []}}')))
+    client_with(session).call("GetDataModel", {"id": "abc"})
+    _url, body = session.posts[-1]
+    assert json.loads(body)["params"]["arguments"] == {"variables": {"id": "abc"}}
+
+
+def test_an_unknown_model_id_returns_none_rather_than_raising():
+    """`data_model` reports absence; the caller turns it into a `missing` finding."""
+    session = FakeSession(FakeResponse(tool_result('{"dataModels": {"edges": []}}')))
+    assert client_with(session).data_model("nope") is None
+
+
+def test_data_model_unwraps_the_edge_node():
+    node = {"id": "m1", "latestRevision": {"revisionNumber": 4}}
+    session = FakeSession(FakeResponse(
+        tool_result(json.dumps({"dataModels": {"edges": [{"node": node}]}}))))
+    assert client_with(session).data_model("m1") == node
+
+
+def test_the_handshake_runs_once_for_many_calls():
+    """The sweep makes one call per contract; a per-call handshake would triple its cost."""
+    session = FakeSession(FakeResponse(tool_result('{"dataModels": {"edges": []}}')))
+    c = client_with(session, handshaken=False)
+    c.data_model("a")
+    c.data_model("b")
+    methods = [json.loads(body)["method"] for _url, body in session.posts]
+    assert methods.count("initialize") == 1
+    assert methods.count("notifications/initialized") == 1
+    assert methods.count("tools/call") == 2

--- a/tests/test_schedule_doc.py
+++ b/tests/test_schedule_doc.py
@@ -22,7 +22,7 @@ DOC = ROOT / "docs/operations/deploy-models.md"
 # The gates whose times the doc's table quotes. Dataset crons live on the platform and
 # cannot be read from the repo, so they are out of scope here by construction.
 GATES = ("parity", "artifacts", "freshness", "channel-authority", "reverify", "identity-eval",
-         "identity-digest")
+         "identity-digest", "mirror-drift")
 
 _DAYS = {"1": "Monday", "2": "Tuesday", "3": "Wednesday", "4": "Thursday",
          "5": "Friday", "6": "Saturday", "0": "Sunday"}


### PR DESCRIPTION
## The gap

`warehouse/dependencies.yaml` holds 17 mirror contracts — platform-authored models the repo
copies read-only, each with a `mirror:` block naming a revision, the platform's hash for it,
and a `local_sha256` over the bytes on disk.

Every gate over those blocks reads only the repo. `build/assets.dependency_violations` proves
the file on disk is the file the contract claims, that `verified_revision` equals
`mirror.revision`, and that bytes and revision move together across commits. None of it can
tell you the contract still matches the platform. A model can be revised the day after a
mirror is synced and the repo stays green: the file still hashes, the anchor still matches,
and nothing anywhere compares either number to the platform. The repo then evaluates,
reviews and reasons about revision N while N+1 is what builds the table — silent in exactly
the direction that matters, since the more confident the gates look the more stale the mirror
can be.

## How the platform is queried

Revision numbers, hashes and deployed code are asset metadata, not rows, so `build/warehouse.py`
cannot answer this. `build/oso_mcp.py` is a small JSON-RPC client for the MCP server at
`https://mcp.oso.xyz/mcp`, authenticating with the `OSO_API_KEY` CI already holds — no new
secret. It calls `GetDataModel` with each contract's `mirror.model_id` and reads
`latestRevision`: number, hash, code and creation time. Verified working against the live
endpoint.

Three transport hazards are documented and tested in that module:

- **A default user agent has been refused at the CDN.** `python-urllib/3.12` returned
  `403 Error 1010: browser_signature_banned` with "Do not retry" in the body; the same key
  worked immediately with a real `User-Agent`. The rule looks intermittent or has since
  changed (a plain `python-requests` POST was accepted in a later session), so the module
  now frames this as a hazard rather than a certainty. Worth keeping either way, because a
  403 reads exactly like a bad token and would send someone to rotate a key that was never
  the problem.
- **The response is `text/event-stream` with no charset**, so `requests` falls back to
  ISO-8859-1 and mangles every em-dash in a model's comments. That made 5 of 17 code
  comparisons fail with a two-to-six character difference and no visible cause. `_post`
  decodes UTF-8 itself, and `tests/test_oso_mcp.py` pins the round trip — the fake response
  deliberately defines `.text` as the ISO-8859-1 decode, so reverting to the shorter
  `response.text` fails the test instead of reaching the comparison.
- **The key must not reach a CI log.** Every message raised passes through `_scrub`, and the
  two raises that wrap a foreign exception use `from None`: a chained `requests` exception
  prints its own `repr`, and a prepared request's `repr` is one plausible place for an
  `Authorization` header to surface. Neither a response body nor a transport error string is
  under this module's control.

**On "released".** The check compares against `latestRevision` and says so throughout. Release
state is not readable: `GetDataModel` has no release field and `GetAssetChangelog`'s
`publishStatus` is null on every revision of every model in this org. A contract behind the
latest revision is worth a look either way — either the newer revision is released and the
mirror describes code that no longer runs, or it is not yet and the resync is cheap now. What
the check cannot confirm is that the revision it found is the one a run would materialize;
that is the same gap as the missing revision-versus-release assertion already noted in
`deploy-models.md`.

## Four findings, two exit codes

`revision` (the platform moved on), `hash` (same number, different content — worse, and
invisible to every repo-side gate), `code` (numbers agree, deployed source does not match the
mirror body — the one a hand-edited file with a refreshed `local_sha256` cannot defeat), and
`missing` (no model at that `model_id` at all). Mirror files carry a five-line
`PLATFORM MIRROR (read-only)` banner, which is why `local_sha256` and `hash` are different
hashes of nearly the same text; the check strips it before comparing.

Exit 1 means every contract was checked and some drifted: the job is a resync. Exit 2 means
nothing was checked: the job is to find out why. Everything that prevents checking lands in 2
— unreachable, non-200, a 200 carrying `isError`, an unparseable frame. This matters because
`report-failure.yml` turns either into the same `sentinel` issue, so the exit code is all a
maintainer has to tell the two jobs apart. Verified live: a bogus key, a refused connection
and a 404 all exit 2, and none of the three prints the key.

## The live run

```
table                                              contract platform  hash  code  revised_at           status
-------------------------------------------------------------------------------------------------------------
currentai.evidence.product_evidence                      11       11   yes   yes  2026-08-24T11:26:34  ok
currentai.scores.openness_facts                           7        9    NO     -  2026-08-16T19:29:19  revision
currentai.scores.openness_computed                       15       17    NO     -  2026-08-16T19:31:19  revision
currentai.signal_github.artifact_state                    2        3    NO     -  2026-09-03T07:41:14  revision
currentai.signal_huggingface.artifact_state               2        2   yes   yes  2026-08-24T11:20:46  ok
currentai.signal_pypi.package_downloads                   3        4    NO     -  2026-08-16T17:22:53  revision
currentai.signal_semanticscholar.paper_citations          5        5   yes   yes  2026-08-26T13:29:44  ok
currentai.identity.artifact_nodes                         3        3   yes   yes  2026-09-04T06:14:23  ok
currentai.identity.artifact_identity_edges                4        4   yes   yes  2026-09-04T06:16:24  ok
currentai.identity.candidates                             3        3   yes   yes  2026-09-04T06:15:20  ok
currentai.identity.membership_edges                       2        3    NO     -  2026-09-04T08:50:55  revision
currentai.identity.equivalence_edges                      5        6    NO     -  2026-09-04T08:54:26  revision
currentai.identity.org_edges                              3        4    NO     -  2026-09-04T08:52:34  revision
currentai.identity.digest                                 4        5    NO     -  2026-09-04T08:58:15  revision
currentai.signal_hfhub.model_universe                     3        3   yes   yes  2026-09-03T17:01:23  ok
currentai.signal_openrouter.models                        2        2   yes   yes  2026-09-03T16:55:18  ok
currentai.signal_goodailist.repo_catalog                  4        4   yes   yes  2026-08-16T17:22:58  ok

9 of 17 mirror contracts match the platform, 8 drifted
```

**Four of these appeared while this branch was in review.** `identity.membership_edges` 2→3,
`identity.equivalence_edges` 5→6, `identity.org_edges` 3→4 and `identity.digest` 4→5 were all
revised on the platform between 08:50 and 08:58 UTC on 2026-09-04, by a planned identity
redeploy. Four of the mirrors #480 just landed on `main` are already stale. That is not a
defect in this branch, and it is the best demonstration available that the sentinel measures
something real and that the drift window is hours, not months. **A resync PR follows** — it
touches scoring and identity inputs and needs the deployed diffs read properly, so it does not
belong here.

The other four (`openness_facts` 7→9, `openness_computed` 15→17, `signal_github.artifact_state`
2→3, `signal_pypi.package_downloads` 3→4) are the older, longer-standing drift and land in the
same resync.

Note where this does *not* bite: `build/check_parity.py` reads the platform **table** through
`build/warehouse.query`, never the mirror file, so a stale mirror cannot make parity lie. What
it breaks is the diagnosis — when parity diverges, the only readable copy of the warehouse's
ladder is a mirror two unreviewed revisions behind. `check_parity.py`'s own comment about the
SQL "resolving the tier up front" is a claim read off revision 15.

## What else changed

- `.github/workflows/mirror-drift.yml` — weekly, Monday 08:30 UTC, plus `workflow_dispatch`.
  The half hour keeps it off `freshness` at 08:00 and out of its logs, which is why every
  other Monday gate sits on its own minute; the gate reads asset metadata, so it has no
  ordering relationship to the chain either way. Not a `pull_request` gate — drift here is
  caused by a platform deploy, not by the PR, and failing contributors' PRs for a maintainer's
  unsynced deploy is the fastest way to get a gate switched off.
- Added to `report-failure.yml`'s workflow list, so a red run opens or comments on one
  `sentinel` issue.
- Added to `tests/test_schedule_doc.py::GATES` and the schedule table in `deploy-models.md`,
  so the documented time stays answerable to the cron.
- A "Mirror resync" runbook in `deploy-models.md`: what each of the four findings means, and
  the five steps to resync one contract (fetch the deployed code, replace the body below the
  banner, update `verified_revision`/`mirror.revision`/`hash`/`local_sha256`/`synced_at`, then
  the gates).

## Test plan

`tests/test_check_mirror_drift.py` — 16 tests against a stub client returning nodes in the real
`GetDataModel` shape: match, revision drift, hash drift, code drift, missing model, missing
mirror file, banner stripping in both `--` and `#` forms, a file with no banner, the report
JSON, exit 0/1/2 including a stubbed `isError` for both "cannot check" classes, that no report
is written when nothing could be checked, and that a read failure mid-sweep propagates rather
than returning half a result. Plus a test that the sweep covers every real mirror contract and
only those.

`tests/test_oso_mcp.py` — 16 tests against a fake session, no network: the UTF-8 round trip,
undecodable bytes, the user-agent and bearer headers, a missing key refused before any request,
the key absent from every exception message and from a chained traceback, `isError` →
`MCPCallFailed`, connection error and non-200 → `MCPUnreachable`, a body with no result frame,
`variables` nesting, an unknown model id returning `None`, and one handshake across many calls.

```
uv run pytest tests/test_oso_mcp.py tests/test_check_mirror_drift.py \
  tests/test_schedule_doc.py tests/test_docs_integrity.py tests/test_registry_triggers.py -q -n 4
57 passed in 0.79s

uv run pytest -q -n 4 -m "not serial"
1559 passed in 384.19s
```

Refs #365