### PR TITLE
Let mirror contracts record metadata-only platform revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,23 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
 
 ### Added
 
+- `mirror.code_unchanged_from` in `warehouse/dependencies.yaml`: a marker letting a mirror contract
+  record a platform revision that was minted over byte-identical code (a cron cleared, a
+  description added), which the coherence gate would otherwise forbid forever. Accepted only when
+  the marker names the revision committed at the merge base, the revision strictly advances, the
+  mirrored bytes are unchanged and `synced_at` does not regress; setting it alongside changed bytes
+  is itself a violation. `currentai.scores.openness_facts` (7 → 9),
+  `currentai.scores.openness_computed` (15 → 17) and `currentai.signal_github.artifact_state`
+  (2 → 3) now record the deployed revision (#365).
+
 - `build/propose_org_handles.py`, which proposes `huggingface` org handles from the namespaces of
   already declared Hugging Face artifacts, grouped by org and checked for aggregator accounts and
   ownership conflicts, for review as a GitHub issue rather than seeded silently (#365).
 - A weekly mirror-drift sentinel (`mirror-drift.yml`, Monday 08:30 UTC): every `mirror:` contract
   in `warehouse/dependencies.yaml` is compared against the platform's latest revision, and a
-  mismatch opens a `sentinel` issue. Reports revision, hash, code and missing-model drift
-  separately, and exits 2 rather than passing whenever the platform cannot be read at all. Closes
+  mismatch opens a `sentinel` issue. Reports revision, hash, code, metadata-only and missing-model
+  findings separately, and exits 2 rather than passing whenever the platform cannot be read at all.
+  A revision or hash disagreement over byte-identical code is `metadata-only` and exits 0. Closes
   the gap where the repo's own gates stay green while the platform releases past a mirror; the
   first runs found eight of seventeen contracts behind. "Mirror resync" in
   `docs/operations/deploy-models.md` is the runbook (#365).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
   description added), which the coherence gate would otherwise forbid forever. Accepted only when
   the marker names the revision committed at the merge base, the revision strictly advances, the
   mirrored bytes are unchanged and `synced_at` does not regress; setting it alongside changed bytes
-  is itself a violation. `currentai.scores.openness_facts` (7 → 9),
+  is itself a violation, so the next genuine resync deletes the line.
+  `currentai.scores.openness_facts` (7 → 9),
   `currentai.scores.openness_computed` (15 → 17) and `currentai.signal_github.artifact_state`
   (2 → 3) now record the deployed revision (#365).
 
@@ -31,10 +32,12 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
   already declared Hugging Face artifacts, grouped by org and checked for aggregator accounts and
   ownership conflicts, for review as a GitHub issue rather than seeded silently (#365).
 - A weekly mirror-drift sentinel (`mirror-drift.yml`, Monday 08:30 UTC): every `mirror:` contract
-  in `warehouse/dependencies.yaml` is compared against the platform's latest revision, and a
-  mismatch opens a `sentinel` issue. Reports revision, hash, code, metadata-only and missing-model
-  findings separately, and exits 2 rather than passing whenever the platform cannot be read at all.
-  A revision or hash disagreement over byte-identical code is `metadata-only` and exits 0. Closes
+  in `warehouse/dependencies.yaml` is compared against the platform's latest revision, and a red
+  run is picked up by `report-failure.yml`, which opens or comments on the `sentinel` issue.
+  Reports revision, hash, code, metadata-only and missing-model findings separately, and exits 2
+  rather than passing whenever the platform cannot be read at all. A newer platform revision over
+  byte-identical code is `metadata-only` and exits 0; a hash change at an unchanged revision
+  number stays drift however well the code matches. Closes
   the gap where the repo's own gates stay green while the platform releases past a mirror; the
   first runs found eight of seventeen contracts behind. "Mirror resync" in
   `docs/operations/deploy-models.md` is the runbook (#365).

--- a/build/assets.py
+++ b/build/assets.py
@@ -1588,6 +1588,29 @@ def _compare_mirror(label: str, prior: dict, cur: dict, has_migration: bool) -> 
     Bytes and provenance move together and forward: if `local_sha256` changed, `revision` must
     advance, `hash` must change, and `synced_at` must not go backward; if the bytes did NOT
     change, none of the provenance may. `model_id` is stable unless a migration authorizes it.
+
+    The one exception, and why it exists: the platform mints a revision for changes that touch
+    no code at all -- a cron cleared, a description filled in. The mirror bytes are then
+    identical by construction, so the default rule forbids the contract from ever recording the
+    revision that is actually deployed, and the weekly sentinel
+    (`build/check_mirror_drift`) reports drift on it forever. `mirror.code_unchanged_from` is
+    the escape valve, the exact analogue of `mirror_migration` for `model_id`: an explicit,
+    reviewable claim naming the revision the code is unchanged FROM. An offline gate cannot
+    verify that claim -- it has no platform to ask -- so what it does instead is pin the claim
+    down hard enough that a reviewer can check it in one look, and reject every shape that is
+    not the narrow case it exists for:
+
+      1. the marker is present (silence still means "bytes and provenance move together");
+      2. it equals the revision committed at the merge base, so it names a real prior state
+         rather than an arbitrary number;
+      3. the revision strictly advances;
+      4. the mirrored bytes are unchanged -- enforced from both sides, since the marker is only
+         reachable when neither sha moved AND setting it alongside changed bytes is itself a
+         violation (the marker's own claim would be false);
+      5. `synced_at` does not regress.
+
+    `hash` is allowed to move here and not required to: the platform's hash does change across
+    a metadata-only revision, but that is its business, not a rule the repo should depend on.
     """
     problems: list[str] = []
     if cur.get("model_id") != prior.get("model_id") and not has_migration:
@@ -1601,11 +1624,34 @@ def _compare_mirror(label: str, prior: dict, cur: dict, has_migration: bool) -> 
     # freeze the revision.
     bytes_moved = (cur.get("local_sha256") != prior.get("local_sha256")
                    or cur.get("schema_sha256") != prior.get("schema_sha256"))
-    if not bytes_moved:
-        if any(cur.get(f) != prior.get(f) for f in ("revision", "hash", "synced_at")):
-            problems.append(f"{label}: provenance changed but the mirrored bytes did not")
-        return problems
+    marker = cur.get("code_unchanged_from")
     old_rev, new_rev = prior.get("revision"), cur.get("revision")
+    if not bytes_moved:
+        if not any(cur.get(f) != prior.get(f) for f in ("revision", "hash", "synced_at")):
+            return problems
+        if marker is None:
+            problems.append(f"{label}: provenance changed but the mirrored bytes did not")
+            return problems
+        if marker != old_rev:
+            problems.append(
+                f"{label}: mirror.code_unchanged_from is {marker!r}, which is not the revision "
+                f"committed at the merge base ({old_rev!r}); the marker must name the prior "
+                "recorded revision"
+            )
+        if not (isinstance(old_rev, int) and isinstance(new_rev, int) and new_rev > old_rev):
+            problems.append(
+                f"{label}: a metadata-only revision still advances the revision, and it went "
+                f"{old_rev!r} -> {new_rev!r}"
+            )
+        old_at, new_at = str(prior.get("synced_at") or ""), str(cur.get("synced_at") or "")
+        if new_at < old_at:
+            problems.append(f"{label}: synced_at moved backward, {old_at} -> {new_at}")
+        return problems
+    if marker is not None:
+        problems.append(
+            f"{label}: mirror.code_unchanged_from is set to {marker!r} but the mirrored bytes "
+            "changed; a resync that moves the bytes is not a metadata-only revision"
+        )
     if isinstance(old_rev, int) and isinstance(new_rev, int):
         if new_rev <= old_rev:
             problems.append(

--- a/build/assets.py
+++ b/build/assets.py
@@ -1606,7 +1606,8 @@ def _compare_mirror(label: str, prior: dict, cur: dict, has_migration: bool) -> 
       3. the revision strictly advances;
       4. the mirrored bytes are unchanged -- enforced from both sides, since the marker is only
          reachable when neither sha moved AND setting it alongside changed bytes is itself a
-         violation (the marker's own claim would be false);
+         violation (the marker's own claim would be false). The next genuine resync therefore
+         DELETES the marker line along with everything else it updates;
       5. `synced_at` does not regress.
 
     `hash` is allowed to move here and not required to: the platform's hash does change across
@@ -1650,7 +1651,8 @@ def _compare_mirror(label: str, prior: dict, cur: dict, has_migration: bool) -> 
     if marker is not None:
         problems.append(
             f"{label}: mirror.code_unchanged_from is set to {marker!r} but the mirrored bytes "
-            "changed; a resync that moves the bytes is not a metadata-only revision"
+            "changed; a resync that moves the bytes is not a metadata-only revision -- DELETE "
+            "the code_unchanged_from line, the rest of the resync stands"
         )
     if isinstance(old_rev, int) and isinstance(new_rev, int):
         if new_rev <= old_rev:

--- a/build/check_mirror_drift.py
+++ b/build/check_mirror_drift.py
@@ -48,7 +48,8 @@ different things:
   * `revision` — the numbers differ. The plain case: the platform moved on.
   * `hash` — the numbers agree and the platform's hash does not. Worse than a revision bump,
     because it means the same revision number now denotes different content, and nothing in
-    the repo's own gates could ever see it.
+    the repo's own gates could ever see it. Identical code does not soften this one: either the
+    platform rewrote a revision in place or the contract's hash is mis-pinned.
   * `code` — numbers and hash agree, and the deployed source does not match the mirror file's
     body. This is the belt-and-braces check: it does not trust the hash to be a hash of the
     code, and it is the only one of the three that a maintainer editing a mirror file by hand
@@ -60,15 +61,21 @@ so the contract is anchored to something that no longer exists.
 ## `metadata-only`, which is not drift
 
 The platform mints a revision for changes that touch no code: a cron cleared, a description
-filled in. The numbers then disagree while the deployed source is byte-identical to the mirror,
-and calling that drift sends a maintainer to resync a file that cannot change. So the code
-comparison runs on every contract, not only on the ones whose numbers already agree, and a
-revision or hash disagreement over identical code is reported as `metadata-only` and exits 0.
+filled in. The revision numbers then disagree while the deployed source is byte-identical to the
+mirror, and calling that drift sends a maintainer to resync a file that cannot change. So the
+code comparison runs on every contract, not only on the ones whose numbers already agree, and a
+NEW REVISION over identical code is reported as `metadata-only` and exits 0.
 
-Exit 1 is reserved for a disagreement the code itself confirms: `code` drift, or a revision or
-hash mismatch whose deployed source really does differ. `metadata-only` is still worth
-recording in the contract — `mirror.code_unchanged_from` is how (see the `dependencies.yaml`
-header) — but it is a bookkeeping job, not a stale mirror.
+The "new revision" half is load-bearing, and it is why a hash disagreement at an unchanged
+revision number stays `hash` however well the code matches. There is nothing to record in that
+case: `mirror.code_unchanged_from` authorizes advancing to a revision, the coherence gate
+rejects a marker whose revision does not advance, and so reporting it as metadata-only would
+instruct a commit the repo's own gate refuses.
+
+Exit 1 is therefore `code` drift, a `hash` disagreement, and a revision mismatch whose deployed
+source really does differ. `metadata-only` is still worth recording in the contract —
+`mirror.code_unchanged_from` is how (see the `dependencies.yaml` header) — but it is a
+bookkeeping job, not a stale mirror.
 
 ## The banner
 
@@ -244,13 +251,24 @@ def compare(contract: dict, node: dict | None, root: Path) -> Row:
                f"revision {platform_revision} on both sides, and its hash is {platform_hash} "
                f"against the contract's {mirror.get('hash')}")
 
-    if code_match:
+    if code_match and not revision_match:
         # A revision the platform minted without touching the code -- a cron cleared, a
         # description added. Nothing to resync; the contract records it with
         # mirror.code_unchanged_from.
         return row("metadata-only", f"{numbers}, and the deployed source is byte-identical to "
                                     f"{contract['files']['model']} below its banner")
-    return row("revision" if not revision_match else "hash", f"{numbers}; {code_detail}")
+    if not revision_match:
+        return row("revision", f"{numbers}; {code_detail}")
+    # Same revision number, different hash. Identical code does NOT excuse it: a metadata-only
+    # revision is a new revision, and there is none here. Either the platform rewrote a revision
+    # in place or the contract's `mirror.hash` is mis-pinned, and neither is recordable -- the
+    # coherence gate rejects a marker whose revision does not advance, so reporting this as
+    # metadata-only would instruct a commit the repo's own gate refuses.
+    return row("hash", f"{numbers}; a hash change with no new revision is a mis-pin or an "
+                       f"in-place rewrite, not a metadata-only revision"
+                       + (f" ({code_detail})" if code_detail else
+                          " -- the deployed source does match the mirror, which narrows it to "
+                          "the recorded hash"))
 
 
 def check(contracts: list[dict], client, root: Path) -> list[Row]:

--- a/build/check_mirror_drift.py
+++ b/build/check_mirror_drift.py
@@ -57,6 +57,19 @@ different things:
 `missing` is a fourth and the loudest: the platform serves no model at that `model_id` at all,
 so the contract is anchored to something that no longer exists.
 
+## `metadata-only`, which is not drift
+
+The platform mints a revision for changes that touch no code: a cron cleared, a description
+filled in. The numbers then disagree while the deployed source is byte-identical to the mirror,
+and calling that drift sends a maintainer to resync a file that cannot change. So the code
+comparison runs on every contract, not only on the ones whose numbers already agree, and a
+revision or hash disagreement over identical code is reported as `metadata-only` and exits 0.
+
+Exit 1 is reserved for a disagreement the code itself confirms: `code` drift, or a revision or
+hash mismatch whose deployed source really does differ. `metadata-only` is still worth
+recording in the contract — `mirror.code_unchanged_from` is how (see the `dependencies.yaml`
+header) — but it is a bookkeeping job, not a stale mirror.
+
 ## The banner
 
 Mirror files are not byte-identical to the deployed code, by design: each carries a five-line
@@ -150,7 +163,12 @@ class Row:
 
     @property
     def drifted(self) -> bool:
-        return self.status != "ok"
+        """Whether a maintainer has a resync to do. `metadata-only` is a finding, not drift."""
+        return self.status not in ("ok", "metadata-only")
+
+    @property
+    def metadata_only(self) -> bool:
+        return self.status == "metadata-only"
 
 
 def mirror_contracts(root: Path) -> list[dict]:
@@ -161,6 +179,27 @@ def mirror_contracts(root: Path) -> list[dict]:
     """
     doc = yaml.safe_load((root / "warehouse/dependencies.yaml").read_text()) or {}
     return [d for d in (doc.get("dependencies") or []) if d.get("mirror")]
+
+
+def code_verdict(contract: dict, revision: dict, root: Path) -> tuple[bool, str]:
+    """Whether the deployed source matches the mirror file below its banner, and why not.
+
+    Run on every contract, not only where the numbers agree, because it is what separates a
+    metadata-only platform revision from a stale mirror.
+    """
+    path = root / contract["files"]["model"]
+    if not path.exists():
+        # dependency_violations already fails on this; reported here too so a drift run
+        # against a broken tree explains itself rather than raising.
+        return False, f"mirror file {contract['files']['model']} is missing"
+    local = strip_mirror_banner(path.read_text())
+    deployed = revision.get("code") or ""
+    if sha256_text(local) != sha256_text(deployed):
+        return False, (
+            f"the deployed source does not match {contract['files']['model']} below its banner "
+            f"({len(deployed)} chars deployed against {len(local)} mirrored)"
+        )
+    return True, ""
 
 
 def compare(contract: dict, node: dict | None, root: Path) -> Row:
@@ -181,52 +220,37 @@ def compare(contract: dict, node: dict | None, root: Path) -> Row:
     platform_hash = revision.get("hash")
     revised_at = revision.get("createdAt")
 
-    if platform_revision != contract_revision:
+    revision_match = platform_revision == contract_revision
+    hash_match = platform_hash == mirror.get("hash")
+    # The source comparison decides every remaining case, so it runs before the numbers are
+    # judged. It is also the only check a hand-edited mirror with a refreshed local_sha256
+    # cannot get past.
+    code_match, code_detail = code_verdict(contract, revision, root)
+
+    def row(status: str, detail: str) -> Row:
         return Row(
-            table=table, status="revision", contract_revision=contract_revision,
-            platform_revision=platform_revision, hash_match=platform_hash == mirror.get("hash"),
-            code_match=None, revised_at=revised_at,
-            detail=f"the platform's latest revision is {platform_revision}, "
-                   f"the contract records {contract_revision}",
+            table=table, status=status, contract_revision=contract_revision,
+            platform_revision=platform_revision, hash_match=hash_match, code_match=code_match,
+            revised_at=revised_at, detail=detail,
         )
 
-    if platform_hash != mirror.get("hash"):
-        return Row(
-            table=table, status="hash", contract_revision=contract_revision,
-            platform_revision=platform_revision, hash_match=False, code_match=None,
-            revised_at=revised_at,
-            detail=f"revision {platform_revision} on both sides, and its hash is "
-                   f"{platform_hash} against the contract's {mirror.get('hash')}",
-        )
+    if revision_match and hash_match:
+        if code_match:
+            return row("ok", "")
+        return row("code", f"revision {platform_revision} and hash agree, and {code_detail}")
 
-    # Numbers agree. Compare the source itself, which is the only one of the three checks a
-    # hand-edited mirror with a refreshed local_sha256 cannot get past.
-    path = root / contract["files"]["model"]
-    if not path.exists():
-        # dependency_violations already fails on this; reported here too so a drift run
-        # against a broken tree explains itself rather than raising.
-        return Row(
-            table=table, status="code", contract_revision=contract_revision,
-            platform_revision=platform_revision, hash_match=True, code_match=False,
-            revised_at=revised_at, detail=f"mirror file {contract['files']['model']} is missing",
-        )
-    local = strip_mirror_banner(path.read_text())
-    deployed = revision.get("code") or ""
-    if sha256_text(local) != sha256_text(deployed):
-        return Row(
-            table=table, status="code", contract_revision=contract_revision,
-            platform_revision=platform_revision, hash_match=True, code_match=False,
-            revised_at=revised_at,
-            detail=f"revision {platform_revision} and hash agree, and the deployed source "
-                   f"does not match {contract['files']['model']} below its banner "
-                   f"({len(deployed)} chars deployed against {len(local)} mirrored)",
-        )
+    numbers = (f"the platform's latest revision is {platform_revision} against the contract's "
+               f"{contract_revision}" if not revision_match else
+               f"revision {platform_revision} on both sides, and its hash is {platform_hash} "
+               f"against the contract's {mirror.get('hash')}")
 
-    return Row(
-        table=table, status="ok", contract_revision=contract_revision,
-        platform_revision=platform_revision, hash_match=True, code_match=True,
-        revised_at=revised_at,
-    )
+    if code_match:
+        # A revision the platform minted without touching the code -- a cron cleared, a
+        # description added. Nothing to resync; the contract records it with
+        # mirror.code_unchanged_from.
+        return row("metadata-only", f"{numbers}, and the deployed source is byte-identical to "
+                                    f"{contract['files']['model']} below its banner")
+    return row("revision" if not revision_match else "hash", f"{numbers}; {code_detail}")
 
 
 def check(contracts: list[dict], client, root: Path) -> list[Row]:
@@ -289,15 +313,29 @@ def main(argv: list[str] | None = None, root: Path | None = None, client=None) -
 
     print(render_table(rows))
     drifted = [r for r in rows if r.drifted]
-    print(f"\n{len(rows) - len(drifted)} of {len(rows)} mirror contracts match the platform, "
+    metadata_only = [r for r in rows if r.metadata_only]
+    print(f"\n{len(rows) - len(drifted)} of {len(rows)} mirror contracts match the platform's "
+          f"deployed source ({len(metadata_only)} of them over a metadata-only revision), "
           f"{len(drifted)} drifted")
+    for row in metadata_only:
+        print(f"  - {row.table} [metadata-only]: {row.detail}")
     for row in drifted:
         print(f"  x {row.table} [{row.status}]: {row.detail}")
 
     if args.report:
         args.report.write_text(json.dumps(
             {"checked": len(rows), "drifted": len(drifted),
+             "metadata_only": len(metadata_only),
              "rows": [asdict(r) for r in rows]}, indent=2) + "\n")
+
+    if metadata_only and not drifted:
+        print(
+            "\nEvery contract mirrors the source the platform is running. The revisions marked "
+            "metadata-only\nmoved without the code moving; record each one by setting "
+            "mirror.code_unchanged_from to the\nrevision currently in the contract, then "
+            "advancing verified_revision, mirror.revision,\nmirror.hash and mirror.synced_at. "
+            'The runbook is "Metadata-only revisions" in\ndocs/operations/deploy-models.md.'
+        )
 
     if drifted:
         print(
@@ -308,7 +346,7 @@ def main(argv: list[str] | None = None, root: Path | None = None, client=None) -
             '"Mirror resync" in docs/operations/deploy-models.md.'
         )
         return 1
-    print("[OK] every mirror contract matches the platform's latest revision")
+    print("[OK] every mirror contract mirrors the source the platform is running")
     return 0
 
 

--- a/docs/operations/deploy-models.md
+++ b/docs/operations/deploy-models.md
@@ -138,15 +138,22 @@ red run opens a `sentinel` issue. It exists because nothing else could see this 
 dependency gate proves a mirror file matches its own contract, which stays true no matter how far
 the platform has moved on, so the repo can review revision N while N+1 builds the table.
 
-It reports four findings, and they are not the same job:
+It reports five findings, and they are not the same job:
 
-- **`revision`** — the platform's latest revision number is ahead of the contract. Resync.
-- **`hash`** — same revision number, different hash. The number the repo pins now denotes
-  different content; resync, and look at why a revision was rewritten in place.
+- **`revision`** — the platform's latest revision number is ahead of the contract, over
+  different code. Resync.
+- **`hash`** — same revision number, different hash, over different code. The number the repo
+  pins now denotes different content; resync, and look at why a revision was rewritten in place.
 - **`code`** — number and hash agree and the deployed source does not match the mirror file
   below its banner. Either the mirror was hand-edited, or the hash is not a hash of the code.
+- **`metadata-only`** — the numbers disagree and the deployed source is byte-identical to the
+  mirror. Nothing to resync; see below.
 - **`missing`** — the platform serves no model at that `model_id`. Do not resync; find out
   whether the model was deleted or recreated, because the contract's anchor is gone.
+
+Only the first three exit 1. The check compares the deployed source on every contract, not just
+the ones whose numbers already agree, so that a revision minted over unchanged code is not
+reported as a stale mirror.
 
 To resync one contract:
 
@@ -168,6 +175,24 @@ To resync one contract:
 Resync in one commit per contract where you can. The cross-commit coherence gate reads bytes,
 revision, hash and `synced_at` as one movement, and a batch that half-lands is harder to read
 than several small ones.
+
+### Metadata-only revisions
+
+The platform mints a revision for edits that touch no code — a cron cleared, a description
+filled in — and the mirror bytes are then identical by construction. Because the coherence gate
+requires revision, hash and `synced_at` to move only when the bytes move, such a contract cannot
+record the revision that is actually deployed, and the sentinel would report it forever.
+`mirror.code_unchanged_from` is the escape valve, the same shape as `mirror_migration` for
+`model_id`: an explicit claim, in the contract, naming the revision the code is unchanged from.
+
+Confirm the sentinel reports the contract `metadata-only` first, then set
+`mirror.code_unchanged_from` to the revision the contract currently records and advance
+`verified_revision`, `mirror.revision`, `mirror.hash` (live, from `GetDataModel`) and
+`mirror.synced_at`. Leave `local_sha256` and `schema_sha256` untouched. The gate accepts the
+move only if the marker equals the revision committed at the merge base, the revision strictly
+advances, the mirrored bytes are unchanged and `synced_at` does not regress — an offline gate
+cannot verify the platform's side of the claim, so it pins the claim to a shape a reviewer can
+check in one look. Setting the marker alongside changed bytes is itself a violation.
 
 **The sentinel cannot see an unreleased revision, and does not pretend to.** The platform
 exposes no release marker — `GetDataModel` has no release field and `GetAssetChangelog`'s

--- a/docs/operations/deploy-models.md
+++ b/docs/operations/deploy-models.md
@@ -133,8 +133,10 @@ uv run python -m build.serialize_rubric && uv run python -m build.publish_regist
 ## Mirror resync, when the drift sentinel fires
 
 `build/check_mirror_drift.py` compares every `mirror:` contract in `warehouse/dependencies.yaml`
-against the platform once a week (`.github/workflows/mirror-drift.yml`, Monday 08:30 UTC), and a
-red run opens a `sentinel` issue. It exists because nothing else could see this failure: the
+against the platform once a week (`.github/workflows/mirror-drift.yml`, Monday 08:30 UTC). A red
+run is picked up by `report-failure.yml`, which opens or comments on the `sentinel` issue —
+`mirror-drift` is in that workflow's `workflow_run` list. The check exists because nothing else
+could see this failure: the
 dependency gate proves a mirror file matches its own contract, which stays true no matter how far
 the platform has moved on, so the repo can review revision N while N+1 builds the table.
 
@@ -142,18 +144,20 @@ It reports five findings, and they are not the same job:
 
 - **`revision`** — the platform's latest revision number is ahead of the contract, over
   different code. Resync.
-- **`hash`** — same revision number, different hash, over different code. The number the repo
-  pins now denotes different content; resync, and look at why a revision was rewritten in place.
+- **`hash`** — same revision number, different hash. The number the repo pins now denotes
+  different content; resync, and look at why a revision was rewritten in place. Identical code
+  does not soften this: there is no new revision to record, so it is a mis-pinned `mirror.hash`
+  or an in-place rewrite either way.
 - **`code`** — number and hash agree and the deployed source does not match the mirror file
   below its banner. Either the mirror was hand-edited, or the hash is not a hash of the code.
-- **`metadata-only`** — the numbers disagree and the deployed source is byte-identical to the
-  mirror. Nothing to resync; see below.
+- **`metadata-only`** — the platform's revision number is ahead and the deployed source is
+  byte-identical to the mirror. Nothing to resync; see below.
 - **`missing`** — the platform serves no model at that `model_id`. Do not resync; find out
   whether the model was deleted or recreated, because the contract's anchor is gone.
 
-Only the first three exit 1. The check compares the deployed source on every contract, not just
-the ones whose numbers already agree, so that a revision minted over unchanged code is not
-reported as a stale mirror.
+Everything but `metadata-only` exits 1. The check compares the deployed source on every
+contract, not just the ones whose numbers already agree, so that a revision minted over
+unchanged code is not reported as a stale mirror.
 
 To resync one contract:
 
@@ -166,7 +170,10 @@ To resync one contract:
 3. Update the contract: `verified_revision` and `mirror.revision` to the new revision number,
    `mirror.hash` to the platform's hash, `mirror.local_sha256` to `sha256` of the file's bytes
    **including** the banner, and `mirror.synced_at` to today. `model_id` does not change — a
-   changed `model_id` is a different model, and the cross-commit gate rejects it.
+   changed `model_id` is a different model, and the cross-commit gate rejects it. **If the
+   contract carries `mirror.code_unchanged_from`, delete that line.** It claims the mirrored
+   bytes have not moved, and a resync moves them; leaving it in fails the coherence gate. See
+   "Metadata-only revisions" below.
 4. If the schema file changed too, update `mirror.schema_sha256` the same way. A schema-only
    edit is still a byte change and must advance the revision.
 5. Run the gates: `uv run pytest tests/test_scope_gates.py -q` for the contract's integrity,
@@ -192,7 +199,13 @@ Confirm the sentinel reports the contract `metadata-only` first, then set
 move only if the marker equals the revision committed at the merge base, the revision strictly
 advances, the mirrored bytes are unchanged and `synced_at` does not regress — an offline gate
 cannot verify the platform's side of the claim, so it pins the claim to a shape a reviewer can
-check in one look. Setting the marker alongside changed bytes is itself a violation.
+check in one look. Setting the marker alongside changed bytes is itself a violation, which is
+why the next genuine resync of the contract deletes the line (step 3 above).
+
+A `hash` finding at an unchanged revision number is **not** this case, however well the code
+matches. The marker authorizes advancing to a revision, and there is no new revision to advance
+to; a contract in that state has a mis-pinned `mirror.hash` or sits on a revision the platform
+rewrote in place, and both want a look rather than a marker.
 
 **The sentinel cannot see an unreleased revision, and does not pretend to.** The platform
 exposes no release marker — `GetDataModel` has no release field and `GetAssetChangelog`'s

--- a/tests/test_assets_inventory.py
+++ b/tests/test_assets_inventory.py
@@ -816,6 +816,82 @@ def test_a_same_day_refetch_is_legal(monkeypatch):
                            _mirror(revision=5, hash="h2", local_sha256="S2"))
 
 
+# --- metadata-only platform revisions, and the marker that authorizes recording one ---------
+# The platform mints revisions over byte-identical code (a cron cleared, a description added).
+# Without an escape valve the affected contracts can never record the deployed revision, so the
+# weekly sentinel fires on them forever. `mirror.code_unchanged_from` is that valve, and these
+# tests pin the four ways of getting it wrong as tightly as the one way of getting it right.
+
+def test_a_metadata_only_revision_is_allowed_with_the_marker(monkeypatch):
+    """Bytes unchanged, revision advanced, and the marker names the prior revision."""
+    after = _mirror(revision=5, hash="h2", synced_at="2026-08-20", code_unchanged_from=4)
+    assert _provenance(monkeypatch, _mirror(), after) == []
+
+
+def test_the_marker_must_name_the_prior_committed_revision(monkeypatch):
+    """An arbitrary number would let the marker authorize any bump. It has to name the state
+    the reviewer can see in the merge base."""
+    after = _mirror(revision=5, hash="h2", synced_at="2026-08-20", code_unchanged_from=3)
+    violations = _provenance(monkeypatch, _mirror(), after)
+    assert any("code_unchanged_from is 3" in v for v in violations), violations
+    assert any("committed at the merge base (4)" in v for v in violations), violations
+
+
+def test_the_marker_is_rejected_when_the_bytes_changed(monkeypatch):
+    """The marker's own claim is that the code did not move. Bytes moving makes it false, so
+    it is a violation in its own right rather than a no-op on the resync path."""
+    after = _mirror(revision=5, hash="h2", local_sha256="S2", synced_at="2026-08-20",
+                    code_unchanged_from=4)
+    violations = _provenance(monkeypatch, _mirror(), after)
+    assert any("but the mirrored bytes changed" in v for v in violations), violations
+
+
+def test_the_marker_does_not_excuse_a_revision_that_does_not_advance(monkeypatch):
+    """A metadata-only revision is still a new revision. Freezing or regressing the number
+    while moving the hash is the drift the gate exists to catch."""
+    for revision in (4, 3):
+        after = _mirror(revision=revision, hash="h2", synced_at="2026-08-20",
+                        code_unchanged_from=4)
+        violations = _provenance(monkeypatch, _mirror(), after)
+        assert any("still advances the revision" in v for v in violations), (revision, violations)
+
+
+def test_the_marker_does_not_excuse_synced_at_moving_backward(monkeypatch):
+    after = _mirror(revision=5, hash="h2", synced_at="2026-08-01", code_unchanged_from=4)
+    violations = _provenance(monkeypatch, _mirror(), after)
+    assert any("moved backward" in v for v in violations), violations
+
+
+def test_provenance_still_may_not_move_without_the_marker(monkeypatch):
+    """The default is unchanged: silence means bytes and provenance move together."""
+    after = _mirror(revision=5, hash="h2", synced_at="2026-08-20")
+    assert _provenance(monkeypatch, _mirror(), after) == [
+        "x.y: provenance changed but the mirrored bytes did not"
+    ]
+
+
+def test_the_marker_alone_changes_nothing_when_no_provenance_moved(monkeypatch):
+    """Adding the marker without advancing anything is inert, not a violation -- the gate
+    judges movement, and there is none."""
+    assert _provenance(monkeypatch, _mirror(), _mirror(code_unchanged_from=4)) == []
+
+
+def test_the_three_metadata_only_contracts_carry_the_marker():
+    """The contracts the platform revised without touching their code. Named rather than
+    counted, because the marker is a per-contract claim a reviewer signed off on; a fourth
+    contract acquiring one should be a deliberate edit to this list."""
+    marked = {d["table"]: d["mirror"]["code_unchanged_from"]
+              for d in A.dependencies() if (d.get("mirror") or {}).get("code_unchanged_from")}
+    assert marked == {
+        "currentai.scores.openness_facts": 7,
+        "currentai.scores.openness_computed": 15,
+        "currentai.signal_github.artifact_state": 2,
+    }
+    for table, prior in marked.items():
+        mirror = next(d for d in A.dependencies() if d["table"] == table)["mirror"]
+        assert mirror["revision"] > prior, table
+
+
 # --- the platform-model audit is reproducible from a committed receipt -------------
 # platform_models: checked is not 57 authored booleans; it is backed by
 # warehouse/audits/platform_models.json, the credential-free receipt of the Phase 0b audit.

--- a/tests/test_check_mirror_drift.py
+++ b/tests/test_check_mirror_drift.py
@@ -125,7 +125,8 @@ def test_the_same_revision_with_a_different_hash_over_different_code_is_hash_dri
 def test_a_newer_platform_revision_over_identical_code_is_metadata_only(tmp_path):
     """A cron cleared or a description added. The contract is behind by a number and by
     nothing else, so sending a maintainer to resync would be sending them to copy a file
-    onto itself."""
+    onto itself. A NEW revision is required, which is what separates this from the hash case
+    below."""
     row = compare(build_tree(tmp_path), node(revision=5, hash_="newhash"), tmp_path)
     assert row.status == "metadata-only"
     assert not row.drifted
@@ -134,12 +135,16 @@ def test_a_newer_platform_revision_over_identical_code_is_metadata_only(tmp_path
     assert "byte-identical" in row.detail
 
 
-def test_a_hash_change_over_identical_code_is_metadata_only(tmp_path):
-    """Same treatment when it is the hash rather than the revision that moved: the source is
-    what decides whether there is anything to do."""
+def test_a_hash_change_with_no_new_revision_stays_hash_drift(tmp_path):
+    """Identical code does NOT make this metadata-only. There is no new revision to record, the
+    coherence gate rejects a marker whose revision does not advance, and so calling it
+    metadata-only would tell a maintainer to make a commit the repo's own gate refuses. It is a
+    mis-pinned hash or an in-place rewrite, and it stays loud."""
     row = compare(build_tree(tmp_path), node(hash_="rewritten"), tmp_path)
-    assert row.status == "metadata-only"
-    assert not row.drifted
+    assert row.status == "hash"
+    assert row.drifted
+    assert row.code_match is True
+    assert "mis-pin" in row.detail
 
 
 def test_a_metadata_only_sweep_exits_zero_and_names_the_marker(tmp_path, capsys):

--- a/tests/test_check_mirror_drift.py
+++ b/tests/test_check_mirror_drift.py
@@ -1,10 +1,11 @@
-"""The mirror-drift sentinel must separate four findings from each other, and from silence.
+"""The mirror-drift sentinel must separate five findings from each other, and from silence.
 
 Written against a stub client rather than the platform, because the whole value of the gate
 is the distinction it draws between "the mirror is stale", "the same revision number now
-means different bytes", "the numbers agree and the code does not", and "we could not tell".
-Those are four different things a maintainer does four different things about, and only the
-last one must never be reported as a pass.
+means different bytes", "the numbers agree and the code does not", "the numbers moved and the
+code did not", and "we could not tell". Those are five different things a maintainer does five
+different things about; only the fourth is not a resync, and only the last must never be
+reported as a pass.
 
 The stub returns platform nodes in the shape `GetDataModel` actually returns -- a
 `latestRevision` carrying `revisionNumber`, `hash`, `code` and `createdAt` -- so the
@@ -100,20 +101,68 @@ def test_a_matching_contract_is_ok(tmp_path):
     assert row.platform_revision == row.contract_revision == 4
 
 
-def test_a_newer_platform_revision_is_revision_drift(tmp_path):
-    row = compare(build_tree(tmp_path), node(revision=5, hash_="newhash"), tmp_path)
+def test_a_newer_platform_revision_over_different_code_is_revision_drift(tmp_path):
+    row = compare(build_tree(tmp_path), node(revision=5, hash_="newhash", code="SELECT 2\n"),
+                  tmp_path)
     assert row.status == "revision"
     assert row.drifted
     assert (row.contract_revision, row.platform_revision) == (4, 5)
     assert "latest revision is 5" in row.detail
+    assert "does not match" in row.detail
 
 
-def test_the_same_revision_with_a_different_hash_is_hash_drift(tmp_path):
+def test_the_same_revision_with_a_different_hash_over_different_code_is_hash_drift(tmp_path):
     """The worst of the three: the number the repo pins now denotes different content."""
-    row = compare(build_tree(tmp_path), node(hash_="rewritten"), tmp_path)
+    row = compare(build_tree(tmp_path), node(hash_="rewritten", code="SELECT 2\n"), tmp_path)
     assert row.status == "hash"
+    assert row.drifted
     assert row.hash_match is False
     assert "rewritten" in row.detail
+
+
+# --- the revision the platform minted over code it did not touch -------------------------
+
+def test_a_newer_platform_revision_over_identical_code_is_metadata_only(tmp_path):
+    """A cron cleared or a description added. The contract is behind by a number and by
+    nothing else, so sending a maintainer to resync would be sending them to copy a file
+    onto itself."""
+    row = compare(build_tree(tmp_path), node(revision=5, hash_="newhash"), tmp_path)
+    assert row.status == "metadata-only"
+    assert not row.drifted
+    assert row.metadata_only
+    assert (row.hash_match, row.code_match) == (False, True)
+    assert "byte-identical" in row.detail
+
+
+def test_a_hash_change_over_identical_code_is_metadata_only(tmp_path):
+    """Same treatment when it is the hash rather than the revision that moved: the source is
+    what decides whether there is anything to do."""
+    row = compare(build_tree(tmp_path), node(hash_="rewritten"), tmp_path)
+    assert row.status == "metadata-only"
+    assert not row.drifted
+
+
+def test_a_metadata_only_sweep_exits_zero_and_names_the_marker(tmp_path, capsys):
+    """Exit 0, because there is no stale mirror -- but the run still says what to record."""
+    write_dependencies(tmp_path, [build_tree(tmp_path)])
+    code = main([], root=tmp_path, client=StubClient(node(revision=5, hash_="newhash")))
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "0 drifted" in out
+    assert "1 of them over a metadata-only revision" in out
+    assert "code_unchanged_from" in out
+    assert "Mirror resync" not in out
+
+
+def test_a_metadata_only_row_is_counted_apart_in_the_report(tmp_path):
+    write_dependencies(tmp_path, [build_tree(tmp_path)])
+    report = tmp_path / "drift.json"
+    code = main(["--report", str(report)], root=tmp_path,
+                client=StubClient(node(revision=5, hash_="newhash")))
+    assert code == 0
+    payload = json.loads(report.read_text())
+    assert (payload["checked"], payload["drifted"], payload["metadata_only"]) == (1, 0, 1)
+    assert payload["rows"][0]["status"] == "metadata-only"
 
 
 def test_matching_numbers_over_different_source_is_code_drift(tmp_path):
@@ -160,7 +209,8 @@ def test_a_clean_sweep_exits_zero_and_writes_the_report(tmp_path, capsys):
 
 def test_any_drift_exits_one_and_names_the_runbook(tmp_path, capsys):
     write_dependencies(tmp_path, [build_tree(tmp_path)])
-    code = main([], root=tmp_path, client=StubClient(node(revision=9, hash_="h9")))
+    code = main([], root=tmp_path,
+                client=StubClient(node(revision=9, hash_="h9", code="SELECT 2\n")))
     assert code == 1
     out = capsys.readouterr().out
     assert "1 drifted" in out

--- a/warehouse/dependencies.yaml
+++ b/warehouse/dependencies.yaml
@@ -25,7 +25,9 @@
 #         code_unchanged_from to the revision the contract currently records, and advance
 #         verified_revision, mirror.revision, mirror.hash (live, from GetDataModel) and
 #         mirror.synced_at. Leave local_sha256 and schema_sha256 alone -- the marker's whole claim
-#         is that they do not move, and the gate rejects it if they do.
+#         is that they do not move, and the gate rejects it if they do, so the next genuine resync
+#         DELETES the code_unchanged_from line. A `hash` finding at an unchanged revision number is
+#         not this case: there is no new revision to advance to, so it wants a look, not a marker.
 #       - oso.* upstream -> content_contract_sha256 over table + grain + TYPED expected_columns
 #         (name + type + nullable), recomputed by the gate + a verified_at date.
 #         Reproduce: sha256(table + "\n" + expected_grain + "\n" +

--- a/warehouse/dependencies.yaml
+++ b/warehouse/dependencies.yaml
@@ -17,6 +17,15 @@
 #         EVERY claimed file (model via local_sha256, schema via schema_sha256) against the bytes on
 #         disk; cross-commit coherence (bytes move with revision/hash/synced_at, model_id stable) is
 #         gated across BOTH manifests, including the one-time asset->dependency move;
+#         A metadata-only platform revision (a cron cleared, a description added) mints a new
+#         revision over byte-identical code, so bytes-move-with-revision would forbid the contract
+#         from ever recording the deployed revision. `mirror.code_unchanged_from: <prior revision>`
+#         is the escape valve, the analogue of `mirror_migration` for model_id. Recipe: confirm
+#         `uv run python -m build.check_mirror_drift` reports the contract `metadata-only`, then set
+#         code_unchanged_from to the revision the contract currently records, and advance
+#         verified_revision, mirror.revision, mirror.hash (live, from GetDataModel) and
+#         mirror.synced_at. Leave local_sha256 and schema_sha256 alone -- the marker's whole claim
+#         is that they do not move, and the gate rejects it if they do.
 #       - oso.* upstream -> content_contract_sha256 over table + grain + TYPED expected_columns
 #         (name + type + nullable), recomputed by the gate + a verified_at date.
 #         Reproduce: sha256(table + "\n" + expected_grain + "\n" +
@@ -59,17 +68,18 @@ dependencies:
   freshness_requirement: <= 8 days (weekly platform refresh)
   required_by:
   - warehouse/models/scores/openness_computed.sql
-  verified_revision: 7
+  verified_revision: 9
   owner: oso
   files:
     model: warehouse/models/scores/openness_facts.sql
     schema: warehouse/models/scores/openness_facts.schema.json
   mirror:
     model_id: 68d9e34c-b0b6-460b-b4ae-21b7016eb1f8
-    revision: 7
-    hash: 7ce706d47d74cc433b6eb02b7b8558d26af21f6689d83426296d2457fa3ad26c
+    revision: 9
+    hash: de80c94bdc10b1ffcc00f92882b7b60587ed15881c86fe50e701565bc54e891b
     local_sha256: 1952f4b3939ade83f4ec239795ad234fa3ec8464c1789edb4d66374f072e4e39
-    synced_at: '2026-08-15'
+    synced_at: '2026-09-04'
+    code_unchanged_from: 7
     schema_sha256: e0af61b46f8e470354b9c0c5e1efe8fc419cd37bbbfccc3bdbf44991ecddebf9
   platform_schedule:
     cron: 0 4 * * 1
@@ -85,17 +95,18 @@ dependencies:
   required_by:
   - build/apply_scores.py
   - build/check_parity.py
-  verified_revision: 15
+  verified_revision: 17
   owner: oso
   files:
     model: warehouse/models/scores/openness_computed.sql
     schema: warehouse/models/scores/openness_computed.schema.json
   mirror:
     model_id: 6aef560b-cc85-4a9d-afa8-8f4798208e74
-    revision: 15
-    hash: 5606414402e540d23105552aa2320e4d62cdc71540e84e1d1a8db842df429ca1
+    revision: 17
+    hash: b72dca7a6b36b9aa529d64089df7cf14f6e9d409aa7ed746554b2475e1031824
     local_sha256: afc40feea6966d0ad946b0f2ae1d00b8ad4f5a9a6e2fb74dea8383ec5d88b464
-    synced_at: '2026-08-15'
+    synced_at: '2026-09-04'
+    code_unchanged_from: 15
     schema_sha256: 0802e69dd10acc0575ba95e845514f59ec818b6b51e5a69551ceaa2fec910a8e
   platform_schedule:
     cron: 0 4 * * 1
@@ -114,16 +125,17 @@ dependencies:
   - warehouse/models/identity/artifact_identity_edges.sql
   - warehouse/models/observations/product_adoption_current.sql
   - warehouse/models/signal_github/product_adoption.sql
-  verified_revision: 2
+  verified_revision: 3
   owner: oso
   files:
     model: warehouse/models/signal_github/artifact_state.py
   mirror:
     model_id: fed14549-c660-44fc-a6cc-c859795bde7f
-    revision: 2
-    hash: 4ca130834731c7cdee5534b15eef71143b20179b725cb90758e3cfd5d4fcec5f
+    revision: 3
+    hash: 50753eeafde043fc4e7ba8674143296fea8e311805adfd9e78ae51bd4053b2e8
     local_sha256: 66b18ee046d741510a0669028c8b4fb4dd47c8190ca0f92d83c6ccdb20b7f9ea
-    synced_at: '2026-08-24'
+    synced_at: '2026-09-04'
+    code_unchanged_from: 2
   platform_schedule:
     cron: 0 3 * * 0
     timezone: UTC


### PR DESCRIPTION
## The gap

`warehouse/dependencies.yaml` pins, for every platform-authored model the repo mirrors
read-only, a `mirror:` block naming the revision, the platform's hash for it, and a
`local_sha256` over the bytes on disk. The offline coherence gate in `build/assets.py`
(`_compare_mirror`) requires revision, hash and `synced_at` to move only when the mirrored
bytes move. That rule is correct: an offline gate has no platform to ask, so it cannot verify
a bare revision bump.

But the platform legitimately mints revisions over byte-identical code — a cron cleared, a
description filled in. Three contracts were in that state, which is why #488 resynced five
mirrors and left these three pinned: there was no legal way to record their deployed revision,
and the weekly mirror-drift sentinel (#486) reported drift on them forever. A sentinel with
three permanent false positives is a sentinel nobody reads.

## The marker and its five checks

`mirror.code_unchanged_from: <prior revision>` is the escape valve, the exact analogue of the
existing `mirror_migration` for `model_id`: an explicit, reviewable claim naming the revision
the code is unchanged from. The gate's not-bytes-moved branch allows revision, hash and
`synced_at` to move only when:

1. the marker is present — silence still means bytes and provenance move together;
2. it equals the revision committed at the merge base, so it names a real prior state rather
   than an arbitrary number;
3. the revision strictly advances;
4. the mirrored bytes are unchanged — enforced from both sides, since the marker is only
   reachable when neither sha moved, and setting it alongside changed bytes is itself a
   violation (the marker's own claim would be false). The next genuine resync therefore deletes
   the marker line, and both the runbook and the gate's rejection message say so;
5. `synced_at` does not regress.

`hash` may move here and is not required to. The bytes-moved path is otherwise untouched.

## The three contracts

| Contract | Revision | Hash |
|---|---|---|
| `currentai.scores.openness_facts` | 7 → 9 | fetched live via `GetDataModel` |
| `currentai.scores.openness_computed` | 15 → 17 | fetched live via `GetDataModel` |
| `currentai.signal_github.artifact_state` | 2 → 3 | fetched live via `GetDataModel` |

`local_sha256` and `schema_sha256` are unchanged on all three, which is the whole point.
`synced_at` moves to 2026-09-04.

## The drift check

`build/check_mirror_drift.py` now compares the deployed source on **every** contract rather
than only where the revision and hash already agree, because the source is what separates a
metadata-only revision from a stale mirror. A **newer platform revision** over byte-identical
code is reported as `metadata-only` and exits 0, counted apart in the summary and the JSON
report, with the run naming what to record.

The "newer revision" half is load-bearing. A hash disagreement at an unchanged revision number
stays class `hash` and exits 1 however well the source matches: there is no revision to advance
to, the coherence gate rejects a marker whose revision does not advance, and so reporting it as
metadata-only would instruct a commit the repo's own gate refuses. The message names the two
real causes, a mis-pinned `mirror.hash` or a revision the platform rewrote in place.

Exit 1 is therefore `code` drift, any `hash` finding, and a revision mismatch whose deployed
source really does differ.

## Live run

Rebased onto #488. `uv run python -m build.check_mirror_drift`:

```
17 of 17 mirror contracts match the platform's deployed source (0 of them over a
metadata-only revision), 0 drifted
[OK] every mirror contract mirrors the source the platform is running
```

The three marker contracts read `ok` with `hash yes / code yes` at 9/9, 17/17 and 3/3;
#488's five resyncs (`signal_pypi.package_downloads` and the four `identity.*` models) are
`ok` too, so the sentinel is green for the first time. Before this branch the same run
reported the three as `revision` drift with `code` uncomputed, which is what made them
indistinguishable from the five real ones.

## Test plan

- `uv run pytest tests/test_scope_gates.py tests/test_assets_inventory.py tests/test_check_mirror_drift.py tests/test_docs_integrity.py -q -n 4` — 197 passed
- `uv run python -m build.validate` — 0 errors, 2 pre-existing warnings
- `uv run python -m build.check_mirror_drift` (live) — 17 of 17 ok, exit 0
- `uv run pytest -q -n 4 -m "not serial"` — 1629 passed

New tests: the marker accepted; naming the wrong prior revision rejected; set alongside changed
bytes rejected; a revision that does not advance rejected; `synced_at` regressing rejected;
provenance still immovable without the marker; the marker inert when nothing moved; and the
three real contracts named rather than counted. For the drift check: a newer revision over
identical code is `metadata-only`; a hash change with no new revision stays `hash` and drifted
even when the code matches; both revision and hash findings over differing code stay drift; and
a metadata-only sweep exits 0 while still naming the marker.

`tests/test_assets_inventory.py::test_dependency_mirror_provenance_holds` runs the gate live
against the merge base, so the three updated contracts are proof the marker works rather than
a stub: dropping the marker turns them straight back into three violations.

Also corrected in passing: the CHANGELOG and the runbook said the sentinel "opens a `sentinel`
issue". It does not — `report-failure.yml` picks up the red `workflow_run` and opens or comments
on the issue, and `mirror-drift` is in its workflow list.

Refs #365
