### PR TITLE
Evaluate org recall per handle route and count tail declarations as truth

### DIFF
--- a/.github/workflows/identity-eval.yml
+++ b/.github/workflows/identity-eval.yml
@@ -20,7 +20,16 @@ name: identity-eval
 # warehouse tables (they may not exist, and a fork PR has no OSO_API_KEY regardless). The
 # fixture (tests/fixtures/identity_edges_pass.json) carries all four edge tables in the real
 # WAREHOUSE_COLUMNS shape, so this run exercises the scoring math, the tier split and the
-# schema end to end -- it is not a substitute for the two never-auto-emit governance rules,
+# schema end to end. Its membership rows for the tail are the corpus's own tail declarations, so
+# a tail registry edit makes this run fail on membership_non_scoring's floor (27 truth items,
+# no headroom) until the fixture is regenerated:
+#
+#   uv run python -m build.identity_eval --write-fixture tests/fixtures/identity_edges_pass.json
+#
+# test_the_pass_fixture_tail_rows_match_the_corpus fails first and names that command, so the
+# floor message is not the only signal.
+#
+# This fixture run is not a substitute for the two never-auto-emit governance rules,
 # which are pinned as pytest tests (test_name_match_never_auto_emits*,
 # test_scoring_bearing_*) and run on every PR through validate.yml regardless of this
 # workflow. Only schedule and workflow_dispatch touch the warehouse.
@@ -33,7 +42,8 @@ name: identity-eval
 # are recoverable at all, and so moves org recall's denominator.
 # sources/model_families.yaml does not exist in this repo yet (Task 4 adds the table it backs);
 # the path is kept as a forward reference so this workflow does not need a second edit when it
-# lands.
+# lands. tests/fixtures/identity_edges_pass.json is a trigger path too: it is what the PR-time
+# run grades, so a commit that only regenerates it has to re-run the eval it is regenerated for.
 
 on:
   schedule:
@@ -49,6 +59,7 @@ on:
       - "sources/organizations/**"
       - "sources/registry/**"
       - "sources/org_handles.yaml"
+      - "tests/fixtures/identity_edges_pass.json"
   pull_request:
     paths:
       - "build/identity*.py"
@@ -58,6 +69,7 @@ on:
       - "sources/organizations/**"
       - "sources/registry/**"
       - "sources/org_handles.yaml"
+      - "tests/fixtures/identity_edges_pass.json"
 
 jobs:
   identity-eval:

--- a/.github/workflows/identity-eval.yml
+++ b/.github/workflows/identity-eval.yml
@@ -25,9 +25,12 @@ name: identity-eval
 # test_scoring_bearing_*) and run on every PR through validate.yml regardless of this
 # workflow. Only schedule and workflow_dispatch touch the warehouse.
 #
-# sources/products/** and sources/organizations/** are in the path triggers because that is
-# where membership, org and artifact-identity TRUTH is built from (build.identity_eval.load_truth)
-# -- a roster edit changes truth without touching build/identity*.py or the ledger.
+# sources/products/**, sources/organizations/**, sources/registry/** and sources/org_handles.yaml
+# are in the path triggers because that is where TRUTH is built from
+# (build.identity_eval.load_truth) -- a roster edit, a tail row or a handle changes truth without
+# touching build/identity*.py or the ledger. Tail rows are declarations too, so sources/registry/**
+# moves membership, org and artifact-identity truth; org_handles.yaml decides which org truth pairs
+# are recoverable at all, and so moves org recall's denominator.
 # sources/model_families.yaml does not exist in this repo yet (Task 4 adds the table it backs);
 # the path is kept as a forward reference so this workflow does not need a second edit when it
 # lands.
@@ -44,6 +47,8 @@ on:
       - "sources/model_families.yaml"
       - "sources/products/**"
       - "sources/organizations/**"
+      - "sources/registry/**"
+      - "sources/org_handles.yaml"
   pull_request:
     paths:
       - "build/identity*.py"
@@ -51,6 +56,8 @@ on:
       - "sources/model_families.yaml"
       - "sources/products/**"
       - "sources/organizations/**"
+      - "sources/registry/**"
+      - "sources/org_handles.yaml"
 
 jobs:
   identity-eval:

--- a/build/identity.py
+++ b/build/identity.py
@@ -178,6 +178,23 @@ def fold_for_proposal(kind: str, ident: str) -> str:
     return c
 
 
+def fold_handle(platform: str, handle: str) -> str:
+    """A declared org handle (`sources/org_handles.yaml`) folded for comparison.
+
+    Case only, plus a leading `www.` stripped for a domain. `build/validate.py` folds this way
+    to enforce one `(platform, handle)` per organization and `build/identity_eval.py` folds
+    this way to decide whether a handle bridges an artifact to an org; both import this, so the
+    uniqueness gate and the eval cannot disagree about which handle matches what.
+
+    Deliberately not `fold_for_proposal`: a handle is an ACCOUNT or a DOMAIN, not an artifact
+    id, so PEP 503 collapsing or crate `-`/`_` folding has no business touching it.
+    """
+    folded = (handle or "").strip().casefold()
+    if platform == "homepage_domain":
+        folded = folded.removeprefix("www.")
+    return folded
+
+
 def _homepage_canonical(url: str) -> str:
     """Scheme-less canonical form: lowercased host minus `www.`, plus the path as
     declared (case kept -- paths can be case-sensitive), minus query/fragment and any

--- a/build/identity_eval.py
+++ b/build/identity_eval.py
@@ -55,12 +55,24 @@ CI with no `OSO_API_KEY`:
   `excluded_boundary`/`excluded_maintenance` is a negative one (the artifact must never
   resolve to *any* product). A `member_of`/`not_member_of` ruling is a positive or negative
   `product_membership` answer, keyed on `(artifact_kind, folded artifact_id, product_slug)`.
-- `sources/products/*.yaml` -- every artifact a product declares is a positive membership
+- `sources/products/*.yaml` -- every artifact a HEAD product declares is a positive membership
   truth. Two or more DISTINCT declared spellings of the same kind that fold to the same
   comparison key are `artifact_identity` truth (a fold-collapse pair) -- there are none in
   the corpus today, so this truth set is empty; see `test_artifact_identity_truth_is_empty_today`.
+- `sources/registry/*.yaml` -- the TAIL. A tail row is a declaration too: somebody wrote down
+  that this artifact is this product's, owned by this org, and the replay question ("would the
+  graph have recovered what a person already declared") does not care which tier the
+  declaration sits in. Tail rows contribute membership truth, `org` truth, and any fold-collapse
+  pairs they form with each other or with a head spelling. Read through
+  `build.serialize_registry.tail_product_rows`/`load_registry` -- the same derivation
+  `registry.tail_products` is built from, so which fields count as artifacts and how a
+  homepage is reduced cannot drift between the table and this eval. Every truth item carries
+  its `tier`, so the table reports the head/tail split of each relation's `n_truth` rather than
+  quietly pooling them.
 - `sources/organizations/*.yaml` -- each org's `products:` roster, bridged through a
-  product's declared artifacts, gives `candidate_key -> org_slug` truth.
+  product's declared artifacts, gives `candidate_key -> org_slug` truth. A tail row names its
+  org directly (`org:`), which is the same truth one step shorter; a tail org need not have an
+  `sources/organizations/<slug>.yaml` file at all, and most today do not.
 - `KNOWN_NEGATIVES` -- artifacts a person has confirmed do NOT belong where a naive signal
   would place them: eight PyPI packages, verified against `sources/scores/*.yaml` notes in
   the `storage` category, that share (or nearly share) a product's name but are that
@@ -100,28 +112,39 @@ artifacts in the corpus today genuinely belong to two orgs each
 which silently kept only the first org read and scored the second as a false positive. Every
 emitted org in the truth set for a candidate counts as correct.
 
-## Org recall is measured against recoverable truth
+## Org recall is measured per handle route, pair by pair
 
 The graph can only recover an org through a declared handle in `sources/org_handles.yaml`
-(`registry.org_handles` once published) -- there is no other route from an artifact to an
-org. Org truth, however, is every declared `(candidate_key, org_slug)` pair bridged through a
-product's org roster, whether or not that org happens to declare a handle -- most of the
-corpus does (302 of 347 orgs, any platform, as of this writing), but a curation gap in
-`org_handles.yaml` is not a graph defect, and scoring recall against the full, unrestricted
-truth set bounds recall at the coverage fraction no matter how good the graph is. So **org
-recall truth is restricted to pairs whose `org_slug` declares at least one handle** (any
-platform) in `sources/org_handles.yaml` -- `Truth.recoverable_orgs`, loaded via the same
-optional-YAML loader `build.validate` uses (`_load_optional_yaml`, tolerant of the file not
-existing at all in an older tree). Precision truth is unchanged: every emitted org edge is
-still judged against the full truth set, since an edge to an org with no handle is either
-wrong (real false positive) or a graph capability this eval has no business hiding.
+(`registry.org_handles` once published) -- there is no other route from an artifact to an org,
+and a route runs from ONE artifact kind to ONE handle platform. So recoverability is a property
+of the `(artifact, org)` PAIR, not of the org: whether the org declares a handle on the route
+that this artifact's kind actually travels.
 
-Two things stay visible so the restriction cannot quietly hide the curation gap: the eval
-prints a `handle coverage: <orgs with >=1 handle>/<orgs rostered> (<pct>)` line (`orgs
-rostered` = every organization with at least one product on its roster, the population org
-truth is drawn from), and `Metrics.n_truth_unrecoverable` -- the truth pairs dropped from
-`org`'s recall denominator because their org has no handle -- appears in the table for every
-relation (0 except for `org`).
+- `github:<owner>/<repo>` -- the org must declare a `github` handle whose folded value equals
+  `<owner>`.
+- `huggingface_model:<ns>/<name>`, `huggingface_dataset:<ns>/<name>` -- a `huggingface` handle
+  equal to `<ns>`.
+- `homepage:<host><path>` -- a `homepage_domain` handle equal to `<host>`, or a parent domain of
+  it (`acme.com` covers `docs.acme.com`).
+- `pypi`, `npm`, `crates`, `arxiv` -- no owner concept in the identifier at all, so no route
+  exists and no handle could ever bridge one. These are excluded from org recall entirely.
+
+An earlier version restricted recall to pairs whose org declared **any** handle on **any**
+platform, which was too generous in both directions at once: it kept a `pypi` pair (structurally
+unrecoverable) because the org happened to declare a homepage, and it kept a `github` pair whose
+org declares only a homepage domain. `ORG_ROUTES` and `org_pair_recoverable` replace that rule.
+
+Precision truth is unchanged: every emitted org edge is judged against the FULL truth set, since
+an edge to an org that declares no matching handle is either wrong (a real false positive) or a
+graph capability this eval has no business hiding.
+
+Two things keep the exclusion visible rather than flattering. `Metrics.n_truth_unrecoverable`
+(in the table for every relation, 0 except `org`) counts the pairs dropped from the recall
+denominator, and `Metrics.unrecoverable_by_kind` breaks that down per artifact kind, printed
+under the table -- so a structural exclusion (`pypi`) and a curation gap (a `github` artifact
+whose org declares no `github` handle) are two readable numbers rather than one lump. And
+`org_handle_coverage` is now per route: for each route, how many of the orgs that actually have
+artifacts on it declare the handle it needs.
 
 ## What `--from-warehouse` supplies, and what it does not
 
@@ -159,9 +182,14 @@ today and the workflow no longer passes it.
 
 A relation's floor is enforced only when `n_truth >= MIN_TRUTH` (20). Below that, the table
 prints `insufficient truth (n)` for that relation and `--floors` cannot exit 1 on it --
-`artifact_identity` (0 truth pairs today) and `membership_non_scoring` (0 truth items with a
-kind that has no adoption route, today only `homepage`, which no product declares) would
-otherwise floor on data that cannot possibly satisfy them, which is exactly the review's M8.
+`artifact_identity` (0 truth pairs today) would otherwise floor on data that cannot possibly
+satisfy it, which is exactly the review's M8.
+
+`membership_non_scoring` was in the same position until tail declarations became truth: the
+only artifact kind with no adoption route is `homepage`, no head product declares one, and the
+tail rows that do were not being read. They are now, which puts the relation over `MIN_TRUTH`
+and under a real floor for the first time. Clearing that floor is the graph's job; a floor that
+now bites is the point of counting the truth, not a reason to raise `MIN_TRUTH`.
 
 ## The two rules pinned as tests, not metrics
 
@@ -191,15 +219,16 @@ import argparse
 import itertools
 import json
 import sys
+from collections import Counter
 from collections.abc import Iterable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 import yaml
 
 from build import resolution
 from build.identity import KINDS, fold_for_proposal
-from build.serialize_registry import artifact_id
+from build.serialize_registry import artifact_id, load_registry, tail_product_rows
 from build.validate import _load_optional_yaml
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -241,6 +270,32 @@ FLOORS: dict[str, tuple[float, float]] = {
 MIN_TRUTH = 20
 
 ALL_RELATIONS = ("equivalence", "membership_scoring", "membership_non_scoring", "artifact_identity", "org")
+
+# The artifact kind -> handle platform routes an artifact can reach an org through, and the only
+# kinds `org` recall is measured over. A kind absent from this map carries no owner in its
+# identifier -- `pypi:torch`, `npm:react`, `crates:serde`, `arxiv:2401.00001` name a package or a
+# paper, never who publishes it -- so no handle on any platform could bridge it, and its truth
+# pairs are counted unrecoverable rather than held against recall. See the module docstring.
+ORG_ROUTES: dict[str, str] = {
+    "github": "github",
+    "huggingface_model": "huggingface",
+    "huggingface_dataset": "huggingface",
+    "homepage": "homepage_domain",
+}
+
+# How each route is labeled in the `handle coverage` line, in print order.
+ORG_ROUTE_LABELS: tuple[tuple[str, str], ...] = (
+    ("github", "github handles"),
+    ("huggingface", "hf handles"),
+    ("homepage_domain", "homepage handles"),
+)
+
+# What a route's coverage denominator is named in that same line.
+ORG_ROUTE_ARTIFACTS: dict[str, str] = {
+    "github": "github",
+    "huggingface": "hf",
+    "homepage_domain": "homepage",
+}
 
 # Eight storage-category products whose same- or near-same-named PyPI package is a verified
 # client library, not the product's own countable artifact -- read from each product's
@@ -444,12 +499,17 @@ class Truth:
     `route_kinds`: artifact kinds `sources/signal_routing.yaml` compiles at least one adoption
     route for -- used only to split membership truth into scoring/non-scoring buckets for
     `n_truth`, mirroring `identity_membership_edges.sql`'s own `scoring_bearing` derivation.
-    `recoverable_orgs`: rostered org slugs (every org with >=1 product on its roster) that
-    declare at least one handle in `sources/org_handles.yaml` -- the graph's only route from an
-    artifact to an org. `org` recall truth is restricted to this set (see the module docstring
-    "Org recall is measured against recoverable truth"); `org` precision truth is not.
-    `orgs_rostered`: every rostered org slug, recoverable or not -- the denominator of the
-    `handle coverage` line (`org_handle_coverage`).
+    `org_handles`: `org_slug -> platform -> {folded handle, ...}`, read from
+    `sources/org_handles.yaml` -- the graph's only route from an artifact to an org, and what
+    `org_pair_recoverable` consults per pair to decide whether a truth pair belongs in `org`'s
+    recall denominator (see the module docstring "Org recall is measured per handle route").
+    `org` precision truth is unrestricted.
+
+    The four `*_tier` maps carry the declaring tier (`"head"`/`"tail"`) of each truth item, so
+    the table can report the split. A key absent from one of them has no known tier -- a ledger
+    ruling naming a product slug that is neither a head product nor a tail row, say -- and
+    counts toward `n_truth` but neither `n_head` nor `n_tail`. `org_tier` prefers `"head"` where
+    a pair is declared in both tiers, since the head declaration is the stronger record.
     """
 
     equivalence: dict[str, str] = field(default_factory=dict)
