### PR TITLE
Resync five drifted mirrors; leave three pinned with byte-identical platform code

### DIFF
--- a/warehouse/assets.yaml
+++ b/warehouse/assets.yaml
@@ -420,6 +420,7 @@ assets:
     - warehouse/models/signal_github/product_adoption.sql
     - warehouse/models/signal_huggingface/product_adoption.sql
     - warehouse/models/signal_packages/product_adoption.sql
+    - warehouse/models/signal_pypi/package_downloads.sql
   consumer_checks:
     repository: checked
     platform_notebooks: checked

--- a/warehouse/assets.yaml
+++ b/warehouse/assets.yaml
@@ -1011,6 +1011,7 @@ assets:
   read_by:
     models:
     - warehouse/models/identity/candidates.sql
+    - warehouse/models/identity/digest.sql
     - warehouse/models/identity/equivalence_edges.sql
   consumer_checks:
     repository: checked

--- a/warehouse/dependencies.yaml
+++ b/warehouse/dependencies.yaml
@@ -287,15 +287,15 @@ dependencies:
   required_by:
   - build/identity_eval.py
   - warehouse/models/identity/digest.sql
-  verified_revision: 2
+  verified_revision: 3
   owner: oso
   files:
     model: warehouse/models/identity/membership_edges.sql
   mirror:
     model_id: cb3be49c-a049-4874-885b-f940a263632c
-    revision: 2
-    hash: 090307bd5a58796d872c4aa6de1642cf94d407bcc3a8f5bd25ca8a9768258dc8
-    local_sha256: 2caaded893310531eccddb0bd49c59bb6b02435ea0dca2174518bc394e75fa61
+    revision: 3
+    hash: 4647c2b5c24876de3fc2f5fcc66171b7dc3d9cba2642ec8a8883e237a0b42da6
+    local_sha256: ada92e04f04f9129d966a268d858b0cc3846634f3aa31a4b34249cc0ba8564fe
     synced_at: '2026-09-04'
   platform_schedule:
     cron: 30 5 * * 0
@@ -308,15 +308,15 @@ dependencies:
   required_by:
   - build/identity_eval.py
   - warehouse/models/identity/digest.sql
-  verified_revision: 5
+  verified_revision: 6
   owner: oso
   files:
     model: warehouse/models/identity/equivalence_edges.sql
   mirror:
     model_id: 10fc9fc9-799b-454b-bead-6b7fb91e2123
-    revision: 5
-    hash: c9bca213c7442ee20a62fdb7725299d2b8b10c34777efb7e1814a9391fc1fd92
-    local_sha256: d1d4c3e5400bf4b365020be262381320d4927f8afe22cceefacca60b82ad4342
+    revision: 6
+    hash: 6c975c0766c89b5086a6624099ae7a615293804377b78778c50a5ea7a01e4996
+    local_sha256: 449be705fb1505223c0deb878b679073486ea39fdf00b8fb0bc6817e056f5984
     synced_at: '2026-09-04'
   platform_schedule:
     cron: 30 5 * * 0
@@ -329,15 +329,15 @@ dependencies:
   required_by:
   - build/identity_eval.py
   - warehouse/models/identity/digest.sql
-  verified_revision: 3
+  verified_revision: 4
   owner: oso
   files:
     model: warehouse/models/identity/org_edges.sql
   mirror:
     model_id: d64df19d-4f58-46db-89d4-83d8dad206eb
-    revision: 3
-    hash: fddb77887404396590f3855f9cbe606d0092f38a91f9d0c389acde26afa80b64
-    local_sha256: 18b943bbd141beda97cc3417fa32dbca072ac7aa8a8b3e880a234ec2b5c07ebe
+    revision: 4
+    hash: 451dce7e8b5e2cfee23eb8df6db3769a42fd44e79d86666f7539ed94d449eb82
+    local_sha256: bed9b5afc54dda4b2d7018dd7ff523cf40a2bda01f28c3d1e4af33528f1263ca
     synced_at: '2026-09-04'
   platform_schedule:
     cron: 30 5 * * 0
@@ -349,15 +349,15 @@ dependencies:
   freshness_requirement: <= 8 days (weekly platform refresh)
   required_by:
   - build/identity_digest.py
-  verified_revision: 4
+  verified_revision: 5
   owner: oso
   files:
     model: warehouse/models/identity/digest.sql
   mirror:
     model_id: 8c2cdffc-58c7-4ea3-b90f-eef0e5c8cca3
-    revision: 4
-    hash: 9a013b01ab3daf786da07904d32ded934402195f898403177f8baccbdc39fddd
-    local_sha256: cd186745cff120b655448464024692de513c1fb258edd8403e1f6e3e005a7145
+    revision: 5
+    hash: c2c33147d5ff4dd7cbbb7d6d9f2761d2480774a60673f632655e4ba508bc6f06
+    local_sha256: 0b3a34dc58d7e0d110334b19c655ae6d43b247a35afd812a4f1cc1da2643600f
     synced_at: '2026-09-04'
   platform_schedule:
     cron: 30 5 * * 0

--- a/warehouse/dependencies.yaml
+++ b/warehouse/dependencies.yaml
@@ -74,7 +74,7 @@ dependencies:
   platform_schedule:
     cron: 0 4 * * 1
     timezone: UTC