@@ -458,8 +518,11 @@ class Truth:
     org: dict[str, set[str]] = field(default_factory=dict)
     identity_pairs: set[tuple[str, str, str]] = field(default_factory=set)
     route_kinds: frozenset[str] = field(default_factory=frozenset)
-    recoverable_orgs: frozenset[str] = field(default_factory=frozenset)
-    orgs_rostered: frozenset[str] = field(default_factory=frozenset)
+    org_handles: dict[str, dict[str, frozenset[str]]] = field(default_factory=dict)
+    equivalence_tier: dict[str, str] = field(default_factory=dict)
+    membership_tier: dict[tuple[Key, str], str] = field(default_factory=dict)
+    org_tier: dict[tuple[str, str], str] = field(default_factory=dict)
+    identity_tier: dict[tuple[str, str, str], str] = field(default_factory=dict)
 
 
 @dataclass
@@ -468,10 +531,17 @@ class Metrics:
     recall: float | None
     n_truth: int
     n_emitted_at_threshold: int
-    # Truth pairs excluded from `n_truth`/recall because they cannot be recovered by the graph
-    # at all -- only meaningful for `org` (an org with no declared handle in
-    # `sources/org_handles.yaml`); 0 for every other relation.
+    # Truth pairs excluded from `n_truth`/recall because no handle route could recover them --
+    # only meaningful for `org`; 0 for every other relation. `unrecoverable_by_kind` breaks the
+    # same count down per artifact kind, which is what separates a structural exclusion (`pypi`
+    # has no owner in its identifier) from a curation gap (a `github` artifact whose org
+    # declares no `github` handle).
     n_truth_unrecoverable: int = 0
+    unrecoverable_by_kind: dict[str, int] = field(default_factory=dict)
+    # The head/tail split of `n_truth`. These need not sum to `n_truth`: a truth item whose
+    # declaring tier is unknown counts in neither (see `Truth`'s `*_tier` maps).
+    n_truth_head: int = 0
+    n_truth_tail: int = 0
 
 
 class KnownNegativeDeclaredError(ValueError):
@@ -545,27 +615,94 @@ def _membership_from_ledger(entries: Iterable[dict]) -> dict[tuple[Key, str], bo
 ORG_HANDLES_PATH = ROOT / "sources" / "org_handles.yaml"
 
 
-def _orgs_with_handles(path: Path = ORG_HANDLES_PATH) -> frozenset[str]:
-    """Org slugs that declare at least one handle (any platform) in `sources/org_handles.yaml`.
+def fold_handle(platform: str, handle: str) -> str:
+    """A declared handle folded for comparison against a folded artifact key.
+
+    Case only, plus a leading `www.` stripped for a domain -- the same folding
+    `build/validate.py` applies when it enforces one `(platform, handle)` per organization, so
+    the uniqueness gate and this eval cannot disagree about which handle matches what. Not
+    `fold_for_proposal`: a handle is an ACCOUNT, not an artifact id, and PEP 503 or crate
+    `-`/`_` collapsing has no business touching a GitHub account name.
+    """
+    folded = (handle or "").strip().casefold()
+    if platform == "homepage_domain":
+        folded = folded.removeprefix("www.")
+    return folded
+
+
+def _org_handles(path: Path = ORG_HANDLES_PATH) -> dict[str, dict[str, frozenset[str]]]:
+    """`org_slug -> platform -> {folded handle, ...}` from `sources/org_handles.yaml`.
 
     Reuses `build.validate._load_optional_yaml` -- the same loader `validate_sources` reads
     this file with -- so an older tree that predates the file (no `sources/org_handles.yaml`
-    at all) reads as "no orgs declare a handle" rather than raising, exactly as it does there.
+    at all) reads as "no org declares a handle" rather than raising, exactly as it does there.
     """
     doc = _load_optional_yaml(path, {"version": 1, "handles": []})
-    return frozenset(
-        entry["org"]
-        for entry in doc.get("handles") or []
-        if isinstance(entry, dict) and isinstance(entry.get("org"), str)
-    )
+    by_org: dict[str, dict[str, set[str]]] = {}
+    for entry in doc.get("handles") or []:
+        if not isinstance(entry, dict):
+            continue
+        org_slug, platform, handle = entry.get("org"), entry.get("platform"), entry.get("handle")
+        if not (isinstance(org_slug, str) and isinstance(platform, str) and isinstance(handle, str)):
+            continue
+        by_org.setdefault(org_slug, {}).setdefault(platform, set()).add(fold_handle(platform, handle))
+    return {org: {p: frozenset(h) for p, h in platforms.items()} for org, platforms in by_org.items()}
 
 
-def org_handle_coverage(truth: Truth) -> tuple[int, int]:
-    """`(orgs with >=1 handle, orgs rostered)` -- the two numbers behind the `handle coverage`
-    line. `truth.recoverable_orgs` is already restricted to rostered orgs (see `load_truth`),
-    so its size is the numerator directly.
+def _owner_segment(kind: str, folded_id: str) -> str | None:
+    """The part of a folded artifact key a handle can be compared to, or None if the kind
+    carries no owner. `github`/Hugging Face ids are `<owner>/<name>`; a folded homepage key is
+    `<host><path>`, so the host is everything up to the first `/`.
     """
-    return len(truth.recoverable_orgs), len(truth.orgs_rostered)
+    if kind == "homepage":
+        return folded_id.split("/", 1)[0] or None
+    owner, separator, _name = folded_id.partition("/")
+    return owner if separator and owner else None
+
+
+def org_pair_recoverable(candidate_key_value: str, org_slug: str, truth: Truth) -> bool:
+    """Whether the graph could reach `org_slug` from this artifact through a declared handle.
+
+    True only when the artifact's kind has a handle route (`ORG_ROUTES`) AND the org declares a
+    handle on that route matching the artifact's owner segment. A `homepage_domain` handle also
+    matches a subdomain of itself (`acme.com` covers `docs.acme.com`), which is the one route
+    where the declared handle is deliberately broader than the artifact -- an org publishes one
+    domain and hangs product pages off it. The other routes are exact.
+    """
+    kind, _, folded = (candidate_key_value or "").partition(":")
+    route = ORG_ROUTES.get(kind)
+    if route is None:
+        return False
+    owner = _owner_segment(kind, folded)
+    if not owner:
+        return False
+    handles = truth.org_handles.get(org_slug, {}).get(route) or frozenset()
+    if route == "homepage_domain":
+        return any(owner == handle or owner.endswith(f".{handle}") for handle in handles)
+    return owner in handles
+
+
+def org_handle_coverage(truth: Truth) -> dict[str, tuple[int, int]]:
+    """Per route: `(orgs declaring the handle that route needs, orgs with artifacts on it)`.
+
+    The denominator is the population that route's recall is actually drawn from -- orgs that
+    own at least one artifact of a kind travelling that route -- not every rostered org, which
+    would mix a missing `huggingface` handle into `github`'s coverage and back.
+    """
+    per_route: dict[str, tuple[set[str], set[str]]] = {
+        route: (set(), set()) for route in ORG_ROUTES.values()
+    }
+    for ck, orgs in truth.org.items():
+        kind, _, _folded = ck.partition(":")
+        route = ORG_ROUTES.get(kind)
+        if route is None:
+            continue
+        with_handle, rostered = per_route[route]
+        for org_slug in orgs:
+            rostered.add(org_slug)
+            if truth.org_handles.get(org_slug, {}).get(route):
+                with_handle.add(org_slug)
+    return {route: (len(with_handle), len(rostered)) for route, (with_handle, rostered) in per_route.items()}
 
 
 def _route_kinds() -> frozenset[str]:
@@ -598,25 +735,51 @@ def load_truth(known_negatives: tuple[dict[str, str], ...] = KNOWN_NEGATIVES) ->
     membership = _membership_from_ledger(ledger_items)
 
     products = _declared_products()
+    # Tail declarations are truth too -- see the module docstring. Read through
+    # `serialize_registry`'s own derivation so this eval and `registry.tail_products` cannot
+    # disagree about which tail fields are artifacts.
+    tail_rows = tail_product_rows(load_registry(ROOT))
+    head_slugs = set(products)
+    tail_slugs = {row["slug"] for row in tail_rows if row["slug"]}
+
+    def tier_of_product(slug: str | None) -> str | None:
+        if slug in head_slugs:
+            return "head"
+        if slug in tail_slugs:
+            return "tail"
+        return None
 
     # fold-collapse artifact_identity truth: distinct declared spellings of one kind that fold
-    # to the same comparison key. None exist in the corpus today (see the module docstring),
-    # so this is deliberately built from first principles rather than assumed empty.
-    by_key: dict[Key, set[str]] = {}
+    # to the same comparison key, from either tier. None exist in the corpus today (see the
+    # module docstring), so this is deliberately built from first principles rather than
+    # assumed empty.
+    by_key: dict[Key, dict[str, str]] = {}
     for product in products.values():
         for kind in KINDS:
             for entry in product.get(kind) or []:
                 ident = artifact_id(kind, entry.get("url") or "")
                 if ident:
-                    by_key.setdefault((kind, fold_for_proposal(kind, ident)), set()).add(ident)
+                    by_key.setdefault((kind, fold_for_proposal(kind, ident)), {})[ident] = "head"
+    for row in tail_rows:
+        kind, ident = row["artifact_kind"], row["artifact_id"]
+        if ident:
+            by_key.setdefault((kind, fold_for_proposal(kind, ident)), {}).setdefault(ident, "tail")
+
     identity_pairs: set[tuple[str, str, str]] = set()
+    identity_tier: dict[tuple[str, str, str], str] = {}
     for (kind, _folded), spellings in by_key.items():
         if len(spellings) < 2:
             continue
         for a, b in itertools.combinations(sorted(spellings), 2):
             fa, fb = fold_for_proposal(kind, a), fold_for_proposal(kind, b)
             lo, hi = sorted((fa, fb))
-            identity_pairs.add((kind, lo, hi))
+            pair = (kind, lo, hi)
+            identity_pairs.add(pair)
+            # A pair spanning both tiers is recorded as head: the head declaration is the
+            # stronger record, and a mixed pair counted twice would double the split.
+            tier = "head" if "head" in (spellings[a], spellings[b]) else "tail"
+            if identity_tier.get(pair) != "head":
+                identity_tier[pair] = tier
 
     # Declared artifacts: positive membership truth, and org truth bridged through each
     # product's org(s). `product_org` is `product_slug -> {org_slug, ...}` -- a SET, not a
@@ -629,7 +792,15 @@ def load_truth(known_negatives: tuple[dict[str, str], ...] = KNOWN_NEGATIVES) ->
         for slug in roster.get("products") or []:
             product_org.setdefault(slug, set()).add(path.stem)
 
+    membership_tier: dict[tuple[Key, str], str] = {}
     org: dict[str, set[str]] = {}
+    org_tier: dict[tuple[str, str], str] = {}
+
+    def record_org(ck: str, org_slug: str, tier: str) -> None:
+        org.setdefault(ck, set()).add(org_slug)
+        if org_tier.get((ck, org_slug)) != "head":
+            org_tier[(ck, org_slug)] = tier
+
     for slug, product in products.items():
         for kind in KINDS:
             for entry in product.get(kind) or []:
@@ -638,8 +809,34 @@ def load_truth(known_negatives: tuple[dict[str, str], ...] = KNOWN_NEGATIVES) ->
                     continue
                 key = _membership_key(kind, ident)
                 membership.setdefault((key, slug), True)
-                if slug in product_org:
-                    org.setdefault(candidate_key(kind, ident), set()).update(product_org[slug])
+                membership_tier[(key, slug)] = "head"
+                for org_slug in product_org.get(slug, ()):
+                    record_org(candidate_key(kind, ident), org_slug, "head")
+
+    # The tail, same two relations. A tail row names its org directly rather than through a
+    # roster, and that org need not have a `sources/organizations/<slug>.yaml` file at all --
+    # most tail orgs today do not, which is why their pairs land in `n_truth_unrecoverable`
+    # (no file, no handles, no route) rather than dragging recall down.
+    for row in tail_rows:
+        kind, ident, slug = row["artifact_kind"], row["artifact_id"], row["slug"]
+        if not (ident and slug):
+            continue
+        key = _membership_key(kind, ident)
+        membership.setdefault((key, slug), True)
+        if membership_tier.get((key, slug)) != "head":
+            membership_tier[(key, slug)] = "tail"
+        if row.get("org_slug"):
+            record_org(candidate_key(kind, ident), row["org_slug"], "tail")
+
+    # Ledger rulings carry no tier of their own; the product they name does.
+    for (key, slug) in membership:
+        if (key, slug) not in membership_tier:
+            tier = tier_of_product(slug)
+            if tier:
+                membership_tier[(key, slug)] = tier
+    equivalence_tier = {
+        ck: tier for ck, slug in equivalence.items() if (tier := tier_of_product(slug))
+    }
 
     declared_true = {(k, s) for (k, s), is_member in membership.items() if is_member}
     for neg in known_negatives:
@@ -653,9 +850,6 @@ def load_truth(known_negatives: tuple[dict[str, str], ...] = KNOWN_NEGATIVES) ->
             )
         membership[(key, neg["product_slug"])] = False
 
-    orgs_rostered = frozenset(o for orgs in product_org.values() for o in orgs)
-    recoverable_orgs = orgs_rostered & _orgs_with_handles()
-
     return Truth(
         equivalence=equivalence,
         equivalence_negatives=equivalence_negatives,
@@ -663,8 +857,11 @@ def load_truth(known_negatives: tuple[dict[str, str], ...] = KNOWN_NEGATIVES) ->
         org=org,
         identity_pairs=identity_pairs,
         route_kinds=_route_kinds(),
-        recoverable_orgs=recoverable_orgs,
-        orgs_rostered=orgs_rostered,
+        org_handles=_org_handles(),
+        equivalence_tier=equivalence_tier,
+        membership_tier=membership_tier,
+        org_tier=org_tier,
+        identity_tier=identity_tier,
     )
 
 
@@ -689,6 +886,14 @@ def _score(emitted: list[dict], key_fn, correct_fn, n_truth: int) -> Metrics:
     return Metrics(precision, recall, n_truth, n_emitted)
 
 
+def _tier_counts(keys: Iterable, tiers: dict) -> tuple[int, int]:
+    """`(n_head, n_tail)` over `keys`, read from a `Truth.*_tier` map. A key the map does not
+    carry has no known tier and counts in neither, so these need not sum to `n_truth`.
+    """
+    counted = Counter(tiers.get(key) for key in keys)
+    return counted["head"], counted["tail"]
+
+
 def _score_equivalence(emitted: list[dict], truth: Truth) -> Metrics:
     def correct_fn(e: dict):
         ck, slug = e.get("candidate_key"), e.get("product_slug")
@@ -697,7 +902,9 @@ def _score_equivalence(emitted: list[dict], truth: Truth) -> Metrics:
         ok = truth.equivalence.get(ck) == slug
         return ok, (ck if ok else None)
 
-    return _score(emitted, _equivalence_key, correct_fn, len(truth.equivalence))
+    metrics = _score(emitted, _equivalence_key, correct_fn, len(truth.equivalence))
+    metrics.n_truth_head, metrics.n_truth_tail = _tier_counts(truth.equivalence, truth.equivalence_tier)
+    return metrics
 
 
 def _score_membership(emitted: list[dict], truth: Truth, scoring_bearing: bool) -> Metrics:
@@ -709,12 +916,14 @@ def _score_membership(emitted: list[dict], truth: Truth, scoring_bearing: bool) 
         ok = truth.membership.get(k) is True
         return ok, (k if ok else None)
 
-    n_truth = sum(
-        1
-        for (key, _slug), is_member in truth.membership.items()
+    counted = [
+        (key, slug)
+        for (key, slug), is_member in truth.membership.items()
         if is_member and (key[0] in truth.route_kinds) == scoring_bearing
-    )
-    return _score(emitted, key_fn, correct_fn, n_truth)
+    ]
+    metrics = _score(emitted, key_fn, correct_fn, len(counted))
+    metrics.n_truth_head, metrics.n_truth_tail = _tier_counts(counted, truth.membership_tier)
+    return metrics
 
 
 def _score_org(emitted: list[dict], truth: Truth) -> Metrics:
@@ -724,24 +933,29 @@ def _score_org(emitted: list[dict], truth: Truth) -> Metrics:
     `(candidate_key, org_slug)` PAIRS, not distinct candidate_keys, so a two-org artifact
     counts as two truth items for recall, not one.
 
-    Recall truth is further restricted to pairs whose org declares a handle
-    (`truth.recoverable_orgs` -- see the module docstring "Org recall is measured against
-    recoverable truth"); precision truth is not. `correct_fn` returns `tk = None` for a
-    correct-but-unrecoverable match, which keeps it out of `matched_truth`/recall (via `_score`
-    filtering `tk is not None`) while it still counts toward `n_correct`/precision, since
-    `is_correct` is `True` either way.
+    Recall truth is restricted to pairs `org_pair_recoverable` accepts -- the artifact's kind
+    has a handle route and the org declares a matching handle on it (see the module docstring
+    "Org recall is measured per handle route"); precision truth is not. `correct_fn` returns
+    `tk = None` for a correct-but-unrecoverable match, which keeps it out of
+    `matched_truth`/recall (via `_score` filtering `tk is not None`) while it still counts
+    toward `n_correct`/precision, since `is_correct` is `True` either way.
     """
 
     def correct_fn(e: dict):
         ck, slug = e.get("candidate_key"), e.get("org_slug")
         ok = slug in truth.org.get(ck, ())
-        recoverable = ok and slug in truth.recoverable_orgs
+        recoverable = ok and org_pair_recoverable(ck, slug, truth)
         return ok, ((ck, slug) if recoverable else None)
 
-    n_truth_total = sum(len(orgs) for orgs in truth.org.values())
-    n_truth = sum(1 for orgs in truth.org.values() for slug in orgs if slug in truth.recoverable_orgs)
-    metrics = _score(emitted, _org_key, correct_fn, n_truth)
-    metrics.n_truth_unrecoverable = n_truth_total - n_truth
+    pairs = [(ck, slug) for ck, orgs in truth.org.items() for slug in orgs]
+    recoverable_pairs = [pair for pair in pairs if org_pair_recoverable(*pair, truth)]
+    metrics = _score(emitted, _org_key, correct_fn, len(recoverable_pairs))
+    metrics.n_truth_unrecoverable = len(pairs) - len(recoverable_pairs)
+    unrecoverable = set(pairs) - set(recoverable_pairs)
+    metrics.unrecoverable_by_kind = dict(
+        sorted(Counter(ck.partition(":")[0] for ck, _slug in unrecoverable).items())
+    )
+    metrics.n_truth_head, metrics.n_truth_tail = _tier_counts(recoverable_pairs, truth.org_tier)
     return metrics
 
 
@@ -759,7 +973,9 @@ def _score_identity(emitted: list[dict], truth: Truth) -> Metrics:
         ok = pair in truth.identity_pairs
         return ok, (pair if ok else None)
 
-    return _score(emitted, _identity_pair, correct_fn, len(truth.identity_pairs))
+    metrics = _score(emitted, _identity_pair, correct_fn, len(truth.identity_pairs))
+    metrics.n_truth_head, metrics.n_truth_tail = _tier_counts(truth.identity_pairs, truth.identity_tier)
+    return metrics
 
 
 def _score_tiered(rows: list[dict], truth: Truth, relation: str, score_fn, key_fn) -> Metrics:
@@ -774,7 +990,9 @@ def _score_tiered(rows: list[dict], truth: Truth, relation: str, score_fn, key_f
     emitted_pool = [e for e in pool if emits(e, relation)]
     metrics = score_fn(emitted_declared, truth)
     pool_count = len({key_fn(e) for e in emitted_pool})
-    return Metrics(metrics.precision, metrics.recall, metrics.n_truth, pool_count, metrics.n_truth_unrecoverable)
+    # `replace`, not a positional rebuild: every field but the emitted count carries over, so a
+    # new `Metrics` field cannot be silently dropped here the way a positional call would drop it.
+    return replace(metrics, n_emitted_at_threshold=pool_count)
 
 
 def replay(edges: dict[str, list[dict]], truth: Truth) -> dict[str, Metrics]:
@@ -1035,9 +1253,15 @@ def floor_failures(metrics: dict[str, Metrics]) -> list[str]:
 
 
 def print_table(metrics: dict[str, Metrics]) -> None:
+    """The per-relation table, then the `org` unrecoverable breakdown under it.
+
+    `n_head`/`n_tail` split `n_truth` by the tier that declared each truth item; they need not
+    sum to `n_truth` (a ledger ruling naming neither a head product nor a tail row has no
+    tier). The breakdown line prints only for relations that have one, which today is `org`.
+    """
     header = (
         f"{'relation':24s} {'precision':>10s} {'recall':>10s} {'n_truth':>8s} "
-        f"{'n_emitted':>10s} {'n_unrecov':>10s}  status"
+        f"{'n_head':>8s} {'n_tail':>8s} {'n_emitted':>10s} {'n_unrecov':>10s}  status"
     )
     print(header)
     print("-" * len(header))
@@ -1045,13 +1269,17 @@ def print_table(metrics: dict[str, Metrics]) -> None:
         m = metrics.get(relation)
         precision = f"{m.precision:.3f}" if m and m.precision is not None else "n/a"
         recall = f"{m.recall:.3f}" if m and m.recall is not None else "n/a"
-        n_truth = m.n_truth if m else 0
-        n_emitted = m.n_emitted_at_threshold if m else 0
-        n_unrecov = m.n_truth_unrecoverable if m else 0
         print(
-            f"{relation:24s} {precision:>10s} {recall:>10s} {n_truth:>8d} {n_emitted:>10d} "
-            f"{n_unrecov:>10d}  {floor_status(relation, metrics)}"
+            f"{relation:24s} {precision:>10s} {recall:>10s} {(m.n_truth if m else 0):>8d} "
+            f"{(m.n_truth_head if m else 0):>8d} {(m.n_truth_tail if m else 0):>8d} "
+            f"{(m.n_emitted_at_threshold if m else 0):>10d} "
+            f"{(m.n_truth_unrecoverable if m else 0):>10d}  {floor_status(relation, metrics)}"
         )
+    for relation in ALL_RELATIONS:
+        m = metrics.get(relation)
+        if m and m.unrecoverable_by_kind:
+            breakdown = ", ".join(f"{kind} {count}" for kind, count in m.unrecoverable_by_kind.items())
+            print(f"\n{relation} truth with no handle route ({m.n_truth_unrecoverable}): {breakdown}")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1132,9 +1360,15 @@ def main(argv: list[str] | None = None) -> int:
     metrics = replay(edges, truth)
     print_table(metrics)
 
-    n_with_handle, n_rostered = org_handle_coverage(truth)
-    pct = (100 * n_with_handle / n_rostered) if n_rostered else 0.0
-    print(f"\nhandle coverage: {n_with_handle}/{n_rostered} ({pct:.1f}%)")
+    coverage = org_handle_coverage(truth)
+    parts = []
+    for route, label in ORG_ROUTE_LABELS:
+        n_with_handle, n_rostered = coverage.get(route, (0, 0))
+        parts.append(
+            f"{label} {n_with_handle}/{n_rostered} orgs with "
+            f"{ORG_ROUTE_ARTIFACTS[route]} artifacts"
+        )
+    print("\nhandle coverage: " + "; ".join(parts))
 
     if args.floors:
         failures = floor_failures(metrics)

--- a/build/identity_eval.py
+++ b/build/identity_eval.py
@@ -138,7 +138,7 @@ Precision truth is unchanged: every emitted org edge is judged against the FULL 
 an edge to an org that declares no matching handle is either wrong (a real false positive) or a
 graph capability this eval has no business hiding.
 
-Two things keep the exclusion visible rather than flattering. `Metrics.n_truth_unrecoverable`
+Two things keep the exclusion legible in the output. `Metrics.n_truth_unrecoverable`
 (in the table for every relation, 0 except `org`) counts the pairs dropped from the recall
 denominator, and `Metrics.unrecoverable_by_kind` breaks that down per artifact kind, printed
 under the table -- so a structural exclusion (`pypi`) and a curation gap (a `github` artifact
@@ -191,6 +191,27 @@ tail rows that do were not being read. They are now, which puts the relation ove
 and under a real floor for the first time. Clearing that floor is the graph's job; a floor that
 now bites is the point of counting the truth, not a reason to raise `MIN_TRUTH`.
 
+## `membership_non_scoring` has no headroom, so read its failures twice
+
+Its truth set is the tail's homepage declarations and nothing else -- 27 today. One wrong or
+missing edge is a ~3.7% swing, which is already more than the 0.98 precision floor allows. Two
+things that are not regressions land as a failure on that row, and `FLOOR_NOTES` prints both
+next to it so a log alone is enough to tell them apart:
+
+- **Publish lag.** Truth is the repo; the edges are the warehouse. A tail homepage row edited or
+  deleted in `sources/registry/*.yaml` is still emitted from the last published
+  `registry.tail_products` until the weekly publish lands, so the scheduled Monday run can go
+  red on precision for an edit that is already correct. The fix is a republish, not a graph
+  change -- diff `sources/registry/*.yaml` against the published table before reading it as a
+  defect.
+- **A stale fixture.** The committed pass fixture carries the corpus's tail rows, so the same
+  edit makes the PR-time fixture run fail too. `--write-fixture` regenerates that block, and
+  `test_the_pass_fixture_tail_rows_match_the_corpus` fails first, naming the fixture, so the
+  floor message is not the only thing pointing at it.
+
+Neither is a reason to widen the floor or raise `MIN_TRUTH`. The relation is small because the
+tail's homepage coverage is small; it gets headroom by the corpus growing.
+
 ## The two rules pinned as tests, not metrics
 
 A metric is a rate that is allowed to miss sometimes. These are not that:
@@ -227,7 +248,7 @@ from pathlib import Path
 import yaml
 
 from build import resolution
-from build.identity import KINDS, fold_for_proposal
+from build.identity import KINDS, fold_for_proposal, fold_handle
 from build.serialize_registry import artifact_id, load_registry, tail_product_rows
 from build.validate import _load_optional_yaml
 
@@ -266,8 +287,24 @@ FLOORS: dict[str, tuple[float, float]] = {
 }
 
 # Below this many truth items, a floor cannot mean anything -- see the module docstring on
-# `artifact_identity` and `membership_non_scoring`, both 0 in the corpus today.
+# `artifact_identity`, 0 in the corpus today.
 MIN_TRUTH = 20
+
+# Printed under a floor failure for the named relation. What goes here is the reading a log
+# alone cannot supply: which failures are not regressions. See the module docstring's
+# "membership_non_scoring has no headroom" section for the arithmetic.
+FLOOR_NOTES: dict[str, str] = {
+    "membership_non_scoring": (
+        "this relation's entire truth set is the tail's homepage declarations (27 today), so a\n"
+        "  SINGLE wrong or missing edge is a ~3.7% swing -- there is no headroom by construction.\n"
+        "  Two non-regressions look like this failure. (1) A tail homepage row edited in the repo\n"
+        "  is still emitted by the warehouse until the weekly registry publish lands, so a red\n"
+        "  scheduled run soon after such an edit means republish, not regression -- check\n"
+        "  sources/registry/*.yaml against the published registry.tail_products before reading it\n"
+        "  as a graph defect. (2) On a fixture run, the fixture's own tail rows may be stale:\n"
+        "  regenerate with `uv run python -m build.identity_eval --write-fixture <path>`."
+    ),
+}
 
 ALL_RELATIONS = ("equivalence", "membership_scoring", "membership_non_scoring", "artifact_identity", "org")
 
@@ -613,21 +650,6 @@ def _membership_from_ledger(entries: Iterable[dict]) -> dict[tuple[Key, str], bo
 
 
 ORG_HANDLES_PATH = ROOT / "sources" / "org_handles.yaml"
-
-
-def fold_handle(platform: str, handle: str) -> str:
-    """A declared handle folded for comparison against a folded artifact key.
-
-    Case only, plus a leading `www.` stripped for a domain -- the same folding
-    `build/validate.py` applies when it enforces one `(platform, handle)` per organization, so
-    the uniqueness gate and this eval cannot disagree about which handle matches what. Not
-    `fold_for_proposal`: a handle is an ACCOUNT, not an artifact id, and PEP 503 or crate
-    `-`/`_` collapsing has no business touching a GitHub account name.
-    """
-    folded = (handle or "").strip().casefold()
-    if platform == "homepage_domain":
-        folded = folded.removeprefix("www.")
-    return folded
 
 
 def _org_handles(path: Path = ORG_HANDLES_PATH) -> dict[str, dict[str, frozenset[str]]]:
@@ -1185,6 +1207,63 @@ def load_edges_from_file(path: Path) -> dict[str, list[dict]]:
     return json.loads(path.read_text())
 
 
+# The confidence and method a fixture's tail membership rows carry. Not a claim about what the
+# deployed model emits for any particular row: 0.95 clears `membership_non_scoring`'s 0.90
+# threshold, and `declared` is what a declaration-sourced membership edge is labeled, which is
+# all the fixture needs to exercise the scoring path.
+FIXTURE_TAIL_CONFIDENCE = 0.95
+FIXTURE_TAIL_METHOD = ("declared",)
+
+
+def tail_membership_rows(route_kinds: frozenset[str]) -> list[dict]:
+    """The `membership` rows a fixture should carry for the tail, in `WAREHOUSE_COLUMNS` shape.
+
+    Derived from the same `tail_product_rows` truth is, so a fixture regenerated with
+    `--write-fixture` is the corpus's tail declarations and nothing else. `scoring_bearing`
+    mirrors the deployed SQL's own derivation (does the kind have an adoption route), which is
+    why this takes `route_kinds` rather than hardcoding `homepage`.
+    """
+    return [
+        {
+            "artifact_kind": row["artifact_kind"],
+            "artifact_id": row["artifact_id"],
+            "product_tier": "tail",
+            "product_slug": row["slug"],
+            "confidence": FIXTURE_TAIL_CONFIDENCE,
+            "method": list(FIXTURE_TAIL_METHOD),
+            "penalties": [],
+            "scoring_bearing": row["artifact_kind"] in route_kinds,
+        }
+        for row in sorted(
+            tail_product_rows(load_registry(ROOT)),
+            key=lambda r: (r["slug"], r["artifact_kind"], r["artifact_id"]),
+        )
+    ]
+
+
+def write_fixture(path: Path, route_kinds: frozenset[str]) -> tuple[int, int]:
+    """Regenerate `path`'s tail membership rows from the tail registry, in place.
+
+    Every other row and relation is left exactly as it was -- only `membership` rows with
+    `product_tier: "tail"` are replaced, so a hand-written head row keeps its wording and a
+    regeneration diff shows the corpus change and nothing else. Returns `(rows removed, rows
+    written)`.
+
+    The fixture stays COMMITTED rather than being generated at test time on purpose: it is what
+    the `identity-eval` workflow grades on every PR, and a gate that builds its own input from
+    the corpus it then grades against cannot fail. Committing it keeps the tail block reviewable
+    in a diff, and `test_the_pass_fixture_tail_rows_match_the_corpus` is what catches it going
+    stale.
+    """
+    doc = json.loads(path.read_text())
+    kept = [row for row in doc.get("membership") or [] if row.get("product_tier") != "tail"]
+    generated = tail_membership_rows(route_kinds)
+    removed = len(doc.get("membership") or []) - len(kept)
+    doc["membership"] = kept + generated
+    path.write_text(json.dumps(doc, indent=2) + "\n")
+    return removed, len(generated)
+
+
 def validate_columns(edges: dict[str, list[dict]]) -> None:
     """Every row of every relation `REQUIRED_COLUMNS` names carries those columns with a
     non-null value. Raises `EdgeColumnMissing` naming the first offending relation and
@@ -1287,6 +1366,14 @@ def main(argv: list[str] | None = None) -> int:
     source = parser.add_mutually_exclusive_group(required=True)
     source.add_argument("--from-warehouse", action="store_true", help="read the four identity edge tables live")
     source.add_argument("--edges", type=Path, help="path to a JSON fixture of edges, keyed by relation")
+    source.add_argument(
+        "--write-fixture", type=Path, metavar="PATH",
+        help=(
+            "regenerate a fixture's tail membership rows from sources/registry/*.yaml and exit "
+            "(scores nothing). Run this after a tail registry edit changes which artifacts the "
+            "tail declares."
+        ),
+    )
     parser.add_argument(
         "--floors", action="store_true",
         help="exit 1 if any relation with automation planned and sufficient truth falls under its floor",
@@ -1305,6 +1392,14 @@ def main(argv: list[str] | None = None) -> int:
     if args.allow_unprovisioned and not args.from_warehouse:
         print("[FAIL] --allow-unprovisioned only applies to --from-warehouse")
         return 2
+
+    if args.write_fixture:
+        removed, written = write_fixture(args.write_fixture, _route_kinds())
+        print(
+            f"{args.write_fixture}: replaced {removed} tail membership row(s) with {written} "
+            f"derived from sources/registry/*.yaml"
+        )
+        return 0
 
     if args.from_warehouse:
         if args.allow_unprovisioned:
@@ -1376,6 +1471,9 @@ def main(argv: list[str] | None = None) -> int:
             print("\n[FAIL] under floor:")
             for line in failures:
                 print(f"  {line}")
+            for relation, note in FLOOR_NOTES.items():
+                if any(failure.startswith(f"{relation}:") for failure in failures):
+                    print(f"\n  {relation}: {note}")
             return 1
         print("\n[OK] every checked relation clears its precision/recall floor")
 

--- a/build/serialize_registry.py
+++ b/build/serialize_registry.py
@@ -56,6 +56,8 @@ import csv
 import sys
 from pathlib import Path
 
+import yaml
+
 from build.identity import ARXIV_ID, canonical, homepage_canonical_url, id_from_url
 from build.resolution import artifact_of as _ledger_artifact_of
 from build.resolution import load as load_resolution_ledger
@@ -177,6 +179,93 @@ def category_layers(taxonomy: dict) -> dict[str, tuple[str, str]]:
             if isinstance(name, str) and isinstance(layer, str):
                 out[slug] = (name, layer)
     return out
+
+
+# Appended (crates, arxiv, homepage) rather than inserted, so existing per-kind ordering
+# in any downstream diff or fixture is undisturbed -- #365 added crates/arxiv as tail row
+# fields but they were still absent here, so a crates- or arxiv-only tail row validated
+# and then silently produced no `tail_products` row at all. `homepage` had the identical
+# bug: a homepage-only tail row satisfies the `anyOf` in the schema and validates, but
+# emitted zero `tail_products` rows because this list never carried it.
+TAIL_ARTIFACT_KINDS = (
+    "github", "pypi", "npm", "huggingface_model", "huggingface_dataset",
+    "crates", "arxiv", "homepage",
+)
+
+
+def load_registry(root: Path = ROOT) -> dict:
+    """The tail registry records, keyed by category slug.
+
+    The same shape `build.validate.load_sources` puts under its `registry` key, loaded on its
+    own for a caller that needs the tail rows and nothing else (`build.identity_eval`) --
+    `load_sources` reads the whole scored corpus, which is several seconds this caller has no
+    use for.
+    """
+    return {
+        path.stem: yaml.safe_load(path.read_text()) or {}
+        for path in sorted((root / "sources" / "registry").glob("*.yaml"))
+    }
+
+
+def tail_artifact_url(kind: str, identifier: str) -> str:
+    """The dereferenceable URL for a tail row's artifact of this kind.
+
+    Unlike the other kinds, a tail row's `homepage` field is already a full URI (see
+    docs/schemas/registry.schema.json), so it goes through `homepage_canonical_url` rather
+    than the per-kind templating.
+    """
+    if kind == "homepage":
+        return homepage_canonical_url(identifier)
+    if kind == "github":
+        return f"https://github.com/{identifier}"
+    if kind == "pypi":
+        return f"https://pypi.org/project/{identifier}/"
+    if kind == "npm":
+        return f"https://www.npmjs.com/package/{identifier}"
+    if kind == "huggingface_model":
+        return f"https://huggingface.co/{identifier}"
+    if kind == "huggingface_dataset":
+        return f"https://huggingface.co/datasets/{identifier}"
+    if kind == "crates":
+        return f"https://crates.io/crates/{identifier}"
+    if kind == "arxiv":
+        return f"https://arxiv.org/abs/{identifier}"
+    raise ValueError(kind)
+
+
+def tail_product_rows(registry: dict) -> list[dict]:
+    """One `tail_products` row per (tail product, declared artifact).
+
+    Split out of `build_registry` so `build.identity_eval` can read tail declarations as
+    replay truth through the same derivation rather than re-parsing `sources/registry/*.yaml`
+    with its own idea of which fields are artifacts. `artifact_id` carries a homepage's full
+    canonical URL (host + path), not the bare domain -- a homepage is evidence, not identity,
+    and two products sharing a company's domain at different paths are not a collision (see
+    docs/reference/identity.md). SQL that wants the domain alone derives it from this URL
+    rather than reading a separate column; `homepage_domain` stays available for that
+    derivation but is not stored here.
+    """
+    rows: list[dict] = []
+    for category_slug, record in sorted(registry.items()):
+        for product in record.get("products") or []:
+            for kind in TAIL_ARTIFACT_KINDS:
+                identifier = product.get(kind)
+                if not identifier:
+                    continue
+                row_artifact_id = canonical("homepage", identifier) if kind == "homepage" else identifier
+                rows.append(
+                    {
+                        "slug": product.get("slug", ""),
+                        "display_name": product.get("display_name", ""),
+                        "product_type": product.get("type", ""),
+                        "org_slug": product.get("org", ""),
+                        "category_slug": category_slug,
+                        "artifact_kind": kind,
+                        "artifact_id": row_artifact_id,
+                        "artifact_url": tail_artifact_url(kind, identifier),
+                    }
+                )
+    return rows
 
 
 def build_registry(sources: dict) -> tuple[dict[str, list[dict]], list[str], list[str]]:
@@ -327,62 +416,7 @@ def build_registry(sources: dict) -> tuple[dict[str, list[dict]], list[str], lis
                 {"product_slug": product_slug, "category_slug": slug}
             )
 
-    # Appended (crates, arxiv, homepage) rather than inserted, so existing per-kind ordering
-    # in any downstream diff or fixture is undisturbed -- #365 added crates/arxiv as tail row
-    # fields but they were still absent here, so a crates- or arxiv-only tail row validated
-    # and then silently produced no `tail_products` row at all. `homepage` had the identical
-    # bug: a homepage-only tail row satisfies the `anyOf` in the schema and validates, but
-    # emitted zero `tail_products` rows because this list never carried it. Unlike the other
-    # kinds, a tail row's `homepage` field is already a full URI (see
-    # docs/schemas/registry.schema.json), so it is reduced with `canonical`/
-    # `homepage_canonical_url` directly rather than through the URL-templating below.
-    # `artifact_id` carries the full canonical URL (host + path), not the bare domain --
-    # a homepage is evidence, not identity, and two products sharing a company's domain
-    # at different paths are not a collision (see docs/reference/identity.md). SQL that
-    # wants the domain alone derives it from this URL rather than reading a separate
-    # column; `homepage_domain` stays available for that derivation but is not stored
-    # here.
-    tail_artifact_kinds = (
-        "github", "pypi", "npm", "huggingface_model", "huggingface_dataset",
-        "crates", "arxiv", "homepage",
-    )
-    for category_slug, record in sorted(registry.items()):
-        for product in record.get("products") or []:
-            for kind in tail_artifact_kinds:
-                identifier = product.get(kind)
-                if not identifier:
-                    continue
-                if kind == "homepage":
-                    row_artifact_id = canonical("homepage", identifier)
-                    url = homepage_canonical_url(identifier)
-                else:
-                    row_artifact_id = identifier
-                    if kind == "github":
-                        url = f"https://github.com/{identifier}"
-                    elif kind == "pypi":
-                        url = f"https://pypi.org/project/{identifier}/"
-                    elif kind == "npm":
-                        url = f"https://www.npmjs.com/package/{identifier}"
-                    elif kind == "huggingface_model":
-                        url = f"https://huggingface.co/{identifier}"
-                    elif kind == "huggingface_dataset":
-                        url = f"https://huggingface.co/datasets/{identifier}"
-                    elif kind == "crates":
-                        url = f"https://crates.io/crates/{identifier}"
-                    else:
-                        url = f"https://arxiv.org/abs/{identifier}"
-                tables["tail_products"].append(
-                    {
-                        "slug": product.get("slug", ""),
-                        "display_name": product.get("display_name", ""),
-                        "product_type": product.get("type", ""),
-                        "org_slug": product.get("org", ""),
-                        "category_slug": category_slug,
-                        "artifact_kind": kind,
-                        "artifact_id": row_artifact_id,
-                        "artifact_url": url,
-                    }
-                )
+    tables["tail_products"].extend(tail_product_rows(registry))
 
     # The decision memory: one row per (artifact, relation, resolves_to) ruling, exactly the
     # grain `build.resolution.load` keys on -- a `product_membership` ruling is a statement

--- a/build/validate.py
+++ b/build/validate.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import jsonschema
 import yaml
 
-from build.identity import fold_for_proposal, id_from_url
+from build.identity import fold_for_proposal, fold_handle, id_from_url
 from build.resolution import LEDGER
 from build.vocabulary import axes, SIGNAL_TYPES
 
@@ -400,8 +400,10 @@ def validate_sources(data: dict, *, ledger_path: Path = LEDGER) -> list[str]:
     # `schemas` is loaded; the two cross-file checks here do not need it: `org` must resolve
     # to a real organization, and a handle is ownership evidence, so evidence that names two
     # owners is not evidence of either -- one (platform, handle) pair may belong to one org
-    # only. Compared folded (casefold; homepage_domain additionally strips a leading "www.")
-    # so two spellings of the same account do not slip past as distinct.
+    # only. Compared through `build.identity.fold_handle` (casefold; homepage_domain additionally
+    # strips a leading "www.") so two spellings of the same account do not slip past as distinct
+    # -- the same helper `build/identity_eval.py` folds with when it decides whether a handle
+    # bridges an artifact to an org, rather than a fifth hand-mirror of the rule.
     org_handles = data.get("org_handles") or {}
     handle_owner: dict[tuple[str, str], str] = {}
     for entry in org_handles.get("handles") or []:
@@ -416,10 +418,7 @@ def validate_sources(data: dict, *, ledger_path: Path = LEDGER) -> list[str]:
                 f"{oslug!r}, which has no sources/organizations/{oslug}.yaml"
             )
             continue
-        folded = raw.casefold()
-        if platform == "homepage_domain":
-            folded = folded.removeprefix("www.")
-        key = (platform, folded)
+        key = (platform, fold_handle(platform, raw))
         if key in handle_owner:
             # Same key twice is still a grain violation even when it is the same org
             # claiming it twice -- registry.org_handles is one row per (platform, handle),

--- a/docs/reference/identity.md
+++ b/docs/reference/identity.md
@@ -268,7 +268,7 @@ handle on any platform can bridge one and those pairs are excluded from recall e
 
 The point is that an unbridgeable pair is not a graph defect, and holding it against recall bounds
 recall below 1 no matter how good the graph is. Precision truth is unaffected — every emitted org
-edge is still judged against the full truth set. What the eval prints keeps the exclusion honest:
+edge is still judged against the full truth set. The eval prints what was excluded and why:
 `n_truth_unrecoverable` per relation, a per-artifact-kind breakdown of it (which is what separates
 `pypi`, structurally unreachable, from a `github` artifact whose org simply declares no `github`
 handle), and a `handle coverage` line per route — for each route, how many of the orgs that
@@ -336,10 +336,15 @@ an artifact is a product's and names the org that owns it, which is the same kin
 head product file records — so tail rows carry membership truth, `org` truth, and any fold-collapse
 pairs they form, read through `build/serialize_registry.py`'s own `tail_product_rows` so the eval
 and `registry.tail_products` cannot disagree about which fields are artifacts. Each truth item
-keeps the tier that declared it and the eval reports the head/tail split per relation. One
-consequence worth naming: `homepage` is the only artifact kind with no adoption route, no head
-product declares one, and the tail rows that do are what put `membership_non_scoring` over the
-minimum truth count its floor needs to mean anything.
+keeps the tier that declared it and the eval reports the head/tail split per relation. This is also
+what gives `membership_non_scoring` a floor at all: `homepage` is the only artifact kind with no
+adoption route, no head product declares one, and the tail rows that do are what put
+`membership_non_scoring` over the minimum truth count its floor needs to mean anything. That
+relation's truth set is therefore small enough (27) that one edge decides whether it clears the
+floor, so its failures need reading twice — a tail homepage edit is emitted from the last published
+`registry.tail_products` until the weekly publish lands, and the same edit staleness-fails the
+committed pass fixture. `build/identity_eval.py`'s module docstring carries both readings, and the
+eval prints them next to the failing row.
 
 ## Related
 

--- a/docs/reference/identity.md
+++ b/docs/reference/identity.md
@@ -257,14 +257,22 @@ error, folded the same way any other identity comparison is (case-insensitive, a
 `princeton-nlp-openai` — the handle is assigned to the public or canonical org, and the row's
 `note` names the sibling; the sibling org file is untouched.
 
-A handle is also the graph's only route from an artifact to an org, which is why
-`build/identity_eval.py` measures `org` recall against **recoverable** truth rather than every
-declared `(candidate_key, org_slug)` pair: an org with no handle can never be recovered no matter
-how good the graph is, so including it would bound recall at the coverage fraction and read as a
-graph defect instead of the curation gap it actually is. Precision truth is unaffected — every
-emitted org edge is still judged against the full truth set. The eval prints a `handle coverage:
-<orgs with a handle>/<orgs rostered> (<pct>)` line so the gap stays visible as its own number
-rather than disappearing into a passing recall score.
+A handle is also the graph's only route from an artifact to an org, and each route runs from one
+artifact kind to one handle platform. So `build/identity_eval.py` measures `org` recall against
+**recoverable** truth, decided per `(artifact, org)` pair rather than per org: a `github:owner/repo`
+pair needs a `github` handle folding to `owner`; a `huggingface_model` or `huggingface_dataset` pair
+needs a `huggingface` handle equal to the namespace; a `homepage` pair needs a `homepage_domain`
+handle equal to the host or a parent domain of it (`acme.com` covers `docs.acme.com`). A `pypi`,
+`npm`, `crates` or `arxiv` identifier names a package or a paper and never its publisher, so no
+handle on any platform can bridge one and those pairs are excluded from recall entirely.
+
+The point is that an unbridgeable pair is not a graph defect, and holding it against recall bounds
+recall below 1 no matter how good the graph is. Precision truth is unaffected — every emitted org
+edge is still judged against the full truth set. What the eval prints keeps the exclusion honest:
+`n_truth_unrecoverable` per relation, a per-artifact-kind breakdown of it (which is what separates
+`pypi`, structurally unreachable, from a `github` artifact whose org simply declares no `github`
+handle), and a `handle coverage` line per route — for each route, how many of the orgs that
+actually own artifacts on it declare the handle it needs.
 
 ### Model families bridge a release name to a tier-level slug
 
@@ -319,9 +327,19 @@ hash (ADR-003). They are not governed assets — nothing deploys from the mirror
 one changes nothing.
 
 Two repo-side readers grade the deployed graph. `build/identity_eval.py` replays the four edge
-tables against the resolution ledger's prior human rulings; `build/identity_digest.py` renders
-`identity.digest` into the weekly review digest. Both are audit roots, which is what puts the
-dataset inside the repo's governed dependency closure.
+tables against prior human decisions; `build/identity_digest.py` renders `identity.digest` into the
+weekly review digest. Both are audit roots, which is what puts the dataset inside the repo's
+governed dependency closure.
+
+The eval's truth is every declaration, both tiers. A `sources/registry/*.yaml` tail row states that
+an artifact is a product's and names the org that owns it, which is the same kind of decision a
+head product file records — so tail rows carry membership truth, `org` truth, and any fold-collapse
+pairs they form, read through `build/serialize_registry.py`'s own `tail_product_rows` so the eval
+and `registry.tail_products` cannot disagree about which fields are artifacts. Each truth item
+keeps the tier that declared it and the eval reports the head/tail split per relation. One
+consequence worth naming: `homepage` is the only artifact kind with no adoption route, no head
+product declares one, and the tail rows that do are what put `membership_non_scoring` over the
+minimum truth count its floor needs to mean anything.
 
 ## Related
 

--- a/tests/fixtures/identity_edges_pass.json
+++ b/tests/fixtures/identity_edges_pass.json
@@ -38,9 +38,321 @@
     },
     {
       "artifact_kind": "homepage",
-      "artifact_id": "example.com",
+      "artifact_id": "aci.dev",
       "product_tier": "tail",
-      "product_slug": "some-product",
+      "product_slug": "aci-dev",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "agentskills.io",
+      "product_tier": "tail",
+      "product_slug": "agent-skills",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "agents.md",
+      "product_tier": "tail",
+      "product_slug": "agents-md",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "mcp-atlassian.soomiles.com",
+      "product_tier": "tail",
+      "product_slug": "atlassian-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "awslabs.github.io/mcp",
+      "product_tier": "tail",
+      "product_slug": "aws-mcp-servers",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "agentdesk.ai",
+      "product_tier": "tail",
+      "product_slug": "browser-tools-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "code-review-graph.com",
+      "product_tier": "tail",
+      "product_slug": "code-review-graph",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "stitch.withgoogle.com/docs/design-md/specification",
+      "product_tier": "tail",
+      "product_slug": "design-md",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "desktopcommander.app",
+      "product_tier": "tail",
+      "product_slug": "desktop-commander-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "mcp.excalidraw.com",
+      "product_tier": "tail",
+      "product_slug": "excalidraw-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "fastapi-mcp.tadata.com",
+      "product_tier": "tail",
+      "product_slug": "fastapi-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "gitmcp.io",
+      "product_tier": "tail",
+      "product_slug": "git-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "plugins.hex-rays.com/mrexodia/ida-pro-mcp",
+      "product_tier": "tail",
+      "product_slug": "ida-pro-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "klavis.ai",
+      "product_tier": "tail",
+      "product_slug": "klavis",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "developers.llamaindex.ai/liteparse",
+      "product_tier": "tail",
+      "product_slug": "liteparse",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "mcp-toolbox.dev",
+      "product_tier": "tail",
+      "product_slug": "mcp-toolbox-for-databases",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "developer.nvidia.com/nccl",
+      "product_tier": "tail",
+      "product_slug": "nccl",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "omniparse.cognitivelab.in",
+      "product_tier": "tail",
+      "product_slug": "omniparse",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "oomol.com",
+      "product_tier": "tail",
+      "product_slug": "open-connector",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "opendataloader.org",
+      "product_tier": "tail",
+      "product_slug": "opendataloader-pdf",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "repowise.dev",
+      "product_tier": "tail",
+      "product_slug": "repowise",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "rocm.docs.amd.com/projects/rocALUTION/en/latest",
+      "product_tier": "tail",
+      "product_slug": "rocalution",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "steel.dev",
+      "product_tier": "tail",
+      "product_slug": "steel-browser",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "coplaydev.github.io/unity-mcp",
+      "product_tier": "tail",
+      "product_slug": "unity-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "docs.xberg.io",
+      "product_tier": "tail",
+      "product_slug": "xberg",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "haha.ai/xiaohongshu-mcp",
+      "product_tier": "tail",
+      "product_slug": "xiaohongshu-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "stevenyuyy.com/zotero-mcp",
+      "product_tier": "tail",
+      "product_slug": "zotero-mcp",
       "confidence": 0.95,
       "method": [
         "declared"

--- a/tests/fixtures/identity_edges_pass.json
+++ b/tests/fixtures/identity_edges_pass.json
@@ -37,6 +37,18 @@
       "scoring_bearing": true
     },
     {
+      "artifact_kind": "github",
+      "artifact_id": "aipotheosis-labs/aci",
+      "product_tier": "tail",
+      "product_slug": "aci-dev",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
       "artifact_kind": "homepage",
       "artifact_id": "aci.dev",
       "product_tier": "tail",
@@ -47,6 +59,30 @@
       ],
       "penalties": [],
       "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "Panniantong/Agent-Reach",
+      "product_tier": "tail",
+      "product_slug": "agent-reach",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "agentskills/agentskills",
+      "product_tier": "tail",
+      "product_slug": "agent-skills",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
     },
     {
       "artifact_kind": "homepage",
@@ -61,6 +97,18 @@
       "scoring_bearing": false
     },
     {
+      "artifact_kind": "github",
+      "artifact_id": "agentsmd/agents.md",
+      "product_tier": "tail",
+      "product_slug": "agents-md",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
       "artifact_kind": "homepage",
       "artifact_id": "agents.md",
       "product_tier": "tail",
@@ -71,6 +119,18 @@
       ],
       "penalties": [],
       "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "sooperset/mcp-atlassian",
+      "product_tier": "tail",
+      "product_slug": "atlassian-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
     },
     {
       "artifact_kind": "homepage",
@@ -85,6 +145,18 @@
       "scoring_bearing": false
     },
     {
+      "artifact_kind": "github",
+      "artifact_id": "awslabs/mcp",
+      "product_tier": "tail",
+      "product_slug": "aws-mcp-servers",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
       "artifact_kind": "homepage",
       "artifact_id": "awslabs.github.io/mcp",
       "product_tier": "tail",
@@ -95,6 +167,18 @@
       ],
       "penalties": [],
       "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "AgentDeskAI/browser-tools-mcp",