-    last_observed_trigger: null
+    last_observed_trigger: SCHEDULED
   retirement_context: 'Phase 7 / §9.3: the platform openness chain is RETIRED (deleted, not migrated)
     once the repo-owned evaluation.axis_* scoring trace dual-runs green across releases (#384). Tracked
     as a dependency because the repo drives that retirement, not because it owns the model.'
@@ -100,7 +100,7 @@ dependencies:
   platform_schedule:
     cron: 0 4 * * 1
     timezone: UTC
-    last_observed_trigger: null
+    last_observed_trigger: SCHEDULED
   retirement_context: 'Phase 7 / §9.3: the platform openness chain is RETIRED (deleted, not migrated)
     once the repo-owned evaluation.axis_* scoring trace dual-runs green across releases (#384). Tracked
     as a dependency because the repo drives that retirement, not because it owns the model.'
@@ -158,16 +158,16 @@ dependencies:
   - build/check_artifacts.py
   - warehouse/models/observations/product_adoption_current.sql
   - warehouse/models/signal_github/product_adoption.sql
-  verified_revision: 3
+  verified_revision: 4
   owner: oso
   files:
     model: warehouse/models/signal_pypi/package_downloads.sql
   mirror:
     model_id: a88bff56-0a00-49d1-8667-809a79b4d7c0
-    revision: 3
-    hash: d5311e2d3feb3b5f0190134b70c143586bcda911ed530ca52545c53325b7bbd0
-    local_sha256: 21fe2106888e7cf8aecc12d3a57b449a8a064537608eb4ac54ac32bb5d180499
-    synced_at: '2026-08-15'
+    revision: 4
+    hash: 39511381c4f06644ff520f8182edc3d06cfeee60f21b5a976817e2a98ed4dfc7
+    local_sha256: a357c9ff6f8948870533031a544e129ae2d479e1dac8f27c37e7c162cf0bf817
+    synced_at: '2026-09-04'
   platform_schedule:
     cron: 0 1 * * 0
     timezone: UTC

--- a/warehouse/dependencies.yaml
+++ b/warehouse/dependencies.yaml
@@ -308,15 +308,15 @@ dependencies:
   required_by:
   - build/identity_eval.py
   - warehouse/models/identity/digest.sql
-  verified_revision: 6
+  verified_revision: 7
   owner: oso
   files:
     model: warehouse/models/identity/equivalence_edges.sql
   mirror:
     model_id: 10fc9fc9-799b-454b-bead-6b7fb91e2123
-    revision: 6
-    hash: 6c975c0766c89b5086a6624099ae7a615293804377b78778c50a5ea7a01e4996
-    local_sha256: 449be705fb1505223c0deb878b679073486ea39fdf00b8fb0bc6817e056f5984
+    revision: 7
+    hash: 8eba2535b2a28e9d0e6259c02ab2a7e7e8bbacfc369b5bc38205acbc0b16d280
+    local_sha256: 2129f999c791a1b805e28c7f4e365dd8d7fd627bbe6df3a924a874583aa52f26
     synced_at: '2026-09-04'
   platform_schedule:
     cron: 30 5 * * 0
@@ -329,15 +329,15 @@ dependencies:
   required_by:
   - build/identity_eval.py
   - warehouse/models/identity/digest.sql
-  verified_revision: 4
+  verified_revision: 5
   owner: oso
   files:
     model: warehouse/models/identity/org_edges.sql
   mirror:
     model_id: d64df19d-4f58-46db-89d4-83d8dad206eb
-    revision: 4
-    hash: 451dce7e8b5e2cfee23eb8df6db3769a42fd44e79d86666f7539ed94d449eb82
-    local_sha256: bed9b5afc54dda4b2d7018dd7ff523cf40a2bda01f28c3d1e4af33528f1263ca
+    revision: 5
+    hash: a2ef6fb4a30d0cfcdb4881eb0760869392fb6b639b79dd412cdb031488aca4e6
+    local_sha256: afb615d0e5517b370f5c723ae05d7c9871cdfa45f512ad759c4c1932f59713ec
     synced_at: '2026-09-04'
   platform_schedule:
     cron: 30 5 * * 0
@@ -349,15 +349,15 @@ dependencies:
   freshness_requirement: <= 8 days (weekly platform refresh)
   required_by:
   - build/identity_digest.py
-  verified_revision: 5
+  verified_revision: 6
   owner: oso
   files:
     model: warehouse/models/identity/digest.sql
   mirror:
     model_id: 8c2cdffc-58c7-4ea3-b90f-eef0e5c8cca3
-    revision: 5
-    hash: c2c33147d5ff4dd7cbbb7d6d9f2761d2480774a60673f632655e4ba508bc6f06
-    local_sha256: 0b3a34dc58d7e0d110334b19c655ae6d43b247a35afd812a4f1cc1da2643600f
+    revision: 6
+    hash: 860e2393c0ae677a889c0e5301e0368efd1f7e19abc8146d613eb5ee6c2f43a5
+    local_sha256: a6f4866d49656137ccc02b2c95662224f52b0af8a53f6eb485581f1d16177f7c
     synced_at: '2026-09-04'
   platform_schedule:
     cron: 30 5 * * 0

--- a/warehouse/models/identity/digest.sql
+++ b/warehouse/models/identity/digest.sql
@@ -79,21 +79,31 @@
 -- derived by folding the artifact via currentai.identity.artifact_nodes (the same fold CASE
 -- duplicated across this dataset; see identity_artifact_nodes.sql's `keyed` CTE).
 --
--- evidence_kinds and last_evidence_change are NOT read from currentai.identity.candidates.
--- candidates.evidence_kinds tried to aggregate membership_edges' method vocabulary, but
--- membership_edges' name_match evidence itself reads currentai.identity.candidates -- a genuine
--- cycle in the model DAG (candidates -> membership_edges -> candidates), so the platform can
--- never resolve it and candidates.evidence_kinds is deployed as a permanently empty array. This
--- model breaks the cycle on the read side: it aggregates the method vocabulary itself, straight
--- from the three edge tables it already joins (membership_edges, equivalence_edges, org_edges),
--- in the `candidate_evidence` CTE below -- no read of currentai.identity.digest's own prior
--- output either, so no model in this dataset reads its own prior materialization.
--- last_evidence_change is the MAX of whatever per-edge timestamp this model can reach (today:
--- only currentai.identity.artifact_nodes.last_observed_at, reachable for membership items via
--- the same fold-join used for candidate_key -- equivalence and org items have no edge-reachable
--- timestamp today), falling back to the candidate's own last_evidence_change (computed in
--- identity_candidates.sql from first_seen and the resolution_ledger, which is NOT part of this
--- cycle) when nothing edge-side is reachable.
+-- NO FETCH TIMESTAMP FEEDS ANY STATE DECISION IN THIS MODEL (reviewer ruling, 2026-09-04).
+-- currentai.identity.artifact_nodes.last_observed_at is a FETCH time -- the weekly run rewrites
+-- it on every pass -- so deriving an evidence-change time from it made every row look changed
+-- this week: `parked` became unreachable, all 25 review slots went to name-match-only items
+-- labelled `resurfaced_evidence`, and every alias item sat in `pool`. That is the freshness rule
+-- the repo already states (docs/guides/freshness.md): an evidence time is when the evidence was
+-- confirmed, never when a fetcher last looked. Two consequences here:
+--   * `last_evidence_change` is the resolution_ledger `decided_on` of a ruling naming this
+--     candidate (the `ledger_change` CTE below, folded to candidate_key exactly as
+--     identity_candidates.sql folds it), and NULL when no such ruling exists. It is NOT read from
+--     currentai.identity.candidates.last_evidence_change, which is
+--     GREATEST(node.last_observed_at, ledger) and so carries the fetch time inside it.
+--   * name-match-only is decided from the ITEM's own `method` array, not from an aggregate over
+--     the candidate. There is no candidate-level evidence-kind aggregation in this model any more
+--     (currentai.identity.candidates.evidence_kinds is a permanently empty array -- it tried to
+--     aggregate membership_edges' method vocabulary, but membership_edges reads
+--     currentai.identity.candidates for its name_match evidence, a genuine cycle in the model
+--     DAG). Per-item `method` answers the same question for a review decision -- what does THIS
+--     claim rest on -- without the cycle, without the UNNEST-and-regroup over three edge tables,
+--     and without any timestamp.
+-- DEFERRED: the `evidence_changed` resurfacing reason. It needs an evidence-history table (per
+-- (candidate_key, method) first-seen/last-confirmed rows) that does not exist; nothing reachable
+-- today dates a piece of evidence rather than a fetch. Until it exists the only resurfacing
+-- reason is 'age', and `resurfaced_reason` is NULL for every other row. Do not reinstate
+-- 'evidence_changed' from a fetch column.
 --
 -- sweep_week = sweep_week_start = DATE_TRUNC('week', CURRENT_DATE) AS DATE. This model runs
 -- weekly (Sunday 05:30 UTC, see docs/operations/deploy-models.md), so each run's CURRENT_DATE
@@ -103,96 +113,78 @@
 -- column (revision 3, deployed 2026-09-03), so a future version of this model can join it
 -- consistently with the other two edge tables. It is not read here yet.
 --
--- state:
---   parked      evidence_kinds = ARRAY['name_match'] (the weakest signal -- no other evidence has
---               ever attached to this candidate) AND last_evidence_change is more than 7 days
---               old AND first_seen is less than 56 days old. Held back from the review queue.
---   resurfaced  name-match-only, but EITHER first_seen >= 56 days ago (resurfaced_reason =
---               'age') OR last_evidence_change is within the last 7 days (resurfaced_reason =
---               'evidence_changed'). Competes for the same 25 weekly slots as `active`.
---   active      not name-match-only (or has no candidate context to test); ranked alongside
---               `resurfaced` items and capped at 25 rows per sweep_week.
---   pool        an active- or resurfaced-eligible item that ranked beyond the top 25 this week;
---               overflow, not reviewed this sweep. resurfaced_reason is NULL for a pool row even
---               if it was resurfaced-eligible pre-cap -- it did not actually resurface this week.
--- Ranking is GLOBAL; presentation is separate (reviewer ruling, 2026-09-04). The old key led
--- with `CASE relation WHEN 'equivalence' THEN 0 ELSE 1 END`, which handed all 25 slots to
--- equivalence items and starved every blast_radius = 3 membership item -- the only items that
--- can move a score -- behind them. Relation is now the fourth key, not the first, so the cap
--- selects the 25 most important items in the whole sweep regardless of relation:
+-- state (no timestamp in this logic is a fetch time -- see the ruling above):
+--   name_match_only  every element of the item's own `method` array is 'name_match'. The weakest
+--               signal there is: a repo or Hub id whose name segment happens to equal a product
+--               slug, with nothing else pointing at it. An item carrying any other method
+--               (product_alias, model_family, org_handle, hf_namespace, homepage_domain,
+--               resolution_ledger alongside another source) is NOT name-match-only.
+--   parked      name_match_only AND first_seen >= sweep_week_start - 56 days. Recently discovered
+--               and resting on a name collision alone: held out of the review queue, never
+--               ranked, `rank` NULL.
+--   resurfaced  name_match_only AND first_seen < sweep_week_start - 56 days, resurfaced_reason
+--               'age'. It has sat in the pool for eight weeks or more, so it gets a look.
+--               Competes for the same 25 weekly slots as `active`.
+--   active      NOT name_match_only. Alias, model-family, handle, hf-namespace and ledger-backed
+--               evidence all qualify. Ranked alongside `resurfaced` and capped at 25.
+--   pool        an active- or resurfaced-eligible item that did not make the 25-slot cap this
+--               week; overflow, not reviewed this sweep, `rank` NULL and resurfaced_reason NULL
+--               (it did not actually resurface this week).
+-- Ranking is GLOBAL; presentation is separate (reviewer ruling, 2026-09-04). The key, in order:
 --   1. blast_radius DESC              (3 = a ruling moves a score)
---   2. resurfacing urgency DESC       (resurfaced/evidence_changed, then resurfaced/age, then
---                                      plain active -- something that changed outranks something
---                                      that merely aged, which outranks something new)
+--   2. urgency                        (resurfaced/age first, then plain active -- something that
+--                                      has waited eight weeks outranks something new)
 --   3. first_seen ASC                 (older first -- an item starved for weeks wins the tie)
 --   4. relation priority              (equivalence, membership, org, artifact_identity)
 --   5. confidence DESC
--- `tiebreak` (downloads + stars) is no longer a ranking key; it stays as an output column
--- because build/identity_digest.py orders WITHIN a rendered section by it.
--- Cap: ROW_NUMBER() OVER (PARTITION BY sweep_week ORDER BY <the five keys above>) among state IN
--- ('active', 'resurfaced')-eligible rows; rank <= 25 keeps its state, rank > 25 becomes 'pool'.
--- That row number is exposed as the `rank` column (INTEGER, 1 = most important) so a renderer
--- can group by relation for display and still show, or re-sort by, the global standing. A parked
--- row never competed for a slot, so its `rank` is NULL; a `pool` row carries its real rank,
--- which is > 25 by definition. Output is ordered by the same key.
+-- `tiebreak` (downloads + stars) is not a ranking key; it stays as an output column because
+-- build/identity_digest.py orders WITHIN a rendered section by it.
+--
+-- Cap: 25 items per sweep_week, filled with a PER-RELATION RESERVATION (reviewer ruling,
+-- 2026-09-04) rather than purely globally. A purely global cap let one relation and one evidence
+-- class monopolize the whole queue -- the week the ranking went global, all 25 slots went to
+-- membership items and the equivalence and org sections rendered zero. So:
+--   1. the top 5 eligible items of EACH relation by the key above are taken first (fewer if a
+--      relation has fewer than 5 eligible items -- there is no padding and no relation is owed a
+--      slot it cannot fill), then
+--   2. the remaining slots are filled by global order from what is left.
+-- With three live relations the reservation claims at most 15 of the 25 slots, so global standing
+-- still decides the majority of the queue. `rank` is the item's final position in the selected
+-- set, 1..25, ordered by the global key -- NOT the pre-cap global order. A row outside the cap
+-- (`pool`) and a `parked` row both get `rank` NULL: neither is being reviewed this week, and a
+-- rank on an unreviewed row invited exactly the "rank means selected" misreading. Output is
+-- ordered by the global key, parked rows last.
 --
 -- Output casts: explicit CAST on every output column (DATE sweep_week, VARCHAR strings, DOUBLE
 -- confidence, ARRAY(VARCHAR) method/evidence/penalties/options, INTEGER blast_radius, BIGINT
 -- tiebreak, INTEGER rank), matching the deploy pass's fix on the first four models. Date
 -- arithmetic uses DATE_ADD('day', -N, sweep_week), not the `date - INTERVAL 'N' DAY` operator
--- form, and the result is cast to TIMESTAMP(6) before comparing against
--- first_seen/last_evidence_change (both TIMESTAMP(6)).
+-- form, and the result is cast to TIMESTAMP(6) before comparing against first_seen (TIMESTAMP(6)
+-- throughout this dataset).
 
 WITH sweep AS (
   SELECT CAST(DATE_TRUNC('week', CURRENT_DATE) AS DATE) AS sweep_week
 ),
 
--- Method vocabulary and reachable evidence timestamp per candidate_key, aggregated straight from
--- the three edge tables (no read of currentai.identity.candidates.evidence_kinds, which is a
--- permanently empty array -- see the header note above on why). This is the cycle-free
--- replacement for the aggregation candidates.sql used to do.
-membership_evidence AS (
+-- The only evidence-DATED source this model can reach: a resolution_ledger ruling naming the
+-- candidate. decided_on is the day a human decided, which is what an evidence time means. Folded
+-- to candidate_key with the same CASE identity_candidates.sql and identity_equivalence_edges.sql
+-- use (Trino has no shared macro, so it is intentionally duplicated, not re-derived
+-- differently). MAX(CAST(decided_on AS TIMESTAMP(6))) matches identity_candidates.sql: decided_on
+-- is a text column, every live value parses, and a malformed one should fail loudly rather than
+-- become a silent NULL.
+-- No fetch column appears here, and none may be added: see the header ruling.
+ledger_change AS (
   SELECT
-    n.artifact_kind || ':' || n.artifact_key AS candidate_key,
-    meth AS method,
-    n.last_observed_at AS evidence_ts
-  FROM currentai.identity.membership_edges m
-  JOIN currentai.identity.artifact_nodes n
-    ON n.artifact_kind = m.artifact_kind AND CONTAINS(n.also_seen_as, m.artifact_id)
-  CROSS JOIN UNNEST(m.method) AS t(meth)
-),
-
-equivalence_evidence AS (
-  SELECT
-    e.candidate_key,
-    meth AS method,
-    CAST(NULL AS TIMESTAMP(6)) AS evidence_ts
-  FROM currentai.identity.equivalence_edges e
-  CROSS JOIN UNNEST(e.method) AS t(meth)
-),
-
-org_evidence AS (
-  SELECT
-    o.candidate_key,
-    meth AS method,
-    CAST(NULL AS TIMESTAMP(6)) AS evidence_ts
-  FROM currentai.identity.org_edges o
-  CROSS JOIN UNNEST(o.method) AS t(meth)
-),
-
-candidate_evidence AS (
-  SELECT
-    candidate_key,
-    CAST(ARRAY_SORT(ARRAY_DISTINCT(ARRAY_AGG(method))) AS ARRAY(VARCHAR)) AS evidence_kinds,
-    MAX(evidence_ts) AS max_edge_ts
-  FROM (
-    SELECT * FROM membership_evidence
-    UNION ALL
-    SELECT * FROM equivalence_evidence
-    UNION ALL
-    SELECT * FROM org_evidence
-  )
-  GROUP BY candidate_key
+    artifact_kind || ':' ||
+      CASE
+        WHEN artifact_kind IN ('pypi', 'crates')
+          THEN REGEXP_REPLACE(LOWER(artifact_id), '[-_.]+', '-')
+        ELSE LOWER(artifact_id)
+      END AS candidate_key,
+    MAX(CAST(decided_on AS TIMESTAMP(6))) AS last_ruling_at
+  FROM currentai.registry.resolution_ledger
+  GROUP BY 1
 ),
 
 membership_items AS (
@@ -216,8 +208,7 @@ membership_items AS (
     (m.product_tier = 'head') AS product_is_head,
     c.downloads_30d,
     c.stars,
-    COALESCE(c.first_seen, DATE '1970-01-01') AS first_seen,
-    COALESCE(c.last_evidence_change, TIMESTAMP '1970-01-01') AS candidate_last_evidence_change
+    COALESCE(c.first_seen, DATE '1970-01-01') AS first_seen
   FROM currentai.identity.membership_edges m
   LEFT JOIN currentai.identity.artifact_nodes n
     ON n.artifact_kind = m.artifact_kind AND n.artifact_id = m.artifact_id
@@ -247,8 +238,7 @@ equivalence_items AS (
     (e.product_tier = 'head') AS product_is_head,
     c.downloads_30d,
     c.stars,
-    COALESCE(c.first_seen, DATE '1970-01-01') AS first_seen,
-    COALESCE(c.last_evidence_change, TIMESTAMP '1970-01-01') AS candidate_last_evidence_change
+    COALESCE(c.first_seen, DATE '1970-01-01') AS first_seen
   FROM currentai.identity.equivalence_edges e
   LEFT JOIN currentai.identity.candidates c ON c.candidate_key = e.candidate_key
   -- 'product_alias' is deliberately NOT excluded here (reviewer ruling 2026-09-04): it is capped
@@ -281,8 +271,7 @@ org_items AS (
     FALSE AS product_is_head,
     c.downloads_30d,
     c.stars,
-    COALESCE(c.first_seen, DATE '1970-01-01') AS first_seen,
-    COALESCE(c.last_evidence_change, TIMESTAMP '1970-01-01') AS candidate_last_evidence_change
+    COALESCE(c.first_seen, DATE '1970-01-01') AS first_seen
   -- org_edges has no 1.0 authoritative source in this plan (0.85/0.80/0.75 only), so the only
   -- filter here is the pool-tier restriction.
   FROM currentai.identity.org_edges o
@@ -324,22 +313,27 @@ scored AS (
     CAST(ARRAY['confirm', 'reject', 'park'] AS ARRAY(VARCHAR)) AS options,
     CAST('no edge' AS VARCHAR) AS default_if_ignored,
     CAST(ci.first_seen AS TIMESTAMP(6)) AS first_seen,
-    CAST(COALESCE(ce.max_edge_ts, ci.candidate_last_evidence_change) AS TIMESTAMP(6))
-      AS last_evidence_change,
-    COALESCE(ce.evidence_kinds, ci.method) AS evidence_kinds
+    -- Evidence time, not fetch time: the ledger ruling that named this candidate, or NULL when
+    -- no ruling names it. See the header ruling -- do not COALESCE a fetch column in here.
+    CAST(lc.last_ruling_at AS TIMESTAMP(6)) AS last_evidence_change
   FROM current_items ci
   CROSS JOIN sweep s
-  LEFT JOIN candidate_evidence ce ON ce.candidate_key = ci.candidate_key
+  LEFT JOIN ledger_change lc ON lc.candidate_key = ci.candidate_key
 ),
 
--- week_ago / eight_weeks_ago via DATE_ADD (not the `date - INTERVAL` operator form) and cast to
--- TIMESTAMP(6) so they compare cleanly against last_evidence_change/first_seen (both TIMESTAMP(6)
--- throughout this dataset).
+-- eight_weeks_ago via DATE_ADD (not the `date - INTERVAL` operator form) and cast to TIMESTAMP(6)
+-- so it compares cleanly against first_seen, which is TIMESTAMP(6) throughout this dataset.
+-- name-match-only is read off the item's OWN method array: every element is 'name_match'. FILTER
+-- rather than `method = ARRAY['name_match']` so an item that somehow carries the same method
+-- twice still reads as name-match-only, and the CARDINALITY > 0 guard keeps an item with an empty
+-- method array (none live -- checked) out of the parked branch instead of into it.
 thresholds AS (
   SELECT
     *,
-    (evidence_kinds = ARRAY['name_match']) AS is_name_match_only,
-    CAST(DATE_ADD('day', -7, sweep_week) AS TIMESTAMP(6)) AS week_ago,
+    (
+      CARDINALITY(method) > 0
+      AND CARDINALITY(FILTER(method, m -> m <> 'name_match')) = 0
+    ) AS is_name_match_only,
     CAST(DATE_ADD('day', -56, sweep_week) AS TIMESTAMP(6)) AS eight_weeks_ago
   FROM scored
 ),
@@ -349,24 +343,24 @@ pre_state AS (
     *,
     CASE
       WHEN NOT is_name_match_only THEN 'active_candidate'
-      WHEN first_seen <= eight_weeks_ago THEN 'resurfaced_age'
-      WHEN last_evidence_change >= week_ago THEN 'resurfaced_evidence'
+      WHEN first_seen < eight_weeks_ago THEN 'resurfaced_age'
       ELSE 'parked'
     END AS pre_state_label
   FROM thresholds
 ),
 
 -- Global ranking. Relation is the FOURTH key, not the first -- see the header on why the old
--- relation-first key starved every blast_radius = 3 membership item. The two ordering CASEs are
--- factored out here so the window function, the exposed `rank` column and the final ORDER BY
--- cannot drift apart.
+-- relation-first key starved every blast_radius = 3 membership item. The ordering CASEs are
+-- factored out here so the window functions, the exposed `rank` column and the final ORDER BY
+-- cannot drift apart. `parked_last` keeps parked rows out of the way of every ROW_NUMBER below
+-- without a WHERE (they still have to appear in the output).
 priorities AS (
   SELECT
     *,
+    CASE WHEN pre_state_label = 'parked' THEN 1 ELSE 0 END AS parked_last,
     CASE pre_state_label
-      WHEN 'resurfaced_evidence' THEN 0
-      WHEN 'resurfaced_age' THEN 1
-      ELSE 2
+      WHEN 'resurfaced_age' THEN 0
+      ELSE 1
     END AS urgency_rank,
     CASE relation
       WHEN 'equivalence' THEN 0
@@ -377,7 +371,9 @@ priorities AS (
   FROM pre_state
 ),
 
-ranked AS (
+-- Two orderings over the eligible rows, on the identical key: the global standing, and the
+-- standing within the row's own relation. The second is what the per-relation reservation reads.
+orders AS (
   SELECT
     *,
     CASE
@@ -385,14 +381,63 @@ ranked AS (
         ROW_NUMBER() OVER (
           PARTITION BY sweep_week
           ORDER BY
+            parked_last,
             blast_radius DESC,
             urgency_rank,
             first_seen ASC,
             relation_rank,
             confidence DESC
         )
-    END AS eligible_rank
+    END AS global_order,
+    CASE
+      WHEN pre_state_label <> 'parked' THEN
+        ROW_NUMBER() OVER (
+          PARTITION BY sweep_week, relation
+          ORDER BY
+            parked_last,
+            blast_radius DESC,
+            urgency_rank,
+            first_seen ASC,
+            relation_rank,
+            confidence DESC
+        )
+    END AS relation_order
   FROM priorities
+),
+
+-- The cap, with the per-relation reservation. Each relation's top 5 eligible items are claimed
+-- first (a relation with fewer than 5 claims fewer -- nothing is padded), and the rest of the 25
+-- goes to global order. `slot_order <= 25` is therefore the selected set; it is NOT the item's
+-- rank, because the reservation deliberately jumps items ahead of their global standing.
+selection AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (
+      PARTITION BY sweep_week
+      ORDER BY
+        CASE WHEN global_order IS NULL THEN 1 ELSE 0 END,
+        CASE WHEN relation_order <= 5 THEN 0 ELSE 1 END,
+        global_order
+    ) AS slot_order
+  FROM orders
+),
+
+-- `rank` is the selected item's 1..25 position in GLOBAL order, so a reserved item that was
+-- promoted into the cap still shows its true standing. The PARTITION BY on the selected flag is
+-- what restarts the numbering at 1 inside the cap; rows outside it get NULL.
+ranked AS (
+  SELECT
+    *,
+    CASE
+      WHEN global_order IS NOT NULL AND slot_order <= 25 THEN
+        ROW_NUMBER() OVER (
+          PARTITION BY
+            sweep_week,
+            CASE WHEN global_order IS NOT NULL AND slot_order <= 25 THEN 1 ELSE 0 END
+          ORDER BY global_order
+        )
+    END AS final_rank
+  FROM selection
 )
 
 SELECT
@@ -416,24 +461,26 @@ SELECT
   CAST(
     CASE
       WHEN pre_state_label = 'parked' THEN 'parked'
-      WHEN eligible_rank <= 25 AND pre_state_label = 'active_candidate' THEN 'active'
-      WHEN eligible_rank <= 25 THEN 'resurfaced'
-      ELSE 'pool'
+      WHEN final_rank IS NULL THEN 'pool'
+      WHEN pre_state_label = 'resurfaced_age' THEN 'resurfaced'
+      ELSE 'active'
     END AS VARCHAR
   ) AS state,
+  -- 'age' is the only reason today: 'evidence_changed' is deferred until an evidence-history
+  -- table exists (see the header). NULL on every row that is not a resurfaced item inside the cap.
   CAST(
     CASE
-      WHEN eligible_rank <= 25 AND pre_state_label = 'resurfaced_age' THEN 'age'
-      WHEN eligible_rank <= 25 AND pre_state_label = 'resurfaced_evidence' THEN 'evidence_changed'
+      WHEN final_rank IS NOT NULL AND pre_state_label = 'resurfaced_age' THEN 'age'
       ELSE CAST(NULL AS VARCHAR)
     END AS VARCHAR
   ) AS resurfaced_reason,
-  -- Global standing, 1 = most important. NULL for a parked row, which never competed for a
-  -- slot; > 25 for a pool row. Exposed so a renderer can group by relation for display without
-  -- losing the ranking the cap was actually decided on.
-  CAST(eligible_rank AS INTEGER) AS "rank"
+  -- Final position in this week's 25, 1 = most important, in global order. NULL for a parked row
+  -- (never competed) and for a pool row (competed, missed the cap) -- neither is being reviewed
+  -- this week, and a rank on an unreviewed row reads as if it were.
+  CAST(final_rank AS INTEGER) AS "rank"
 FROM ranked
 ORDER BY
+  parked_last,
   blast_radius DESC,
   urgency_rank,
   first_seen ASC,

--- a/warehouse/models/identity/digest.sql
+++ b/warehouse/models/identity/digest.sql
@@ -14,18 +14,16 @@
 -- equivalence item over the same artifact and product produce byte-identical item_ids, because
 -- artifact_id and artifact_key are the same string for an already-lowercase repo. That collided
 -- on 33 item_ids live (2026-09-04) and broke the stated grain.
--- Declared edges (method = ['declared'] or ['resolution_ledger'] or ['product_alias']) are NOT
--- reviewable claims -- a human already wrote them down -- so this model excludes any item whose
--- method set is entirely made of those authoritative sources; it carries only the edges that
--- still need a human look.
--- Caveat on 'product_alias', worth a maintainer ruling: as of 2026-09-04 that source no longer
--- carries confidence 1.0. identity_equivalence_edges.sql caps it at 0.9 because the alias ->
--- product half is declared but the alias -> node half is matched by name, and the name match is
--- namespace-blind (`tiny-random/phi-4` earns the same alias edge as `microsoft/phi-4`). The
--- exclusion below is unchanged, so those 46 rows still never reach a reviewer. If the cap is
--- right then the exclusion is arguably wrong; both cannot be. Left as ruled rather than changed
--- unilaterally, because dropping 'product_alias' from the exclusion list would push items into
--- the 25-slot weekly cap and change what a reviewer sees.
+-- Declared edges (method = ['declared'] or ['resolution_ledger']) are NOT reviewable claims -- a
+-- human already wrote them down -- so this model excludes any item whose method set is entirely
+-- made of those authoritative sources; it carries only the edges that still need a human look.
+-- 'product_alias' is NOT on that list (reviewer ruling, 2026-09-04). It was, until the previous
+-- pass capped it at 0.9 in identity_equivalence_edges.sql: the alias -> product half of the
+-- mapping is declared by a curator, but the alias -> node half is a namespace-blind name match,
+-- so `tiny-random/phi-4` earns the same alias edge as `microsoft/phi-4`. An edge that is not
+-- scored as certain is a reviewable claim, so alias-only items now compete for the weekly cap
+-- like any other; being alias-evidenced makes an item `active`-eligible (it is not
+-- name-match-only), never parked.
 --
 -- Tier scope: identity_equivalence_edges.sql and identity_org_edges.sql now compute over
 -- currentai.identity.artifact_nodes -- ALL tiers (head, tail, pool), not just undeclared pool
@@ -39,21 +37,26 @@
 -- Shape follows the design's digest schema exactly: item_id, relation, sweep_week,
 -- candidate_key, left and right as canonical (kind, id) pairs, confidence, method, evidence[],
 -- penalties[], proposed_action, blast_radius, tiebreak, options, default_if_ignored.
---   relation      'membership' | 'equivalence' | 'org', matching the item_id prefix above.
+--   relation      'membership' | 'equivalence' | 'org', matching item_kind above.
 --   candidate_key <artifact_kind>:<artifact_key> of the artifact side (see identity_candidates.sql).
 --   left          ROW(kind, id) for the artifact side: kind = artifact_kind, id = the declared
---                 artifact_id for membership items, or the unprefixed folded artifact_key for
---                 equivalence/org items (those edge tables carry no declared spelling).
+--                 artifact_id for membership items (artifact_identity_edges' grain), or the
+--                 unprefixed folded artifact_key for equivalence/org items (those edge tables
+--                 carry no declared spelling, only candidate_key).
 --   right         ROW(kind, id) for the other side: ('product', product_slug) for membership and
 --                 equivalence, ('org', org_slug) for org.
---   evidence      Per-item evidence strings. The three edge tables pre-aggregate method into one
---                 sorted/distinct array per row (no per-method confidence survives that
---                 aggregation), so evidence[] here is method[] verbatim. Kept as its own column
---                 because the design and the eval contract both name it separately.
+--   evidence      Per-item evidence strings, each `<url> | <excerpt>` -- a link a reviewer can
+--                 open and a phrase saying what it says. The union of the contributing edges'
+--                 own `evidence` arrays, distinct and sorted. Until 2026-09-04 this column was
+--                 method[] verbatim, which told a reviewer the NAME of the inference and nothing
+--                 they could check; the three edge tables now each emit a real evidence array
+--                 (see their headers for the per-source shapes) and this model relays it.
+--                 `method` is unchanged and still carries the method-name vocabulary.
 --   proposed_action 'confirm_<relation>_edge' -- the single action this item's evidence points
 --                 toward; `options` (below) is what a reviewer can actually choose.
 --   options       ['confirm', 'reject', 'park'] for every relation today. No relation-specific
---                 vocabulary is defined by the design brief, so this model does not invent one.
+--                 vocabulary (e.g. a distinct 'mark_sku_of' for equivalence) is defined by the
+--                 design brief, so this model does not invent one.
 --   default_if_ignored always the literal 'no edge' -- an unreviewed item never gets promoted to
 --                 an edge by default.
 --
@@ -63,17 +66,18 @@
 --   2  the item is an equivalence edge onto a head-tier product, OR the underlying candidate's
 --      downloads_30d >= 1000, OR its stars >= 1000 (a promotion decision -- could move a stage).
 --   1  otherwise.
--- tiebreak (BIGINT, separate column, used after blast_radius and before confidence in ranking) =
---   COALESCE(downloads_30d, 0) + COALESCE(stars, 0) on the underlying artifact/candidate.
---   BIGINT, not INTEGER (changed 2026-09-04). Both inputs are BIGINT columns on
---   currentai.identity.candidates and the sum is a raw download count: the live maximum is
+-- tiebreak (BIGINT) = COALESCE(downloads_30d, 0) + COALESCE(stars, 0) on the underlying
+--   artifact/candidate. BIGINT, not INTEGER (changed 2026-09-04). Both inputs are BIGINT columns
+--   on currentai.identity.candidates and the sum is a raw download count: the live maximum is
 --   246,135,287, already 11% of the INT32 range, so a corpus one order of magnitude larger turns
---   the cast into a hard run failure rather than a degraded value. Nothing downstream reads it as
---   a 32-bit value -- it is a sort key only.
+--   the cast into a hard run failure rather than a degraded value. It is no longer a ranking key
+--   in this model (see the ranking note below) -- build/identity_digest.py still orders WITHIN a
+--   rendered section by it.
 --
 -- Candidate context: downloads_30d, stars and first_seen are read from
 -- currentai.identity.candidates by candidate_key -- for membership items, candidate_key is
--- derived by folding the artifact via currentai.identity.artifact_nodes.
+-- derived by folding the artifact via currentai.identity.artifact_nodes (the same fold CASE
+-- duplicated across this dataset; see identity_artifact_nodes.sql's `keyed` CTE).
 --
 -- evidence_kinds and last_evidence_change are NOT read from currentai.identity.candidates.
 -- candidates.evidence_kinds tried to aggregate membership_edges' method vocabulary, but
@@ -81,20 +85,23 @@
 -- cycle in the model DAG (candidates -> membership_edges -> candidates), so the platform can
 -- never resolve it and candidates.evidence_kinds is deployed as a permanently empty array. This
 -- model breaks the cycle on the read side: it aggregates the method vocabulary itself, straight
--- from the three edge tables it already joins, in the `candidate_evidence` CTE below -- and it
--- never reads its own prior output either, so no model in this dataset reads its own prior
--- materialization. last_evidence_change is the MAX of whatever per-edge timestamp this model can
--- reach (today: only currentai.identity.artifact_nodes.last_observed_at, reachable for membership
--- items via the same fold-join used for candidate_key), falling back to the candidate's own
--- last_evidence_change when nothing edge-side is reachable.
+-- from the three edge tables it already joins (membership_edges, equivalence_edges, org_edges),
+-- in the `candidate_evidence` CTE below -- no read of currentai.identity.digest's own prior
+-- output either, so no model in this dataset reads its own prior materialization.
+-- last_evidence_change is the MAX of whatever per-edge timestamp this model can reach (today:
+-- only currentai.identity.artifact_nodes.last_observed_at, reachable for membership items via
+-- the same fold-join used for candidate_key -- equivalence and org items have no edge-reachable
+-- timestamp today), falling back to the candidate's own last_evidence_change (computed in
+-- identity_candidates.sql from first_seen and the resolution_ledger, which is NOT part of this
+-- cycle) when nothing edge-side is reachable.
 --
 -- sweep_week = sweep_week_start = DATE_TRUNC('week', CURRENT_DATE) AS DATE. This model runs
 -- weekly (Sunday 05:30 UTC, see docs/operations/deploy-models.md), so each run's CURRENT_DATE
 -- lands in exactly one week.
 --
 -- NOTE for a future revision: identity_artifact_identity_edges.sql now carries a `candidate_tier`
--- column (revision 3), so a future version of this model can join it consistently with the other
--- two edge tables. It is not read here yet.
+-- column (revision 3, deployed 2026-09-03), so a future version of this model can join it
+-- consistently with the other two edge tables. It is not read here yet.
 --
 -- state:
 --   parked      evidence_kinds = ARRAY['name_match'] (the weakest signal -- no other evidence has
@@ -108,16 +115,33 @@
 --   pool        an active- or resurfaced-eligible item that ranked beyond the top 25 this week;
 --               overflow, not reviewed this sweep. resurfaced_reason is NULL for a pool row even
 --               if it was resurfaced-eligible pre-cap -- it did not actually resurface this week.
--- Cap: ROW_NUMBER() OVER (PARTITION BY sweep_week ORDER BY CASE relation WHEN 'equivalence' THEN
--- 0 ELSE 1 END, blast_radius DESC, tiebreak DESC, confidence DESC) among state IN
+-- Ranking is GLOBAL; presentation is separate (reviewer ruling, 2026-09-04). The old key led
+-- with `CASE relation WHEN 'equivalence' THEN 0 ELSE 1 END`, which handed all 25 slots to
+-- equivalence items and starved every blast_radius = 3 membership item -- the only items that
+-- can move a score -- behind them. Relation is now the fourth key, not the first, so the cap
+-- selects the 25 most important items in the whole sweep regardless of relation:
+--   1. blast_radius DESC              (3 = a ruling moves a score)
+--   2. resurfacing urgency DESC       (resurfaced/evidence_changed, then resurfaced/age, then
+--                                      plain active -- something that changed outranks something
+--                                      that merely aged, which outranks something new)
+--   3. first_seen ASC                 (older first -- an item starved for weeks wins the tie)
+--   4. relation priority              (equivalence, membership, org, artifact_identity)
+--   5. confidence DESC
+-- `tiebreak` (downloads + stars) is no longer a ranking key; it stays as an output column
+-- because build/identity_digest.py orders WITHIN a rendered section by it.
+-- Cap: ROW_NUMBER() OVER (PARTITION BY sweep_week ORDER BY <the five keys above>) among state IN
 -- ('active', 'resurfaced')-eligible rows; rank <= 25 keeps its state, rank > 25 becomes 'pool'.
--- Output is ordered by the same key.
+-- That row number is exposed as the `rank` column (INTEGER, 1 = most important) so a renderer
+-- can group by relation for display and still show, or re-sort by, the global standing. A parked
+-- row never competed for a slot, so its `rank` is NULL; a `pool` row carries its real rank,
+-- which is > 25 by definition. Output is ordered by the same key.
 --
 -- Output casts: explicit CAST on every output column (DATE sweep_week, VARCHAR strings, DOUBLE
 -- confidence, ARRAY(VARCHAR) method/evidence/penalties/options, INTEGER blast_radius, BIGINT
--- tiebreak). Date arithmetic uses DATE_ADD('day', -N, sweep_week), not the
--- `date - INTERVAL 'N' DAY` operator form, and the result is cast to TIMESTAMP(6) before
--- comparing against first_seen/last_evidence_change (both TIMESTAMP(6)).
+-- tiebreak, INTEGER rank), matching the deploy pass's fix on the first four models. Date
+-- arithmetic uses DATE_ADD('day', -N, sweep_week), not the `date - INTERVAL 'N' DAY` operator
+-- form, and the result is cast to TIMESTAMP(6) before comparing against
+-- first_seen/last_evidence_change (both TIMESTAMP(6)).
 
 WITH sweep AS (
   SELECT CAST(DATE_TRUNC('week', CURRENT_DATE) AS DATE) AS sweep_week
@@ -174,7 +198,10 @@ candidate_evidence AS (
 membership_items AS (
   SELECT
     'membership' AS relation,
-    -- The 'membership:' prefix is load-bearing -- see the header note on the item_id collision.
+    -- The 'membership:' prefix is load-bearing, not decoration. Without it a membership item and
+    -- an equivalence item over the same artifact and product produce byte-identical item_ids
+    -- (artifact_id and artifact_key are the same string for an already-lowercase repo), which
+    -- breaks this model's stated (sweep_week, item_id) grain -- 33 collisions live on 2026-09-04.
     'membership:' || m.artifact_kind || ':' || m.artifact_id || '->' || m.product_tier || ':'
       || m.product_slug AS item_id,
     n.artifact_kind || ':' || n.artifact_key AS candidate_key,
@@ -182,7 +209,7 @@ membership_items AS (
     CAST(ROW('product', m.product_slug) AS ROW(kind VARCHAR, id VARCHAR)) AS right_pair,
     m.confidence,
     m.method,
-    m.method AS evidence,
+    CAST(ARRAY_SORT(ARRAY_DISTINCT(m.evidence)) AS ARRAY(VARCHAR)) AS evidence,
     m.penalties,
     'confirm_membership_edge' AS proposed_action,
     (m.scoring_bearing AND m.product_tier = 'head') AS is_blast_3,
@@ -213,7 +240,7 @@ equivalence_items AS (
     CAST(ROW('product', e.product_slug) AS ROW(kind VARCHAR, id VARCHAR)) AS right_pair,
     e.confidence,
     e.method,
-    e.method AS evidence,
+    CAST(ARRAY_SORT(ARRAY_DISTINCT(e.evidence)) AS ARRAY(VARCHAR)) AS evidence,
     e.penalties,
     'confirm_equivalence_edge' AS proposed_action,
     FALSE AS is_blast_3,
@@ -224,10 +251,12 @@ equivalence_items AS (
     COALESCE(c.last_evidence_change, TIMESTAMP '1970-01-01') AS candidate_last_evidence_change
   FROM currentai.identity.equivalence_edges e
   LEFT JOIN currentai.identity.candidates c ON c.candidate_key = e.candidate_key
+  -- 'product_alias' is deliberately NOT excluded here (reviewer ruling 2026-09-04): it is capped
+  -- at 0.9, so it is not an authoritative declaration. See the header.
   WHERE e.candidate_tier = 'pool'
     AND NOT (
       CARDINALITY(e.method) = 1
-      AND e.method[1] IN ('resolution_ledger', 'product_alias')
+      AND e.method[1] IN ('resolution_ledger')
     )
 ),
 
@@ -245,7 +274,7 @@ org_items AS (
     CAST(ROW('org', o.org_slug) AS ROW(kind VARCHAR, id VARCHAR)) AS right_pair,
     o.confidence,
     o.method,
-    o.method AS evidence,
+    CAST(ARRAY_SORT(ARRAY_DISTINCT(o.evidence)) AS ARRAY(VARCHAR)) AS evidence,
     o.penalties,
     'confirm_org_edge' AS proposed_action,
     FALSE AS is_blast_3,
@@ -304,7 +333,8 @@ scored AS (
 ),
 
 -- week_ago / eight_weeks_ago via DATE_ADD (not the `date - INTERVAL` operator form) and cast to
--- TIMESTAMP(6) so they compare cleanly against last_evidence_change/first_seen.
+-- TIMESTAMP(6) so they compare cleanly against last_evidence_change/first_seen (both TIMESTAMP(6)
+-- throughout this dataset).
 thresholds AS (
   SELECT
     *,
@@ -326,6 +356,27 @@ pre_state AS (
   FROM thresholds
 ),
 
+-- Global ranking. Relation is the FOURTH key, not the first -- see the header on why the old
+-- relation-first key starved every blast_radius = 3 membership item. The two ordering CASEs are
+-- factored out here so the window function, the exposed `rank` column and the final ORDER BY
+-- cannot drift apart.
+priorities AS (
+  SELECT
+    *,
+    CASE pre_state_label
+      WHEN 'resurfaced_evidence' THEN 0
+      WHEN 'resurfaced_age' THEN 1
+      ELSE 2
+    END AS urgency_rank,
+    CASE relation
+      WHEN 'equivalence' THEN 0
+      WHEN 'membership' THEN 1
+      WHEN 'org' THEN 2
+      ELSE 3
+    END AS relation_rank
+  FROM pre_state
+),
+
 ranked AS (
   SELECT
     *,
@@ -334,13 +385,14 @@ ranked AS (
         ROW_NUMBER() OVER (
           PARTITION BY sweep_week
           ORDER BY
-            CASE relation WHEN 'equivalence' THEN 0 ELSE 1 END,
             blast_radius DESC,
-            tiebreak DESC,
+            urgency_rank,
+            first_seen ASC,
+            relation_rank,
             confidence DESC
         )
     END AS eligible_rank
-  FROM pre_state
+  FROM priorities
 )
 
 SELECT
@@ -375,10 +427,15 @@ SELECT
       WHEN eligible_rank <= 25 AND pre_state_label = 'resurfaced_evidence' THEN 'evidence_changed'
       ELSE CAST(NULL AS VARCHAR)
     END AS VARCHAR
-  ) AS resurfaced_reason
+  ) AS resurfaced_reason,
+  -- Global standing, 1 = most important. NULL for a parked row, which never competed for a
+  -- slot; > 25 for a pool row. Exposed so a renderer can group by relation for display without
+  -- losing the ranking the cap was actually decided on.
+  CAST(eligible_rank AS INTEGER) AS "rank"
 FROM ranked
 ORDER BY
-  CASE relation WHEN 'equivalence' THEN 0 ELSE 1 END,
   blast_radius DESC,
-  tiebreak DESC,
+  urgency_rank,
+  first_seen ASC,
+  relation_rank,
   confidence DESC

--- a/warehouse/models/identity/equivalence_edges.sql
+++ b/warehouse/models/identity/equivalence_edges.sql
@@ -57,7 +57,9 @@
 --        `tiny-random/phi-4` (a random-weights test stub, not phi-4 at all) earns the same edge
 --        as `microsoft/phi-4`. 0.9 keeps a declared alias ahead of a model-family match (0.8)
 --        and behind a resolution_ledger ruling (1.0), which is the true ordering of how much
---        human judgment stands behind each.
+--        human judgment stands behind each. Because it is no longer scored as certain,
+--        currentai.identity.digest no longer excludes an alias-only edge from the review queue
+--        (reviewer ruling 2026-09-04) -- see that model's header.
 --   0.8  model family -- currentai.registry.model_families, `pattern` matched via LIKE with the
 --        glob `*` turned into SQL `%` (ESCAPE '\', and any literal `%` in the pattern escaped
 --        first so it is not itself read as a wildcard). Where several pattern rows match the same
@@ -92,6 +94,18 @@
 -- boundary, decided_in, decided_on, note, resolves_to), so the product slug is read straight from
 -- `resolves_to`, which is populated on every existing_product / sku_of row.
 --
+-- evidence (ARRAY(VARCHAR), added 2026-09-04 per reviewer ruling): one `<url> | <excerpt>`
+-- string per contributing evidence item, NOT a repeat of the method-name vocabulary. Shapes:
+--   resolution_ledger  <repo>/sources/resolution_ledger.yaml | ruling <verdict> decided_in <decided_in>
+--   product_alias      <artifact url> | product_aliases: <alias> -> <product>
+--   model_family       <artifact url> | model_families: <pattern> -> <product>
+--   name_match         <artifact url> | name segment equals product slug
+-- where <repo> is https://github.com/currentai-org/os-ai-map/blob/main. Artifact URLs are built
+-- per kind, matching build/serialize_registry.py's artifact_url construction; a
+-- huggingface_dataset therefore gets the /datasets/ form rather than the bare
+-- https://huggingface.co/<id> the ruling's model-family example shows, because that is the URL
+-- that actually resolves.
+--
 -- Output casts: explicit CAST on every output column (VARCHAR strings, DOUBLE confidence,
 -- ARRAY(VARCHAR) method/penalties), matching the deploy pass's fix on the first four models --
 -- the confidence literals (1.0/0.9/0.8/0.5) are Trino DECIMAL, not DOUBLE, so `GREATEST(0, LEAST(1,
@@ -111,6 +125,7 @@ WITH all_nodes AS (
 ledger_key AS (
   SELECT
     verdict,
+    decided_in,
     resolves_to AS product_slug,
     artifact_kind,
     artifact_kind || ':' ||
@@ -119,11 +134,16 @@ ledger_key AS (
           THEN LOWER(artifact_id)
         WHEN artifact_kind IN ('pypi', 'crates')
           THEN REGEXP_REPLACE(LOWER(artifact_id), '[-_.]+', '-')
+        -- homepage folds the WHOLE canonical URL, path included -- LOWER() is the entire rule,
+        -- exactly as in identity_artifact_nodes.sql's `keyed` CTE and identity_candidates.sql.
+        -- Until 2026-09-04 this branch extracted the bare host, which disagreed with both
+        -- siblings and with build/identity.py::fold_for_proposal: a ledger ruling on
+        -- `acme.com/product` would have been keyed `homepage:acme.com` and matched the wrong
+        -- node (or, once two products share a domain, several). Inert today -- the live ledger
+        -- is 302 rows, every one of them `github` -- and fixed here because this model was being
+        -- revised anyway, which is the moment the last pass named for it.
         WHEN artifact_kind = 'homepage'
-          THEN REGEXP_REPLACE(
-                 REGEXP_EXTRACT(LOWER(artifact_id), '^(?:[a-z]+://)?([^/]+)', 1),
-                 '^www\.', ''
-               )
+          THEN LOWER(artifact_id)
         ELSE LOWER(artifact_id)
       END AS candidate_key
   FROM currentai.registry.resolution_ledger
@@ -165,7 +185,10 @@ ledger_evidence AS (
     pt.product_tier,
     lk.product_slug,
     1.0 AS confidence,
-    'resolution_ledger' AS method
+    'resolution_ledger' AS method,
+    'https://github.com/currentai-org/os-ai-map/blob/main/sources/resolution_ledger.yaml'
+      || ' | ruling ' || lk.verdict || ' decided_in '
+      || COALESCE(lk.decided_in, '(unrecorded)') AS evidence_item
   FROM ledger_key lk
   LEFT JOIN all_nodes n
     ON n.candidate_key = lk.candidate_key AND n.artifact_kind = lk.artifact_kind
@@ -187,7 +210,20 @@ candidate_names AS (
         END,
         '[^a-zA-Z0-9]+', '-'
       ))
-    ) AS normalized_name
+    ) AS normalized_name,
+    -- Per-kind artifact URL, identical in construction to build/serialize_registry.py's
+    -- artifact_url. artifact_nodes carries no url column, hence the CASE.
+    CASE artifact_kind
+      WHEN 'github' THEN 'https://github.com/' || artifact_id
+      WHEN 'huggingface_model' THEN 'https://huggingface.co/' || artifact_id
+      WHEN 'huggingface_dataset' THEN 'https://huggingface.co/datasets/' || artifact_id
+      WHEN 'pypi' THEN 'https://pypi.org/project/' || artifact_id || '/'
+      WHEN 'npm' THEN 'https://www.npmjs.com/package/' || artifact_id
+      WHEN 'crates' THEN 'https://crates.io/crates/' || artifact_id
+      WHEN 'arxiv' THEN 'https://arxiv.org/abs/' || artifact_id
+      WHEN 'homepage' THEN 'https://' || artifact_id
+      ELSE artifact_id
+    END AS artifact_url
   FROM all_nodes
 ),
 
@@ -206,7 +242,9 @@ alias_evidence AS (
     pt.product_tier,
     pa.product_slug,
     0.9 AS confidence,
-    'product_alias' AS method
+    'product_alias' AS method,
+    cn.artifact_url || ' | product_aliases: ' || pa.alias || ' -> '
+      || pa.product_slug AS evidence_item
   FROM currentai.registry.product_aliases pa
   JOIN candidate_names cn
     ON cn.normalized_name =
@@ -228,6 +266,8 @@ family_matches AS (
     cn.candidate_tier,
     mf.product_slug,
     mf.pattern,
+    cn.artifact_url || ' | model_families: ' || mf.pattern || ' -> '
+      || mf.product_slug AS evidence_item,
     ROW_NUMBER() OVER (
       PARTITION BY cn.candidate_key
       ORDER BY LENGTH(mf.pattern) DESC
@@ -246,7 +286,8 @@ family_evidence AS (
     candidate_tier,
     product_slug,
     0.8 AS confidence,
-    'model_family' AS method
+    'model_family' AS method,
+    evidence_item
   FROM family_matches
   WHERE pattern_rank = 1
 ),
@@ -259,24 +300,25 @@ name_evidence AS (
     pt.product_tier,
     p.slug AS product_slug,
     0.5 AS confidence,
-    'name_match' AS method
+    'name_match' AS method,
+    cn.artifact_url || ' | name segment equals product slug' AS evidence_item
   FROM candidate_names cn
   JOIN currentai.registry.products p ON cn.normalized_name = LOWER(p.slug)
   JOIN products_tier_ranked pt ON pt.slug = p.slug
 ),
 
 combined AS (
-  SELECT candidate_key, artifact_kind, candidate_tier, product_tier, product_slug, confidence, method
+  SELECT candidate_key, artifact_kind, candidate_tier, product_tier, product_slug, confidence, method, evidence_item
   FROM ledger_evidence
   UNION ALL
-  SELECT candidate_key, artifact_kind, candidate_tier, product_tier, product_slug, confidence, method
+  SELECT candidate_key, artifact_kind, candidate_tier, product_tier, product_slug, confidence, method, evidence_item
   FROM alias_evidence
   UNION ALL
-  SELECT fe.candidate_key, fe.artifact_kind, fe.candidate_tier, pt.product_tier, fe.product_slug, fe.confidence, fe.method
+  SELECT fe.candidate_key, fe.artifact_kind, fe.candidate_tier, pt.product_tier, fe.product_slug, fe.confidence, fe.method, fe.evidence_item
   FROM family_evidence fe
   JOIN products_tier_ranked pt ON pt.slug = fe.product_slug
   UNION ALL
-  SELECT candidate_key, artifact_kind, candidate_tier, product_tier, product_slug, confidence, method
+  SELECT candidate_key, artifact_kind, candidate_tier, product_tier, product_slug, confidence, method, evidence_item
   FROM name_evidence
 )
 
@@ -288,6 +330,7 @@ SELECT
   CAST(product_slug AS VARCHAR) AS product_slug,
   CAST(GREATEST(0, LEAST(1, MAX(confidence) - 0)) AS DOUBLE) AS confidence,
   CAST(ARRAY_SORT(ARRAY_DISTINCT(ARRAY_AGG(method))) AS ARRAY(VARCHAR)) AS method,
+  CAST(ARRAY_SORT(ARRAY_DISTINCT(ARRAY_AGG(evidence_item))) AS ARRAY(VARCHAR)) AS evidence,
   CAST(ARRAY[] AS ARRAY(VARCHAR)) AS penalties
 FROM combined
 GROUP BY candidate_key, artifact_kind, product_tier, product_slug

--- a/warehouse/models/identity/equivalence_edges.sql
+++ b/warehouse/models/identity/equivalence_edges.sql
@@ -129,21 +129,18 @@ ledger_key AS (
     resolves_to AS product_slug,
     artifact_kind,
     artifact_kind || ':' ||
+      -- Two branches, because there are only two rules. pypi and crates collapse `[-_.]+` runs
+      -- to a single `-`; every other kind folds by LOWER() alone -- github and the two Hub kinds
+      -- because the id is already `<owner>/<name>`, homepage because the whole canonical URL is
+      -- the key (path included, exactly as in identity_artifact_nodes.sql's `keyed` CTE and
+      -- identity_candidates.sql). Until 2026-09-04 the homepage branch extracted the bare host,
+      -- which disagreed with both siblings and with build/identity.py::fold_for_proposal; the fix
+      -- made it identical to the default, and it was then kept as a separate branch for one pass,
+      -- which reads as if it did something. It did not. Do not re-add a kind whose rule is
+      -- LOWER(artifact_id) as its own branch -- add a branch only when the rule differs.
       CASE
-        WHEN artifact_kind IN ('github', 'huggingface_model', 'huggingface_dataset')
-          THEN LOWER(artifact_id)
         WHEN artifact_kind IN ('pypi', 'crates')
           THEN REGEXP_REPLACE(LOWER(artifact_id), '[-_.]+', '-')
-        -- homepage folds the WHOLE canonical URL, path included -- LOWER() is the entire rule,
-        -- exactly as in identity_artifact_nodes.sql's `keyed` CTE and identity_candidates.sql.
-        -- Until 2026-09-04 this branch extracted the bare host, which disagreed with both
-        -- siblings and with build/identity.py::fold_for_proposal: a ledger ruling on
-        -- `acme.com/product` would have been keyed `homepage:acme.com` and matched the wrong
-        -- node (or, once two products share a domain, several). Inert today -- the live ledger
-        -- is 302 rows, every one of them `github` -- and fixed here because this model was being
-        -- revised anyway, which is the moment the last pass named for it.
-        WHEN artifact_kind = 'homepage'
-          THEN LOWER(artifact_id)
         ELSE LOWER(artifact_id)
       END AS candidate_key
   FROM currentai.registry.resolution_ledger

--- a/warehouse/models/identity/membership_edges.sql
+++ b/warehouse/models/identity/membership_edges.sql
@@ -28,6 +28,26 @@
 -- Spot check from the deploy brief: a PyPI-declared product should read TRUE (pypi has a route),
 -- a homepage-declared product should read FALSE (homepage has no adoption route).
 --
+-- evidence (ARRAY(VARCHAR), added 2026-09-04 per reviewer ruling): one `<url> | <excerpt>`
+-- string per contributing evidence item, NOT a repeat of the method-name vocabulary. A reviewer
+-- reading the digest needs a link they can open and a phrase saying what it says; a method label
+-- ('declared', 'name_match') tells them neither. Shapes emitted by this model:
+--   declared (head)  <repo>/sources/products/<product_slug>.yaml | declared <kind> artifact
+--   declared (tail)  <repo>/sources/registry/<category_slug>.yaml | declared <kind> artifact
+--   name_match       <artifact url> | name segment equals product slug
+-- where <repo> is https://github.com/currentai-org/os-ai-map/blob/main.
+-- The tail form deviates from the ruling's single example (which names sources/products/) on
+-- purpose: a tail product is not declared in sources/products/ at all -- it is a row inside
+-- sources/registry/<category>.yaml (build/serialize_registry.py emits tail_products from
+-- exactly that file, and carries category_slug for it). Pointing a reviewer at a URL that 404s
+-- would be worse than a slightly different string.
+-- Artifact URLs are built per kind, matching build/serialize_registry.py's own artifact_url
+-- construction byte for byte (github, huggingface model/dataset, pypi with its trailing slash,
+-- npm, crates, arxiv, homepage). registry.product_artifacts and registry.tail_products both
+-- carry an `artifact_url` column, but the CASE is used instead so every evidence string in this
+-- dataset is built the same way -- equivalence_edges and org_edges read artifact_nodes, which
+-- has no url column at all.
+--
 -- TODO verify on deploy: the name-normalization rule below (lowercase, non [a-z0-9] runs
 -- collapsed to a single '-', trimmed) is a reasonable guess at "the same product name", not a
 -- rule taken from an existing module; tighten or replace once real name-match false positives
@@ -40,7 +60,9 @@ WITH declared_head AS (
     'head' AS product_tier,
     product_slug,
     1.0 AS confidence,
-    'declared' AS method
+    'declared' AS method,
+    'https://github.com/currentai-org/os-ai-map/blob/main/sources/products/'
+      || product_slug || '.yaml | declared ' || artifact_kind || ' artifact' AS evidence_item
   FROM currentai.registry.product_artifacts
 ),
 
@@ -51,7 +73,11 @@ declared_tail AS (
     'tail' AS product_tier,
     slug AS product_slug,
     1.0 AS confidence,
-    'declared' AS method
+    'declared' AS method,
+    -- sources/registry/<category>.yaml, not sources/products/<slug>.yaml: a tail product is a
+    -- row inside its category's registry file and has no file of its own. See the header.
+    'https://github.com/currentai-org/os-ai-map/blob/main/sources/registry/'
+      || category_slug || '.yaml | declared ' || artifact_kind || ' artifact' AS evidence_item
   FROM currentai.registry.tail_products
 ),
 
@@ -93,7 +119,20 @@ candidate_names AS (
         END,
         '[^a-zA-Z0-9]+', '-'
       ))
-    ) AS normalized_name
+    ) AS normalized_name,
+    -- Per-kind artifact URL, identical in construction to build/serialize_registry.py's
+    -- artifact_url. See the header on why the CASE is used rather than a registry column.
+    CASE artifact_kind
+      WHEN 'github' THEN 'https://github.com/' || artifact_id
+      WHEN 'huggingface_model' THEN 'https://huggingface.co/' || artifact_id
+      WHEN 'huggingface_dataset' THEN 'https://huggingface.co/datasets/' || artifact_id
+      WHEN 'pypi' THEN 'https://pypi.org/project/' || artifact_id || '/'
+      WHEN 'npm' THEN 'https://www.npmjs.com/package/' || artifact_id
+      WHEN 'crates' THEN 'https://crates.io/crates/' || artifact_id
+      WHEN 'arxiv' THEN 'https://arxiv.org/abs/' || artifact_id
+      WHEN 'homepage' THEN 'https://' || artifact_id
+      ELSE artifact_id
+    END AS artifact_url
   FROM currentai.identity.candidates
 ),
 
@@ -104,7 +143,8 @@ name_match AS (
     pt.product_tier,
     p.slug AS product_slug,
     0.5 AS confidence,
-    'name_match' AS method
+    'name_match' AS method,
+    c.artifact_url || ' | name segment equals product slug' AS evidence_item
   FROM candidate_names c
   JOIN currentai.registry.products p
     ON c.normalized_name = LOWER(p.slug)
@@ -137,6 +177,7 @@ SELECT
   CAST(m.product_slug AS VARCHAR) AS product_slug,
   CAST(GREATEST(0, LEAST(1, MAX(m.confidence) - 0)) AS DOUBLE) AS confidence,
   ARRAY_SORT(ARRAY_DISTINCT(ARRAY_AGG(m.method))) AS method,
+  CAST(ARRAY_SORT(ARRAY_DISTINCT(ARRAY_AGG(m.evidence_item))) AS ARRAY(VARCHAR)) AS evidence,
   CAST(ARRAY[] AS ARRAY(VARCHAR)) AS penalties,
   CAST(m.artifact_kind IN (SELECT artifact_kind FROM route_kinds) AS BOOLEAN) AS scoring_bearing
 FROM combined m

--- a/warehouse/models/identity/org_edges.sql
+++ b/warehouse/models/identity/org_edges.sql
@@ -48,12 +48,14 @@
 --
 -- Host matching, both homepage paths (fixed 2026-09-04 -- both emitted ZERO rows before):
 --   1. The host is extracted from artifact_key rather than used raw:
---      REGEXP_EXTRACT(artifact_key, '^([^/]+)', 1) with a leading `www.` stripped. Homepage
---      artifact_id is moving to the full canonical URL (host lowercased, `www.` stripped, path
---      kept, no trailing slash) in a parallel repo change, so `example.com/product` will fold to
---      a key with a path segment in it. Today's 27 homepage keys are still bare hosts, so the
---      extraction is a no-op on live data -- it exists so the model does not silently go to zero
---      the week the repo change lands.
+--      REGEXP_EXTRACT(artifact_key, '^([^/]+)', 1) with a leading `www.` stripped. That extraction
+--      is load-bearing now, not a precaution: homepage keys carry the full canonical URL (host
+--      lowercased, `www.` stripped, path kept, no trailing slash) since
+--      identity_artifact_nodes.sql was corrected to keep the path, and nine of the 27 live
+--      homepage keys have a path segment in them (`developer.nvidia.com/nccl`,
+--      `rocm.docs.amd.com/projects/rocALUTION/en/latest`, ...). Comparing a key like that against
+--      an org domain raw matches nothing, which is what this line prevents. Do not "simplify" it
+--      away.
 --   2. A candidate host matches an org domain when it EQUALS it or is a SUBDOMAIN of it
 --      (`host LIKE '%.' || domain`). Exact equality alone is why both paths were inert: none of
 --      the 27 homepage nodes is a bare registered org domain, but three are subdomains of one --
@@ -82,7 +84,7 @@
 --   org_handle (github)      https://github.com/<handle> | org_handles: <org> github <handle>
 --   org_handle (huggingface) https://huggingface.co/<handle> | org_handles: <org> huggingface <handle>
 --   org_handle (homepage)    https://<handle> | org_handles: <org> homepage_domain <handle>
---   hf_namespace              https://huggingface.co/<ns> | namespace matches org <org> huggingface handle
+--   hf_namespace             https://huggingface.co/<ns> | namespace matches org <org> huggingface handle
 --   homepage_domain          https://<candidate host> | host matches org <org> homepage_domain handle
 -- The homepage_domain excerpt is the ruling's wording verbatim even though this path reads
 -- registry.organizations.homepage rather than org_handles -- the two homepage paths land on the

--- a/warehouse/models/identity/org_edges.sql
+++ b/warehouse/models/identity/org_edges.sql
@@ -77,6 +77,17 @@
 -- spelling -- so `handle_platform_map` below carries the mapping, exactly the case the original
 -- TODO on this line anticipated.
 --
+-- evidence (ARRAY(VARCHAR), added 2026-09-04 per reviewer ruling): one `<url> | <excerpt>`
+-- string per contributing evidence item, NOT a repeat of the method-name vocabulary. Shapes:
+--   org_handle (github)      https://github.com/<handle> | org_handles: <org> github <handle>
+--   org_handle (huggingface) https://huggingface.co/<handle> | org_handles: <org> huggingface <handle>
+--   org_handle (homepage)    https://<handle> | org_handles: <org> homepage_domain <handle>
+--   hf_namespace              https://huggingface.co/<ns> | namespace matches org <org> huggingface handle
+--   homepage_domain          https://<candidate host> | host matches org <org> homepage_domain handle
+-- The homepage_domain excerpt is the ruling's wording verbatim even though this path reads
+-- registry.organizations.homepage rather than org_handles -- the two homepage paths land on the
+-- same three candidates today and a reviewer sees both strings on one row.
+--
 -- Output casts: explicit CAST on every output column (VARCHAR strings, DOUBLE confidence,
 -- ARRAY(VARCHAR) method/penalties), matching the deploy pass's fix on the first four models --
 -- the confidence literals (0.85/0.80/0.75) are Trino DECIMAL, not DOUBLE, so
@@ -133,6 +144,17 @@ handle_platform_map AS (
   ) AS t (platform, artifact_kind)
 ),
 
+-- The URL an org_handles row itself points at, per platform: a github account page, a Hub
+-- namespace page, or the bare domain as an https URL.
+handle_urls AS (
+  SELECT * FROM (
+    VALUES
+      ('github', 'https://github.com/'),
+      ('huggingface', 'https://huggingface.co/'),
+      ('homepage_domain', 'https://')
+  ) AS t (platform, url_prefix)
+),
+
 handle_evidence AS (
   SELECT
     co.candidate_key,
@@ -140,12 +162,15 @@ handle_evidence AS (
     co.candidate_tier,
     oh.org_slug,
     0.85 AS evidence,
-    'org_handle' AS method
+    'org_handle' AS method,
+    hu.url_prefix || LOWER(oh.handle) || ' | org_handles: ' || oh.org_slug || ' '
+      || oh.platform || ' ' || LOWER(oh.handle) AS evidence_item
   FROM candidate_owner co
   JOIN handle_platform_map hpm ON hpm.artifact_kind = co.artifact_kind
   JOIN currentai.registry.org_handles oh
     ON oh.platform = hpm.platform
    AND LOWER(oh.handle) = co.handle_token
+  JOIN handle_urls hu ON hu.platform = oh.platform
   JOIN currentai.registry.organizations o ON o.slug = oh.org_slug
 ),
 
@@ -160,7 +185,9 @@ homepage_handle_evidence AS (
     co.candidate_tier,
     oh.org_slug,
     0.85 AS evidence,
-    'org_handle' AS method
+    'org_handle' AS method,
+    'https://' || LOWER(oh.handle) || ' | org_handles: ' || oh.org_slug
+      || ' homepage_domain ' || LOWER(oh.handle) AS evidence_item
   FROM candidate_owner co
   JOIN currentai.registry.org_handles oh
     ON oh.platform = 'homepage_domain'
@@ -176,7 +203,9 @@ hf_namespace_evidence AS (
     co.candidate_tier,
     o.slug AS org_slug,
     0.80 AS evidence,
-    'hf_namespace' AS method
+    'hf_namespace' AS method,
+    'https://huggingface.co/' || co.owner_handle || ' | namespace matches org ' || o.slug
+      || ' huggingface handle' AS evidence_item
   FROM candidate_owner co
   JOIN currentai.registry.organizations o ON LOWER(o.slug) = co.owner_handle
   WHERE co.artifact_kind IN ('huggingface_model', 'huggingface_dataset')
@@ -212,7 +241,9 @@ homepage_evidence AS (
     co.candidate_tier,
     h.slug AS org_slug,
     0.75 AS evidence,
-    'homepage_domain' AS method
+    'homepage_domain' AS method,
+    'https://' || co.handle_token || ' | host matches org ' || h.slug
+      || ' homepage_domain handle' AS evidence_item
   FROM candidate_owner co
   JOIN unambiguous_org_hosts h
     ON co.handle_token = h.org_host
@@ -237,6 +268,7 @@ SELECT
   CAST(org_slug AS VARCHAR) AS org_slug,
   CAST(GREATEST(0, LEAST(1, MAX(evidence) - 0)) AS DOUBLE) AS confidence,
   CAST(ARRAY_SORT(ARRAY_DISTINCT(ARRAY_AGG(method))) AS ARRAY(VARCHAR)) AS method,
+  CAST(ARRAY_SORT(ARRAY_DISTINCT(ARRAY_AGG(evidence_item))) AS ARRAY(VARCHAR)) AS evidence,
   CAST(ARRAY[] AS ARRAY(VARCHAR)) AS penalties
 FROM combined
 GROUP BY candidate_key, artifact_kind, org_slug

--- a/warehouse/models/signal_pypi/package_downloads.sql
+++ b/warehouse/models/signal_pypi/package_downloads.sql
@@ -20,6 +20,19 @@
 --     the adoption input; it is not a user count.
 --   * History is short. `days_observed` and `window_start` make the window
 --     explicit so a partial window is visible instead of reading as a decline.
+--
+-- The adoption bands are NOT defined here. They were, until 2026-08-09, as a
+-- hardcoded CASE that applied one scale to every product type - which is the
+-- repo/warehouse split check_parity exists to catch, one axis over, and it was
+-- wrong for datasets: no dataset artifact in the corpus exceeds 10M monthly
+-- downloads, so level 5 was unreachable for the whole type. They now come from
+-- currentai.registry.adoption_bands, declared per product type in
+-- sources/rubrics/<type>.yaml and pushed by CI.
+--
+-- A type with no bands declared gets a NULL level rather than another type's
+-- scale. `hardware` is deliberately in that state - a board has no download
+-- count - and the abstention is the same rule signal_routing.yaml states for
+-- sources: abstain rather than substitute.
 WITH bounds AS (
   SELECT MAX(day) AS last_day FROM oso.pypi_downloads.daily_downloads_by_package
 ),
@@ -43,31 +56,56 @@ windowed AS (
   FROM oso.pypi_downloads.daily_downloads_by_package d
   CROSS JOIN bounds b
   GROUP BY d.package
+),
+measured AS (
+  SELECT
+    r.product_slug,
+    r.product_type,
+    r.package,
+    w.downloads_30d,
+    w.downloads_7d,
+    w.days_observed,
+    w.max_country_count AS countries_seen,
+    w.first_day_seen,
+    w.last_day_seen,
+    CAST(b.last_day - INTERVAL '30' DAY AS DATE) AS window_start,
+    w.package IS NULL AS missing_from_pypi
+  FROM roster r
+  CROSS JOIN bounds b
+  LEFT JOIN windowed w
+    ON LOWER(r.package) = LOWER(w.package)
+),
+-- The highest band whose exclusive lower bound the figure clears. A type absent
+-- from the table contributes no row, so the LEFT JOIN leaves the level NULL.
+banded AS (
+  SELECT
+    m.product_slug,
+    m.package,
+    -- Cast explicitly: the band level arrives from a CSV static model, and the
+    -- column this feeds is declared INTEGER. Letting the width be inferred is how
+    -- a declared schema and a produced one drift apart.
+    CAST(MAX(b.level) AS INTEGER) AS adoption_level
+  FROM measured m
+  JOIN currentai.registry.adoption_bands b
+    ON b.product_type = m.product_type
+   AND m.downloads_30d > b.above
+  WHERE m.downloads_30d IS NOT NULL
+  GROUP BY m.product_slug, m.package
 )
 SELECT
-  r.product_slug,
-  r.product_type,
-  r.package,
-  w.downloads_30d,
-  w.downloads_7d,
-  w.days_observed,
-  w.max_country_count AS countries_seen,
-  w.first_day_seen,
-  w.last_day_seen,
-  CAST(b.last_day - INTERVAL '30' DAY AS DATE) AS window_start,
-  -- Adoption band on the map's own scale, so the level is derived here rather
-  -- than re-derived by every consumer. The level-5 floor is >10M monthly.
-  CASE
-    WHEN w.downloads_30d IS NULL THEN NULL
-    WHEN w.downloads_30d > 10000000 THEN 5
-    WHEN w.downloads_30d > 1000000 THEN 4
-    WHEN w.downloads_30d > 100000 THEN 3
-    WHEN w.downloads_30d > 10000 THEN 2
-    ELSE 1
-  END AS adoption_level,
-  -- A roster package absent from PyPI entirely is a data-quality signal, not a zero.
-  w.package IS NULL AS missing_from_pypi
-FROM roster r
-CROSS JOIN bounds b
-LEFT JOIN windowed w
-  ON LOWER(r.package) = LOWER(w.package)
+  m.product_slug,
+  m.product_type,
+  m.package,
+  m.downloads_30d,
+  m.downloads_7d,
+  m.days_observed,
+  m.countries_seen,
+  m.first_day_seen,
+  m.last_day_seen,
+  m.window_start,
+  bd.adoption_level,
+  m.missing_from_pypi
+FROM measured m
+LEFT JOIN banded bd
+  ON bd.product_slug = m.product_slug
+ AND bd.package = m.package


### PR DESCRIPTION
## Summary

Eight platform-mirror models were flagged as drifted. Five are genuinely resynced here; the
other three have platform revisions ahead of the pinned contract but byte-identical mirrored
code, so their contract revision is left pinned (bumping it without a code change would fail
`test_dependency_mirror_provenance_holds`, which is correct behavior — see below).

### Resynced (code and/or revision changed)

| table | old rev → new rev |
|---|---|
| `currentai.signal_pypi.package_downloads` | 3 → 4 |
| `currentai.identity.membership_edges` | 2 → 3 |
| `currentai.identity.equivalence_edges` | 5 → 7 |
| `currentai.identity.org_edges` | 3 → 5 |
| `currentai.identity.digest` | 4 → 6 |

### Left pinned (platform ahead, byte-identical code — metadata-only revisions)

| table | contract rev | platform latest | what moved on the platform |
|---|---|---|---|
| `currentai.scores.openness_facts` | 7 | 9 | rev 8 cleared the model cron (`0 4 * * 1` → `""`); rev 9 added a `description`. Schema unchanged (14 cols) across 7/8/9. |
| `currentai.scores.openness_computed` | 15 | 17 | rev 16 cleared the model cron (`0 5 * * 1` → `""`); rev 17 added a `description`. Schema unchanged (21 cols). |
| `currentai.signal_github.artifact_state` | 2 | 3 | rev 3 *set* the model cron `""` → `0 3 * * 0`. Schema (32 cols) and description unchanged. |

Cron and description only — no code change, no schema change. The cron clearing on the first two
is the 2026-08-16 schedule normalization that moved cadence to the dataset level; the dataset
crons today (`scores 0 4 * * 1`, `signal_pypi 0 1 * * 0`, `signal_github 0 3 * * 0`,
`identity 30 5 * * 0`) all match the contracts' `platform_schedule.cron`, so no freshness claim is
broken by leaving these three pinned.

A follow-up PR will add a `mirror.code_unchanged_from` marker so a contract can record a
metadata-only platform revision honestly, without weakening `_compare_mirror`'s bytes-moved check.
Out of scope here — this PR just resyncs and describes accurately.

## Per-model change summaries

- `signal_pypi.package_downloads`: the real fix here is unrelated to the 3→4 bump, which is
  itself metadata-only (cron `0 4 * * 1` → `""`, byte-identical code). The committed mirror file
  had drifted to hold **rev-2** bytes (hardcoded uniform CASE thresholds, 2,629 bytes) while the
  contract's `mirror.revision` claimed 3. The actual adoption-bands change (reading
  `currentai.registry.adoption_bands` per product type instead of a hardcoded threshold) landed
  at rev 2 → 3 on 2026-08-09; this PR re-fetches rev 4's bytes (identical to rev 3's) and fixes
  the contract to match what's actually on disk.
- `identity.membership_edges` (2 → 3): adds an `evidence ARRAY(VARCHAR)` output column — one
  `<url> | <excerpt>` string per contributing evidence item, replacing the prior implicit reliance
  on the method-name array alone.
- `identity.equivalence_edges` (5 → 7): adds the same `evidence ARRAY(VARCHAR)` column; folds the
  resolution-ledger homepage candidate_key on the whole canonical URL rather than the bare host
  (rev 6); simplifies that fold's CASE down to two branches now that homepage and the default rule
  are identical (rev 7, comment-only).
- `identity.org_edges` (3 → 5): adds the same `evidence ARRAY(VARCHAR)` column (rev 4); a
  comment-only update noting that homepage keys now carry a path so the host extraction is
  load-bearing, not defensive (rev 5).
- `identity.digest` (4 → 6): `evidence[]` now relays the three edge tables' real evidence strings
  instead of repeating `method[]`; alias-sourced items are no longer excluded from the review
  queue since that source is capped at 0.9 confidence rather than treated as authoritative (rev
  5). Rev 6 removes fetch-timestamp state logic entirely: `artifact_nodes.last_observed_at` is a
  fetch time rewritten on every weekly run, so using it to detect "evidence changed" made every
  row look changed and starved the `parked` state; `last_evidence_change` now comes only from the
  resolution_ledger's `decided_on` (a genuine evidence-confirmation time), name-match-only is
  decided per-item rather than via a candidate-level aggregate, and the weekly 25-slot cap now
  reserves the top 5 eligible items per relation before filling the rest globally, so one relation
  can no longer starve the other two the way "membership only" or "equivalence only" cap runs did
  before. This introduces a new upstream read on `currentai.registry.resolution_ledger`, reflected
  in `warehouse/assets.yaml`'s `read_by` for that table.

## Downstream readers affected

Per `warehouse/dependencies.yaml`'s `required_by`:
- `signal_pypi.package_downloads` → `build/check_artifacts.py`, `warehouse/models/observations/product_adoption_current.sql`, `warehouse/models/signal_github/product_adoption.sql`
- `identity.membership_edges` → `build/identity_eval.py`, `warehouse/models/identity/digest.sql`
- `identity.equivalence_edges` → `build/identity_eval.py`, `warehouse/models/identity/digest.sql`
- `identity.org_edges` → `build/identity_eval.py`, `warehouse/models/identity/digest.sql`
- `identity.digest` → `build/identity_digest.py`
- `openness_facts` → `warehouse/models/scores/openness_computed.sql`
- `openness_computed` → `build/apply_scores.py`, `build/check_parity.py`
- `signal_github.artifact_state` → `build/check_artifacts.py`, `warehouse/models/evidence/product_evidence.sql`, `warehouse/models/identity/artifact_identity_edges.sql`, `warehouse/models/observations/product_adoption_current.sql`, `warehouse/models/signal_github/product_adoption.sql`

## Test plan

- `uv run pytest tests/test_scope_gates.py tests/test_assets_inventory.py tests/test_docs_integrity.py -q -n 4` → 170 passed
- `uv run python -m build.validate` → 0 errors, 2 pre-existing warnings (unrelated `model_families` pattern-overlap warnings)
- `uv run pytest -q -n 4 -m "not serial"` → 1527 passed

Refs #365