+      "product_tier": "tail",
+      "product_slug": "browser-tools-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
     },
     {
       "artifact_kind": "homepage",
@@ -109,6 +193,54 @@
       "scoring_bearing": false
     },
     {
+      "artifact_kind": "npm",
+      "artifact_id": "@agentdeskai/browser-tools-mcp",
+      "product_tier": "tail",
+      "product_slug": "browser-tools-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "unicity-aos/capsule-fs",
+      "product_tier": "tail",
+      "product_slug": "capsule-fs",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "zilliztech/claude-context",
+      "product_tier": "tail",
+      "product_slug": "claude-context",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "tirth8205/code-review-graph",
+      "product_tier": "tail",
+      "product_slug": "code-review-graph",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
       "artifact_kind": "homepage",
       "artifact_id": "code-review-graph.com",
       "product_tier": "tail",
@@ -119,6 +251,18 @@
       ],
       "penalties": [],
       "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "google-labs-code/design.md",
+      "product_tier": "tail",
+      "product_slug": "design-md",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
     },
     {
       "artifact_kind": "homepage",
@@ -133,6 +277,18 @@
       "scoring_bearing": false
     },
     {
+      "artifact_kind": "github",
+      "artifact_id": "wonderwhy-er/DesktopCommanderMCP",
+      "product_tier": "tail",
+      "product_slug": "desktop-commander-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
       "artifact_kind": "homepage",
       "artifact_id": "desktopcommander.app",
       "product_tier": "tail",
@@ -143,6 +299,30 @@
       ],
       "penalties": [],
       "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "npm",
+      "artifact_id": "@wonderwhy-er/desktop-commander",
+      "product_tier": "tail",
+      "product_slug": "desktop-commander-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "excalidraw/excalidraw-mcp",
+      "product_tier": "tail",
+      "product_slug": "excalidraw-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
     },
     {
       "artifact_kind": "homepage",
@@ -157,6 +337,18 @@
       "scoring_bearing": false
     },
     {
+      "artifact_kind": "github",
+      "artifact_id": "tadata-org/fastapi_mcp",
+      "product_tier": "tail",
+      "product_slug": "fastapi-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
       "artifact_kind": "homepage",
       "artifact_id": "fastapi-mcp.tadata.com",
       "product_tier": "tail",
@@ -167,6 +359,30 @@
       ],
       "penalties": [],
       "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "pypi",
+      "artifact_id": "fastapi-mcp",
+      "product_tier": "tail",
+      "product_slug": "fastapi-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "idosal/git-mcp",
+      "product_tier": "tail",
+      "product_slug": "git-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
     },
     {
       "artifact_kind": "homepage",
@@ -181,6 +397,30 @@
       "scoring_bearing": false
     },
     {
+      "artifact_kind": "github",
+      "artifact_id": "Coding-Solo/godot-mcp",
+      "product_tier": "tail",
+      "product_slug": "godot-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "mrexodia/ida-pro-mcp",
+      "product_tier": "tail",
+      "product_slug": "ida-pro-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
       "artifact_kind": "homepage",
       "artifact_id": "plugins.hex-rays.com/mrexodia/ida-pro-mcp",
       "product_tier": "tail",
@@ -191,6 +431,18 @@
       ],
       "penalties": [],
       "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "Klavis-AI/klavis",
+      "product_tier": "tail",
+      "product_slug": "klavis",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
     },
     {
       "artifact_kind": "homepage",
@@ -205,6 +457,18 @@
       "scoring_bearing": false
     },
     {
+      "artifact_kind": "github",
+      "artifact_id": "run-llama/liteparse",
+      "product_tier": "tail",
+      "product_slug": "liteparse",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
       "artifact_kind": "homepage",
       "artifact_id": "developers.llamaindex.ai/liteparse",
       "product_tier": "tail",
@@ -215,6 +479,30 @@
       ],
       "penalties": [],
       "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "pypi",
+      "artifact_id": "liteparse",
+      "product_tier": "tail",
+      "product_slug": "liteparse",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "googleapis/mcp-toolbox",
+      "product_tier": "tail",
+      "product_slug": "mcp-toolbox-for-databases",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
     },
     {
       "artifact_kind": "homepage",
@@ -229,6 +517,18 @@
       "scoring_bearing": false
     },
     {
+      "artifact_kind": "github",
+      "artifact_id": "NVIDIA/nccl",
+      "product_tier": "tail",
+      "product_slug": "nccl",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
       "artifact_kind": "homepage",
       "artifact_id": "developer.nvidia.com/nccl",
       "product_tier": "tail",
@@ -239,6 +539,18 @@
       ],
       "penalties": [],
       "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "adithya-s-k/omniparse",
+      "product_tier": "tail",
+      "product_slug": "omniparse",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
     },
     {
       "artifact_kind": "homepage",
@@ -253,6 +565,18 @@
       "scoring_bearing": false
     },
     {
+      "artifact_kind": "github",
+      "artifact_id": "oomol-lab/open-connector",
+      "product_tier": "tail",
+      "product_slug": "open-connector",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
       "artifact_kind": "homepage",
       "artifact_id": "oomol.com",
       "product_tier": "tail",
@@ -263,6 +587,18 @@
       ],
       "penalties": [],
       "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "opendataloader-project/opendataloader-pdf",
+      "product_tier": "tail",
+      "product_slug": "opendataloader-pdf",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
     },
     {
       "artifact_kind": "homepage",
@@ -277,6 +613,30 @@
       "scoring_bearing": false
     },
     {
+      "artifact_kind": "pypi",
+      "artifact_id": "opendataloader-pdf",
+      "product_tier": "tail",
+      "product_slug": "opendataloader-pdf",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "repowise-dev/repowise",
+      "product_tier": "tail",
+      "product_slug": "repowise",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
       "artifact_kind": "homepage",
       "artifact_id": "repowise.dev",
       "product_tier": "tail",
@@ -287,6 +647,18 @@
       ],
       "penalties": [],
       "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "ROCm/rocALUTION",
+      "product_tier": "tail",
+      "product_slug": "rocalution",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
     },
     {
       "artifact_kind": "homepage",
@@ -301,6 +673,18 @@
       "scoring_bearing": false
     },
     {
+      "artifact_kind": "github",
+      "artifact_id": "steel-dev/steel-browser",
+      "product_tier": "tail",
+      "product_slug": "steel-browser",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
       "artifact_kind": "homepage",
       "artifact_id": "steel.dev",
       "product_tier": "tail",
@@ -311,6 +695,42 @@
       ],
       "penalties": [],
       "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "grab/cursor-talk-to-figma-mcp",
+      "product_tier": "tail",
+      "product_slug": "talk-to-figma-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "uccl-project/uccl",
+      "product_tier": "tail",
+      "product_slug": "uccl",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "CoplayDev/unity-mcp",
+      "product_tier": "tail",
+      "product_slug": "unity-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
     },
     {
       "artifact_kind": "homepage",
@@ -325,6 +745,18 @@
       "scoring_bearing": false
     },
     {
+      "artifact_kind": "github",
+      "artifact_id": "xberg-io/xberg",
+      "product_tier": "tail",
+      "product_slug": "xberg",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
       "artifact_kind": "homepage",
       "artifact_id": "docs.xberg.io",
       "product_tier": "tail",
@@ -337,6 +769,18 @@
       "scoring_bearing": false
     },
     {
+      "artifact_kind": "github",
+      "artifact_id": "xpzouying/xiaohongshu-mcp",
+      "product_tier": "tail",
+      "product_slug": "xiaohongshu-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
       "artifact_kind": "homepage",
       "artifact_id": "haha.ai/xiaohongshu-mcp",
       "product_tier": "tail",
@@ -347,6 +791,18 @@
       ],
       "penalties": [],
       "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "54yyyu/zotero-mcp",
+      "product_tier": "tail",
+      "product_slug": "zotero-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
     },
     {
       "artifact_kind": "homepage",

--- a/tests/test_identity_eval.py
+++ b/tests/test_identity_eval.py
@@ -50,6 +50,7 @@ from build.identity_eval import (
     org_pair_recoverable,
     print_table,
     replay,
+    tail_membership_rows,
     validate_columns,
 )
 
@@ -699,6 +700,84 @@ def test_a_fold_pair_spanning_head_and_tail_is_recorded_as_head(monkeypatch):
     pair = ("github", folded, folded)
     assert pair in truth.identity_pairs
     assert truth.identity_tier[pair] == "head"
+
+
+PASS_FIXTURE = ROOT / "tests" / "fixtures" / "identity_edges_pass.json"
+
+
+def test_the_pass_fixture_tail_rows_match_the_corpus():
+    """The committed pass fixture carries the corpus's own tail declarations, and
+    `membership_non_scoring`'s floor is judged against them -- 27 truth items, so one stale row
+    is a ~3.7% precision swing and the CI failure names the relation rather than the fixture.
+    This test fails first, and names the fix.
+    """
+    fixture = json.loads(PASS_FIXTURE.read_text())
+    stored = [row for row in fixture["membership"] if row.get("product_tier") == "tail"]
+    assert stored == tail_membership_rows(REAL_TRUTH.route_kinds), (
+        "tests/fixtures/identity_edges_pass.json's tail membership rows no longer match "
+        "sources/registry/*.yaml. Regenerate with: uv run python -m build.identity_eval "
+        "--write-fixture tests/fixtures/identity_edges_pass.json"
+    )
+
+
+def test_write_fixture_leaves_head_rows_and_other_relations_alone(tmp_path):
+    """Regeneration replaces the tail block only: a hand-written head row keeps its wording, and
+    every other relation is untouched, so a regeneration diff shows the corpus change only."""
+    path = tmp_path / "edges.json"
+    path.write_text(json.dumps({
+        "membership": [
+            {"artifact_kind": "arxiv", "artifact_id": "1803.05457", "product_tier": "head",
+             "product_slug": "ai2-arc", "confidence": 1.0, "method": ["declared"],
+             "penalties": [], "scoring_bearing": True},
+            {"artifact_kind": "homepage", "artifact_id": "stale.example.com",
+             "product_tier": "tail", "product_slug": "gone", "confidence": 0.95,
+             "method": ["declared"], "penalties": [], "scoring_bearing": False},
+        ],
+        "org": [{"candidate_key": "github:a/b", "candidate_tier": "head", "org_slug": "acme",
+                 "confidence": 0.85, "method": ["org_handle"], "penalties": []}],
+    }))
+    removed, written = identity_eval_module.write_fixture(path, REAL_TRUTH.route_kinds)
+    doc = json.loads(path.read_text())
+    assert (removed, written) == (1, len(tail_membership_rows(REAL_TRUTH.route_kinds)))
+    assert doc["membership"][0]["product_slug"] == "ai2-arc"
+    assert not any(row["artifact_id"] == "stale.example.com" for row in doc["membership"])
+    assert len(doc["org"]) == 1
+
+
+def test_write_fixture_is_idempotent(tmp_path):
+    path = tmp_path / "edges.json"
+    path.write_text(PASS_FIXTURE.read_text())
+    identity_eval_module.write_fixture(path, REAL_TRUTH.route_kinds)
+    once = path.read_text()
+    identity_eval_module.write_fixture(path, REAL_TRUTH.route_kinds)
+    assert path.read_text() == once
+    assert once == PASS_FIXTURE.read_text()  # and the committed fixture is already regenerated
+
+
+def test_main_write_fixture_rewrites_and_scores_nothing(tmp_path, capsys):
+    path = tmp_path / "edges.json"
+    path.write_text(json.dumps({"membership": []}))
+    assert main(["--write-fixture", str(path)]) == 0
+    out = capsys.readouterr().out
+    assert "sources/registry" in out
+    assert "relation" not in out  # no table -- this mode scores nothing
+    assert json.loads(path.read_text())["membership"]
+
+
+def test_a_stale_fixture_tail_row_fails_the_floor_with_the_publish_lag_note(tmp_path, capsys):
+    """The failure mode the note exists for: one wrong row out of 27 breaks the 0.98 precision
+    floor, and the message has to say that a red run can mean "republish" or "regenerate the
+    fixture" rather than "the graph regressed"."""
+    rows = tail_membership_rows(REAL_TRUTH.route_kinds)
+    stale = [dict(row) for row in rows]
+    next(row for row in stale if row["artifact_kind"] == "homepage")["artifact_id"] = "gone.example.com"
+    path = tmp_path / "edges.json"
+    path.write_text(json.dumps({"membership": stale}))
+    assert main(["--edges", str(path), "--floors"]) == 1
+    out = capsys.readouterr().out
+    assert "membership_non_scoring: precision" in out
+    assert "publish" in out
+    assert "--write-fixture" in out
 
 
 def test_head_and_tail_counts_appear_in_the_table(capsys):

--- a/tests/test_identity_eval.py
+++ b/tests/test_identity_eval.py
@@ -12,6 +12,7 @@ the F2 tests stub `build.warehouse.query` directly rather than hitting a real en
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -19,8 +20,11 @@ import yaml
 
 import build.identity_eval as identity_eval_module
 import build.warehouse as warehouse_module
+from build.identity import fold_for_proposal
 from build.identity_eval import (
     KNOWN_NEGATIVES,
+    MIN_TRUTH,
+    ORG_ROUTES,
     EdgeColumnMissing,
     EdgeValueInvalid,
     KnownNegativeDeclaredError,
@@ -38,10 +42,13 @@ from build.identity_eval import (
     emitted_at_threshold,
     floor_failures,
     floor_status,
+    fold_handle,
     load_edges_from_warehouse,
     load_truth,
     main,
     org_handle_coverage,
+    org_pair_recoverable,
+    print_table,
     replay,
     validate_columns,
 )
@@ -250,7 +257,7 @@ def test_duplicate_head_tail_edges_collapse_in_precision_and_recall():
 
 
 def test_recall_cannot_exceed_one():
-    truth = Truth(org={"github:a/b": {"acme"}}, recoverable_orgs=frozenset({"acme"}))
+    truth = Truth(org={"github:a/b": {"acme"}}, org_handles={"acme": {"github": frozenset({"a"})}})
     edges = {
         "org": [
             {"candidate_key": "github:a/b", "candidate_tier": "head", "org_slug": "acme",
@@ -292,7 +299,13 @@ def test_org_truth_holds_more_than_one_org_per_candidate_key_in_the_real_corpus(
 def test_second_org_for_a_shared_candidate_key_scores_correct_not_a_false_positive():
     """The F5 bug: `dict.setdefault` kept only the first org read and scored the second,
     equally correct org as a false positive. Both must score correct now."""
-    truth = Truth(org={"github:a/b": {"org-one", "org-two"}}, recoverable_orgs=frozenset({"org-one", "org-two"}))
+    truth = Truth(
+        org={"github:a/b": {"org-one", "org-two"}},
+        org_handles={
+            "org-one": {"github": frozenset({"a"})},
+            "org-two": {"github": frozenset({"a"})},
+        },
+    )
     edges = {"org": [
         {"candidate_key": "github:a/b", "candidate_tier": "head", "org_slug": "org-one",
          "confidence": 1.0, "method": ["org_handle"]},
@@ -310,35 +323,99 @@ def test_org_n_truth_counts_pairs_not_candidate_keys():
 
 
 # ---------------------------------------------------------------------------
-# org recall is measured against recoverable truth (an org must declare a handle)
+# org recall is measured per handle route, pair by pair
 # ---------------------------------------------------------------------------
 
 
-def test_org_without_a_handle_drops_out_of_recall_truth():
-    """An org with no declared handle can never be recovered by the graph, so it must not
-    inflate `org`'s recall denominator -- `n_truth` counts only pairs whose org is
-    recoverable."""
+def test_github_pair_recoverable_only_when_the_owner_matches_a_github_handle():
+    truth = Truth(org_handles={"acme": {"github": frozenset({"acme-labs"})}})
+    assert org_pair_recoverable("github:acme-labs/widget", "acme", truth) is True
+    assert org_pair_recoverable("github:someone-else/widget", "acme", truth) is False
+
+
+def test_github_pair_not_recoverable_through_a_handle_on_another_route():
+    """The pre-#482-followup rule accepted any handle on any platform. A `homepage_domain`
+    handle cannot bridge a GitHub artifact -- there is no route from one to the other."""
+    truth = Truth(org_handles={"acme": {"homepage_domain": frozenset({"acme.com"})}})
+    assert org_pair_recoverable("github:acme/widget", "acme", truth) is False
+
+
+def test_huggingface_pairs_recoverable_through_the_namespace_on_both_kinds():
+    truth = Truth(org_handles={"acme": {"huggingface": frozenset({"acme-ai"})}})
+    assert org_pair_recoverable("huggingface_model:acme-ai/tiny", "acme", truth) is True
+    assert org_pair_recoverable("huggingface_dataset:acme-ai/corpus", "acme", truth) is True
+    assert org_pair_recoverable("huggingface_model:other/tiny", "acme", truth) is False
+
+
+def test_homepage_pair_recoverable_on_an_exact_host_and_on_a_parent_domain():
+    """A `homepage_domain` handle is deliberately broader than the artifact: an org declares
+    one domain and hangs product pages off subdomains of it."""
+    truth = Truth(org_handles={"acme": {"homepage_domain": frozenset({"acme.com"})}})
+    assert org_pair_recoverable("homepage:acme.com/product", "acme", truth) is True
+    assert org_pair_recoverable("homepage:docs.acme.com/product", "acme", truth) is True
+    assert org_pair_recoverable("homepage:acme.com", "acme", truth) is True
+
+
+def test_homepage_pair_not_recoverable_on_a_domain_that_merely_ends_in_the_same_letters():
+    """`notacme.com` is not a subdomain of `acme.com`; the suffix test has to be on a label
+    boundary or every look-alike domain reads as recoverable."""
+    truth = Truth(org_handles={"acme": {"homepage_domain": frozenset({"acme.com"})}})
+    assert org_pair_recoverable("homepage:notacme.com/product", "acme", truth) is False
+
+
+def test_handles_are_matched_folded_not_raw():
+    truth = Truth(org_handles={"acme": {"github": frozenset({fold_handle("github", "Acme-Labs")})}})
+    assert org_pair_recoverable("github:acme-labs/widget", "acme", truth) is True
+
+
+def test_fold_handle_strips_www_for_a_domain_only():
+    assert fold_handle("homepage_domain", "WWW.Acme.com") == "acme.com"
+    assert fold_handle("github", "WWW-Acme") == "www-acme"
+
+
+@pytest.mark.parametrize("candidate", ["pypi:torch", "npm:react", "crates:serde", "arxiv:2401.00001"])
+def test_kinds_with_no_owner_concept_are_never_recoverable(candidate):
+    """Even for an org that declares a handle on every route -- these identifiers name a
+    package or a paper, never who publishes it, so no handle could bridge them."""
+    truth = Truth(org_handles={"acme": {
+        "github": frozenset({"acme"}),
+        "huggingface": frozenset({"acme"}),
+        "homepage_domain": frozenset({"acme.com"}),
+    }})
+    assert org_pair_recoverable(candidate, "acme", truth) is False
+
+
+def test_pypi_truth_is_excluded_from_recall_and_counted_per_kind():
+    """The routed pair counts; the pypi pair is excluded from the denominator and appears in
+    the breakdown under its own kind."""
     truth = Truth(
-        org={"github:a/b": {"has-handle"}, "github:c/d": {"no-handle"}},
-        recoverable_orgs=frozenset({"has-handle"}),
-        orgs_rostered=frozenset({"has-handle", "no-handle"}),
+        org={"github:acme/widget": {"acme"}, "pypi:widget": {"acme"}},
+        org_handles={"acme": {"github": frozenset({"acme"})}},
     )
     m = replay({"org": []}, truth)["org"]
     assert m.n_truth == 1
     assert m.n_truth_unrecoverable == 1
+    assert m.unrecoverable_by_kind == {"pypi": 1}
 
 
-def test_emitted_edge_to_a_handle_less_org_still_counts_toward_precision():
-    """Precision truth is unchanged: an edge correctly naming an org with no declared handle
-    is still a correct edge, and must not be scored as a false positive just because that org
-    cannot contribute to recall."""
+def test_a_github_pair_whose_org_declares_no_github_handle_is_counted_under_github():
+    """A curation gap and a structural exclusion both land in `n_truth_unrecoverable`, and the
+    per-kind breakdown is what tells them apart."""
     truth = Truth(
-        org={"github:a/b": {"no-handle"}},
-        recoverable_orgs=frozenset(),
-        orgs_rostered=frozenset({"no-handle"}),
+        org={"github:acme/widget": {"acme"}, "arxiv:2401.00001": {"acme"}},
+        org_handles={"acme": {"homepage_domain": frozenset({"acme.com"})}},
     )
+    m = replay({"org": []}, truth)["org"]
+    assert m.n_truth == 0
+    assert m.unrecoverable_by_kind == {"arxiv": 1, "github": 1}
+
+
+def test_emitted_edge_to_an_unrecoverable_pair_still_counts_toward_precision():
+    """Precision truth is unrestricted: an edge correctly naming an org is a correct edge,
+    even where no handle route could have found it."""
+    truth = Truth(org={"pypi:widget": {"acme"}}, org_handles={})
     edges = {"org": [
-        {"candidate_key": "github:a/b", "candidate_tier": "head", "org_slug": "no-handle",
+        {"candidate_key": "pypi:widget", "candidate_tier": "head", "org_slug": "acme",
          "confidence": 1.0, "method": ["org_handle"]},
     ]}
     m = replay(edges, truth)["org"]
@@ -348,19 +425,53 @@ def test_emitted_edge_to_a_handle_less_org_still_counts_toward_precision():
     assert m.n_truth_unrecoverable == 1
 
 
-def test_handle_coverage_computed_correctly_on_a_fixture():
+def test_org_routes_cover_exactly_the_declared_handle_platforms():
+    """`ORG_ROUTES`' platforms are the `org_handles.yaml` schema's own enum. A new platform
+    added there needs a route here, or its handles quietly bridge nothing."""
+    schema = json.loads((ROOT / "docs" / "schemas" / "org_handles.schema.json").read_text())
+    enum = schema["properties"]["handles"]["items"]["properties"]["platform"]["enum"]
+    assert set(ORG_ROUTES.values()) == set(enum)
+
+
+def test_handle_coverage_is_per_route_on_a_fixture():
+    """The denominator is orgs with artifacts ON THAT ROUTE, not every rostered org: `acme`
+    has a github artifact and a github handle, `beta` has a github artifact and only a
+    homepage handle, and `gamma` is never counted against github at all."""
     truth = Truth(
-        recoverable_orgs=frozenset({"a", "b"}),
-        orgs_rostered=frozenset({"a", "b", "c", "d"}),
+        org={
+            "github:acme/widget": {"acme"},
+            "github:beta/widget": {"beta"},
+            "homepage:gamma.com": {"gamma"},
+            "pypi:widget": {"delta"},
+        },
+        org_handles={
+            "acme": {"github": frozenset({"acme"})},
+            "beta": {"homepage_domain": frozenset({"beta.com"})},
+            "gamma": {"homepage_domain": frozenset({"gamma.com"})},
+        },
     )
-    assert org_handle_coverage(truth) == (2, 4)
+    coverage = org_handle_coverage(truth)
+    assert coverage["github"] == (1, 2)
+    assert coverage["homepage_domain"] == (1, 1)
+    assert coverage["huggingface"] == (0, 0)
 
 
-def test_org_handle_coverage_against_the_real_corpus_matches_recoverable_orgs():
-    n_with_handle, n_rostered = org_handle_coverage(REAL_TRUTH)
-    assert n_with_handle == len(REAL_TRUTH.recoverable_orgs)
-    assert n_rostered == len(REAL_TRUTH.orgs_rostered)
-    assert 0 < n_with_handle <= n_rostered
+def test_handle_coverage_against_the_real_corpus_has_a_row_per_route():
+    coverage = org_handle_coverage(REAL_TRUTH)
+    assert set(coverage) == set(ORG_ROUTES.values())
+    for route, (n_with_handle, n_rostered) in coverage.items():
+        assert 0 <= n_with_handle <= n_rostered, route
+    assert coverage["github"][1] > 0  # the corpus certainly has github artifacts
+
+
+def test_main_prints_a_coverage_line_per_route(tmp_path, capsys):
+    fixture = tmp_path / "edges.json"
+    fixture.write_text('{"org": []}')
+    assert main(["--edges", str(fixture)]) == 0
+    out = capsys.readouterr().out
+    assert "github handles" in out
+    assert "hf handles" in out
+    assert "homepage handles" in out
 
 
 def test_non_org_relations_carry_zero_n_truth_unrecoverable():
@@ -472,14 +583,138 @@ def test_membership_split_by_route_kinds_not_by_edge_scoring_bearing():
     assert m["membership_scoring"].n_emitted_at_threshold == 0  # nothing scoring-bearing can ever emit
 
 
-def test_membership_non_scoring_truth_is_zero_against_the_real_corpus():
-    """Every declared kind in today's corpus has an adoption route, so
-    `membership_non_scoring`'s truth is 0 -- `floor_status` must report "insufficient truth",
-    not attempt an unsatisfiable floor (the review's M8)."""
-    assert sum(
-        1 for (key, _slug), is_member in REAL_TRUTH.membership.items()
+def test_membership_non_scoring_truth_is_all_tail_homepage_in_the_real_corpus():
+    """`homepage` is the only kind with no adoption route, and no head product declares one --
+    so every non-scoring truth item comes from a tail row. Before tail declarations counted,
+    this was 0 and the relation could only ever report "insufficient truth" (the review's M8)."""
+    non_scoring = [
+        (key, slug) for (key, slug), is_member in REAL_TRUTH.membership.items()
         if is_member and key[0] not in REAL_TRUTH.route_kinds
-    ) == 0
+    ]
+    assert {key[0] for key, _slug in non_scoring} == {"homepage"}
+    assert all(REAL_TRUTH.membership_tier[item] == "tail" for item in non_scoring)
+
+
+def test_membership_non_scoring_now_clears_min_truth_and_is_really_floored():
+    """The intended consequence of counting tail declarations: the relation is over
+    `MIN_TRUTH`, so its floor is enforced for the first time rather than waived."""
+    metrics = replay({"membership": []}, REAL_TRUTH)
+    assert metrics["membership_non_scoring"].n_truth >= MIN_TRUTH
+    assert floor_status("membership_non_scoring", metrics).startswith("checked")
+
+
+# ---------------------------------------------------------------------------
+# tail declarations are truth
+# ---------------------------------------------------------------------------
+
+
+def _tail_rows():
+    from build.serialize_registry import load_registry, tail_product_rows
+
+    return tail_product_rows(load_registry(ROOT))
+
+
+def test_every_tail_row_is_membership_truth_typed_by_its_kind():
+    """A tail row is a declaration: the artifact belongs to that product. Scoring vs
+    non-scoring is decided by the artifact kind's adoption route, exactly as for a head
+    declaration -- the tier does not enter into it."""
+    rows = _tail_rows()
+    assert rows, "the tail registry is empty; this test would be vacuous"
+    for row in rows:
+        key = (row["artifact_kind"], fold_for_proposal(row["artifact_kind"], row["artifact_id"]))
+        item = (key, row["slug"])
+        assert REAL_TRUTH.membership.get(item) is True, item
+        assert REAL_TRUTH.membership_tier[item] == "tail", item
+
+
+def test_tail_membership_truth_lands_in_the_bucket_its_kind_routes_to():
+    rows = _tail_rows()
+    metrics = replay({"membership": []}, REAL_TRUTH)
+    tail_homepage = {
+        (("homepage", fold_for_proposal("homepage", r["artifact_id"])), r["slug"])
+        for r in rows if r["artifact_kind"] == "homepage"
+    }
+    assert tail_homepage
+    assert metrics["membership_non_scoring"].n_truth_tail == len(tail_homepage)
+    assert metrics["membership_scoring"].n_truth_tail == len(rows) - len(tail_homepage)
+
+
+def test_every_tail_row_with_an_org_is_org_truth():
+    for row in _tail_rows():
+        if not row["org_slug"]:
+            continue
+        ck = candidate_key(row["artifact_kind"], row["artifact_id"])
+        assert row["org_slug"] in REAL_TRUTH.org[ck], ck
+        assert REAL_TRUTH.org_tier[(ck, row["org_slug"])] in ("head", "tail")
+
+
+def test_tail_org_truth_carries_the_tail_tier():
+    """A tail org pair is tagged `tail` unless the same (artifact, org) pair is also declared
+    in the head, where the head record wins."""
+    rows = [r for r in _tail_rows() if r["org_slug"]]
+    tiers = {
+        REAL_TRUTH.org_tier[(candidate_key(r["artifact_kind"], r["artifact_id"]), r["org_slug"])]
+        for r in rows
+    }
+    assert "tail" in tiers
+
+
+def test_tail_declarations_produce_identity_fold_truth(monkeypatch):
+    """Two tail rows spelling one GitHub repo differently fold to the same comparison key,
+    which is `artifact_identity` truth. The real corpus has no such pair (validate gates
+    duplicate tail artifacts), so this drives `load_truth` over a synthetic registry."""
+    monkeypatch.setattr(identity_eval_module, "load_registry", lambda root=None: {
+        "compilers": {
+            "category": "compilers",
+            "products": [
+                {"slug": "tail-one", "display_name": "One", "type": "software",
+                 "org": "acme", "github": "Acme/Widget"},
+                {"slug": "tail-two", "display_name": "Two", "type": "software",
+                 "org": "acme", "github": "acme/widget"},
+            ],
+        }
+    })
+    truth = load_truth()
+    assert ("github", "acme/widget", "acme/widget") in truth.identity_pairs
+    assert truth.identity_tier[("github", "acme/widget", "acme/widget")] == "tail"
+
+
+def test_a_fold_pair_spanning_head_and_tail_is_recorded_as_head(monkeypatch):
+    """The head declaration is the stronger record, so a mixed pair counts once, under head."""
+    folded = next(
+        ident
+        for (kind, ident), _slug in REAL_TRUTH.membership
+        if kind == "github" and ident != ident.upper()
+    )
+    monkeypatch.setattr(identity_eval_module, "load_registry", lambda root=None: {
+        "compilers": {
+            "category": "compilers",
+            "products": [
+                {"slug": "tail-one", "display_name": "One", "type": "software",
+                 "org": "acme", "github": folded.upper()},
+            ],
+        }
+    })
+    truth = load_truth()
+    pair = ("github", folded, folded)
+    assert pair in truth.identity_pairs
+    assert truth.identity_tier[pair] == "head"
+
+
+def test_head_and_tail_counts_appear_in_the_table(capsys):
+    metrics = replay({"membership": []}, REAL_TRUTH)
+    print_table(metrics)
+    out = capsys.readouterr().out
+    assert "n_head" in out
+    assert "n_tail" in out
+    assert str(metrics["membership_non_scoring"].n_truth_tail) in out
+
+
+def test_the_unrecoverable_breakdown_prints_under_the_table(capsys):
+    truth = Truth(org={"pypi:widget": {"acme"}}, org_handles={})
+    print_table(replay({"org": []}, truth))
+    out = capsys.readouterr().out
+    assert "org truth with no handle route (1): pypi 1" in out
 
 
 # ---------------------------------------------------------------------------
@@ -534,6 +769,17 @@ def test_known_negative_declared_as_real_artifact_raises():
 # ---------------------------------------------------------------------------
 
 
+def _thirty_recoverable_github_pairs() -> Truth:
+    """30 org truth pairs that clear `MIN_TRUTH` and are all recoverable: one org, one github
+    handle, thirty repos under it. Every candidate key has to share the owner segment the
+    handle names, or the pairs drop out of the recall denominator and the floor is never
+    checked at all."""
+    return Truth(
+        org={f"github:acme/x{i}": {"acme"} for i in range(30)},
+        org_handles={"acme": {"github": frozenset({"acme"})}},
+    )
+
+
 def test_floor_status_insufficient_truth_below_min():
     truth = Truth(equivalence={f"github:{i}/x": "p" for i in range(5)})
     edges = {"equivalence": [
@@ -557,9 +803,9 @@ def test_floor_status_not_evaluated_when_relation_absent():
 
 
 def test_floor_status_checked_and_failing():
-    truth = Truth(org={f"github:{i}/x": {"acme"} for i in range(30)}, recoverable_orgs=frozenset({"acme"}))
+    truth = _thirty_recoverable_github_pairs()
     edges = {"org": [
-        {"candidate_key": f"github:{i}/x", "candidate_tier": "head", "org_slug": "wrong",
+        {"candidate_key": f"github:acme/x{i}", "candidate_tier": "head", "org_slug": "wrong",
          "confidence": 1.0, "method": ["org_handle"]}
         for i in range(30)
     ]}
@@ -569,9 +815,9 @@ def test_floor_status_checked_and_failing():
 
 
 def test_floor_status_checked_and_passing():
-    truth = Truth(org={f"github:{i}/x": {"acme"} for i in range(30)}, recoverable_orgs=frozenset({"acme"}))
+    truth = _thirty_recoverable_github_pairs()
     edges = {"org": [
-        {"candidate_key": f"github:{i}/x", "candidate_tier": "head", "org_slug": "acme",
+        {"candidate_key": f"github:acme/x{i}", "candidate_tier": "head", "org_slug": "acme",
          "confidence": 1.0, "method": ["org_handle"]}
         for i in range(30)
     ]}
@@ -584,7 +830,7 @@ def test_floor_status_abstains_on_precision_when_nothing_emitted():
     """SF2: `precision is None` (the declared slice emitted nothing at all) must not read as
     0.0 and fail a precision floor for a reason that is not a precision problem -- only
     recall's real 0.0 should fail here."""
-    truth = Truth(org={f"github:{i}/x": {"acme"} for i in range(30)}, recoverable_orgs=frozenset({"acme"}))
+    truth = _thirty_recoverable_github_pairs()
     edges = {"org": []}  # nothing emitted at all
     metrics = replay(edges, truth)
     assert metrics["org"].precision is None


### PR DESCRIPTION
Two changes to `build/identity_eval.py`, both about what the replay is allowed to call truth.

## 1. Org recall's denominator is pair- and kind-specific

A handle route runs from one artifact kind to one handle platform, so whether a truth pair is recoverable is a property of the `(artifact, org)` pair, not of the org. The 0.85 floor is unchanged; what changed is what counts against it.

- `github:<owner>/<repo>` needs a `github` handle folding to `<owner>`.
- `huggingface_model` / `huggingface_dataset` need a `huggingface` handle equal to the namespace.
- `homepage:<host><path>` needs a `homepage_domain` handle equal to the host or a parent domain of it (`acme.com` covers `docs.acme.com`, but not `notacme.com`).
- `pypi`, `npm`, `crates`, `arxiv` name a package or a paper and never its publisher. No handle on any platform can bridge them, so they leave org recall entirely.

The previous rule (any handle on any platform) was wrong in both directions at once: it kept a `pypi` pair because the org happened to declare a homepage, and it kept a `github` pair whose org declares only a domain.

Precision is untouched — every emitted org edge is still judged against the full truth set. Two things keep the exclusion visible: a per-artifact-kind breakdown of `n_truth_unrecoverable` printed under the table (which separates `pypi`, structurally unreachable, from a `github` artifact whose org just has no `github` handle), and a `handle coverage` line per route, whose denominator is the orgs that actually own artifacts on that route.

## 2. Tail declarations count as truth

Truth was built from `sources/products/*.yaml` only. A `sources/registry/*.yaml` tail row is a declaration too — somebody wrote down that this artifact is this product's and named the org that owns it — so tail rows now contribute membership truth (typed scoring/non-scoring by the artifact kind's adoption route, the same rule as head), org truth, and any fold-collapse pairs they form with each other or with a head spelling.

Read through `build/serialize_registry.py`'s own `tail_product_rows` / `load_registry`, split out of `build_registry` for the purpose, so the eval and `registry.tail_products` cannot disagree about which tail fields are artifacts or how a homepage is reduced. Every truth item carries the tier that declared it, and the table reports the head/tail split of each relation's `n_truth`.

`sources/registry/**` and `sources/org_handles.yaml` join the workflow's path triggers, since both now move truth.

## Live table

Before (`main`, from the previous run):

```
relation                  precision     recall  n_truth  n_emitted  n_unrecov  status
equivalence                   1.000      0.333       15         10          0  insufficient truth (15 < 20)
membership_scoring              n/a      0.000      857          0          0  no floor (never automated)
membership_non_scoring          n/a        n/a        0          0          0  insufficient truth (0 < 20)
artifact_identity             0.000        n/a        0          0          0  insufficient truth (0 < 20)
org                           0.989      0.371      747       1199         98  checked (FAIL)

handle coverage: 302/347 (87.0%)
```

After:

```
relation                  precision     recall  n_truth   n_head   n_tail  n_emitted  n_unrecov  status
-------------------------------------------------------------------------------------------------------
equivalence                   1.000      0.333       15       15        0         10          0  insufficient truth (15 < 20)
membership_scoring              n/a      0.000      895      857       38          0          0  no floor (never automated)
membership_non_scoring        1.000      1.000       27        0       27         27          0  checked (pass)
artifact_identity             0.000        n/a        0        0        0          0          0  insufficient truth (0 < 20)
org                           0.996      1.000      282      277        5       1199        628  checked (pass)

org truth with no handle route (628): arxiv 32, crates 1, github 171, homepage 24, huggingface_dataset 81, huggingface_model 132, npm 19, pypi 168

handle coverage: github handles 211/299 orgs with github artifacts; hf handles 2/61 orgs with hf artifacts; homepage handles 6/27 orgs with homepage artifacts

[OK] every checked relation clears its precision/recall floor
```

What moved, per relation:

- **org** — recall 0.371 to 1.000, and it now clears the floor. The denominator fell from 747 to 282 because 628 of the 910 pairs (845 head + 65 tail) have no handle route: 388 are structurally unreachable kinds, and the rest are curation gaps, mostly Hugging Face (only 2 of 61 orgs with HF artifacts declare a `huggingface` handle) and 171 github pairs whose org declares no matching github handle. Precision 0.989 to 0.996: tail org truth made some previously-false-positive edges correct.
- **membership_non_scoring** — 0 truth to 27, all tail homepage rows, so the relation is floored for the first time instead of waived. It passes: the graph emits all 27 and nothing else.
- **membership_scoring** — n_truth 857 to 895, the 38 non-homepage tail rows. Still no floor; a scoring-bearing membership edge never auto-emits at any confidence.
- **equivalence**, **artifact_identity** — unchanged. Tail rows add no fold-collapse pair (validate gates duplicate tail artifacts) and no ledger ruling.

One number to read carefully: `org` recall is now measured against a denominator defined by the same handle join the graph itself uses, so recall near 1.0 is close to tautological. Precision, the per-kind breakdown and the coverage lines are where the information is; recall's job here is to catch the graph failing to use a handle it has.

## Test plan

- `uv run pytest tests/test_identity_eval.py tests/test_docs_integrity.py -q -n 4` — 110 passed
- `uv run pytest -q -n 4 -m "not serial"` — 1550 passed
- `uv run python -m build.identity_eval --edges tests/fixtures/identity_edges_pass.json --floors` — exit 0
- `uv run python -m build.identity_eval --edges tests/fixtures/identity_edges_fail.json --floors` — exit 1
- `uv run python -m build.identity_eval --from-warehouse --floors` — exit 0, table above

New tests cover recoverability positive and negative on each route (including a look-alike domain that must not match on a non-label boundary), every ownerless kind excluded with its unrecoverable count and per-kind breakdown, the per-route coverage numbers and the printed line, tail membership truth typed by kind and tiered `tail`, tail org truth, a synthetic tail fold-collapse pair and a mixed head/tail pair recorded as head, and the head/tail columns plus the breakdown line in the table. `ORG_ROUTES` is pinned against the `org_handles.yaml` schema enum so a new platform cannot be added there without a route here. The pass fixture's placeholder homepage membership row was replaced with the real tail homepage rows, now that the relation has truth to be judged against.

Refs #365


## The pass fixture is pinned to the corpus

`membership_non_scoring`'s truth is the tail's homepage declarations — 27 items, so one edge is a ~3.7% precision swing against a 0.98 floor. The fixture's tail rows are those same declarations, and nothing tied the two together: a tail registry edit failed the eval on `membership_non_scoring` with nothing in the message, the workflow comments or the docs pointing at the fixture.

- `tail_membership_rows()` derives the fixture's tail block from the same `tail_product_rows()` truth is read from, and `--write-fixture PATH` rewrites only `membership` rows with `product_tier: "tail"` — head rows keep their wording, other relations are untouched, nothing is scored. A regeneration diff shows the corpus change and nothing else.
- `test_the_pass_fixture_tail_rows_match_the_corpus` asserts the committed block equals that, with the regeneration command in the failure message. It runs through `validate.yml` on every PR, so it fails ahead of the eval's floor and names the fixture rather than the relation.
- The fixture stays committed rather than being generated at test time. It is the input the `identity-eval` workflow grades on every PR, and a gate that builds its own input out of the corpus it then grades against cannot fail. Committing also keeps the tail block reviewable in a diff.
- `tests/fixtures/identity_edges_pass.json` joins the push and pull_request path triggers, so a commit that only regenerates it re-runs the eval it was regenerated for.

The tail block is now all 65 tail rows rather than the 27 homepage ones. The extra rows are scoring-bearing, so `emits` drops them before scoring and no metric moves; they exist in the real table, so carrying them keeps the fixture the shape the warehouse has.

## Publish lag is documented where a red run gets read

Two things that are not regressions land as a `membership_non_scoring` floor failure, and the relation has no headroom to absorb either. A tail homepage row edited in `sources/registry/*.yaml` is still emitted from the last published `registry.tail_products` until the weekly publish, so a red Monday soon after such an edit means republish, not regression — diff the repo against the published table before reading it as a graph defect. On a fixture run, the fixture's own tail rows may be stale instead.

The module docstring carries both readings, `docs/reference/identity.md` names them in the tail-truth section, and `FLOOR_NOTES` prints them under the failing row so the log alone distinguishes them. `test_a_stale_fixture_tail_row_fails_the_floor_with_the_publish_lag_note` mutates one row out of 27 and asserts the failure, the publish wording and the `--write-fixture` pointer all appear. Neither widens the floor or raises `MIN_TRUTH`; the relation gets headroom by the tail's homepage coverage growing.

`build/validate.py`'s inline handle folding is gone — `fold_handle` moved to `build/identity.py` and both it and the eval import it, so the uniqueness gate and the eval's handle matching are one function.

Fix-round test plan:

- `uv run pytest tests/test_identity_eval.py tests/test_validate.py tests/test_docs_integrity.py -q -n 4` — 179 passed
- `uv run pytest -q -n 4 -m "not serial"` — 1555 passed
- pass fixture exit 0 (`membership_non_scoring` 1.000/1.000 on 27 truth), fail fixture exit 1
