### PR TITLE
Add EuroLLM to base_pretrained (open-weights, 3)

### DIFF
--- a/sources/categories/base_pretrained.yaml
+++ b/sources/categories/base_pretrained.yaml
@@ -259,4 +259,5 @@ products:
 - minicpm
 - seed-oss
 - comma
+- eurollm
 comments: ''

--- a/sources/org_handles.yaml
+++ b/sources/org_handles.yaml
@@ -402,6 +402,17 @@ handles:
 - org: euroeval
   platform: homepage_domain
   handle: euroeval.com
+- org: eurollm
+  platform: github
+  handle: deep-spin
+  note: EuroLLM's pretraining and evaluation code ship under the DeepSPIN GitHub org (IST/IT), the project's engineering home.
+- org: eurollm
+  platform: huggingface
+  handle: utter-project
+  note: EuroLLM models and datasets are published under the utter-project Hugging Face org, from the UTTER Horizon Europe project the family began under.
+- org: eurollm
+  platform: homepage_domain
+  handle: eurollm.io
 - org: evidently-ai
   platform: github
   handle: evidentlyai

--- a/sources/org_handles.yaml
+++ b/sources/org_handles.yaml
@@ -403,10 +403,6 @@ handles:
   platform: homepage_domain
   handle: euroeval.com
 - org: eurollm
-  platform: github
-  handle: deep-spin
-  note: EuroLLM's pretraining and evaluation code ship under the DeepSPIN GitHub org (IST/IT), the project's engineering home.
-- org: eurollm
   platform: huggingface
   handle: utter-project
   note: EuroLLM models and datasets are published under the utter-project Hugging Face org, from the UTTER Horizon Europe project the family began under.

--- a/sources/organizations/eurollm.yaml
+++ b/sources/organizations/eurollm.yaml
@@ -2,7 +2,5 @@ name: eurollm
 display_name: EuroLLM
 type: lab
 homepage: https://eurollm.io
-github:
-- url: https://github.com/deep-spin
 products:
 - eurollm

--- a/sources/organizations/eurollm.yaml
+++ b/sources/organizations/eurollm.yaml
@@ -1,0 +1,8 @@
+name: eurollm
+display_name: EuroLLM
+type: lab
+homepage: https://eurollm.io
+github:
+- url: https://github.com/deep-spin
+products:
+- eurollm

--- a/sources/products/eurollm.yaml
+++ b/sources/products/eurollm.yaml
@@ -1,28 +1,37 @@
 name: eurollm
 display_name: EuroLLM
 type: model
-description: An open multilingual LLM family from the EuroLLM project, a European consortium led by
-  Unbabel and the DeepSPIN group at Instituto Superior Técnico, built under the UTTER Horizon Europe
-  project. The current 22B flagship, alongside 9B and 1.7B siblings, is trained from scratch on ~4
-  trillion tokens covering all 24 official EU languages plus 11 more (35 in total), on the MareNostrum5
-  supercomputer under a EuroHPC grant. The release ships base and instruction-tuned weights, the
-  multilingual web pretraining data, the EuroBlocks instruction datasets, and the pretraining and
-  evaluation codebases, all under Apache-2.0.
+description: An open-weights multilingual LLM family from the EuroLLM project, a European consortium led by
+  Unbabel and the DeepSPIN group at Instituto Superior Técnico, built under the UTTER Horizon Europe project.
+  The current 22B flagship, alongside 9B and 1.7B siblings, is trained from scratch on ~4 trillion tokens
+  covering all 24 official EU languages plus 11 more (35 in total), on the MareNostrum5 supercomputer under
+  a EuroHPC grant. The Apache-2.0 weights ship with base and instruction-tuned variants, intermediate
+  per-phase Megatron-Core checkpoints, the EuroWeb web pretraining subset, the EuroBlocks instruction
+  datasets, and an evaluation harness; the full pretraining corpus and training recipe are documented in the
+  technical report but not released.
 github:
-- url: https://github.com/deep-spin/Megatron-LM-pretrain
 - url: https://github.com/deep-spin/eurollm-eval
 huggingface_model:
 - url: https://huggingface.co/utter-project/EuroLLM-22B-2512
+- url: https://huggingface.co/utter-project/EuroLLM-22B-Instruct-2512
+- url: https://huggingface.co/utter-project/EuroLLM-22B-Preview
+- url: https://huggingface.co/utter-project/EuroLLM-22B-Instruct-Preview
 - url: https://huggingface.co/utter-project/EuroLLM-9B
+- url: https://huggingface.co/utter-project/EuroLLM-9B-2512
+- url: https://huggingface.co/utter-project/EuroLLM-9B-Instruct
+- url: https://huggingface.co/utter-project/EuroLLM-9B-Instruct-2512
 - url: https://huggingface.co/utter-project/EuroLLM-1.7B
+- url: https://huggingface.co/utter-project/EuroLLM-1.7B-Instruct
 huggingface_dataset:
 - url: https://huggingface.co/datasets/utter-project/EuroWeb-2512
 - url: https://huggingface.co/datasets/utter-project/EuroBlocks-SFT-2512
 arxiv:
 - url: https://arxiv.org/abs/2602.05879
-comments: 'The EuroLLM-22B release (models 2512, technical report arXiv:2602.05879, published 2026-02-05)
-  is a full open-source release in the OLMo/Apertus mould: Apache-2.0 weights, released multilingual
-  web pretraining data (EuroWeb-2512), released instruction data (EuroBlocks-SFT-2512), and a released
-  pretraining pipeline (deep-spin/Megatron-LM-pretrain, a Megatron-LM fork) plus evaluation codebase
-  (deep-spin/eurollm-eval). Verified 2026-09-04 via the EuroLLM-22B-2512 model card, the Hugging Face
-  model/dataset APIs, and the technical report.'
+comments: 'EuroLLM-22B (models 2512, technical report arXiv:2602.05879, published 2026-02-05) is an
+  open-weights release: Apache-2.0 weights and public per-phase Megatron-Core checkpoints, but the pretraining
+  corpus is only partly released (the EuroWeb-2512 web subset; parallel/curated/synthetic components are
+  documented, not shipped) and no EuroLLM pretraining recipe is published (the cited deep-spin/Megatron-LM-pretrain
+  is a generic year-stale Megatron-LM fork; only the deep-spin/eurollm-eval harness is EuroLLM-specific).
+  Verified 2026-09-04 via the model/dataset cards, the Hugging Face APIs, the technical report, and a direct
+  read of the Megatron fork. All ten shipped SKUs are declared so the warehouse sums adoption over the same
+  set.'

--- a/sources/products/eurollm.yaml
+++ b/sources/products/eurollm.yaml
@@ -9,8 +9,6 @@ description: An open-weights multilingual LLM family from the EuroLLM project, a
   per-phase Megatron-Core checkpoints, the EuroWeb web pretraining subset, the EuroBlocks instruction
   datasets, and an evaluation harness; the full pretraining corpus and training recipe are documented in the
   technical report but not released.
-github:
-- url: https://github.com/deep-spin/eurollm-eval
 huggingface_model:
 - url: https://huggingface.co/utter-project/EuroLLM-22B-2512
 - url: https://huggingface.co/utter-project/EuroLLM-22B-Instruct-2512

--- a/sources/products/eurollm.yaml
+++ b/sources/products/eurollm.yaml
@@ -32,6 +32,6 @@ comments: 'EuroLLM-22B (models 2512, technical report arXiv:2602.05879, publishe
   corpus is only partly released (the EuroWeb-2512 web subset; parallel/curated/synthetic components are
   documented, not shipped) and no EuroLLM pretraining recipe is published (the cited deep-spin/Megatron-LM-pretrain
   is a generic year-stale Megatron-LM fork; only the deep-spin/eurollm-eval harness is EuroLLM-specific).
-  Verified 2026-09-04 via the model/dataset cards, the Hugging Face APIs, the technical report, and a direct
-  read of the Megatron fork. All ten shipped SKUs are declared so the warehouse sums adoption over the same
-  set.'
+  All ten shipped SKUs are declared so the warehouse sums adoption over the same set. Verified 2026-09-04
+  via the EuroLLM-22B-2512 model card, the EuroWeb-2512 dataset card, the technical report arXiv:2602.05879,
+  and the deep-spin/Megatron-LM-pretrain repository.'

--- a/sources/products/eurollm.yaml
+++ b/sources/products/eurollm.yaml
@@ -1,0 +1,28 @@
+name: eurollm
+display_name: EuroLLM
+type: model
+description: An open multilingual LLM family from the EuroLLM project, a European consortium led by
+  Unbabel and the DeepSPIN group at Instituto Superior Técnico, built under the UTTER Horizon Europe
+  project. The current 22B flagship, alongside 9B and 1.7B siblings, is trained from scratch on ~4
+  trillion tokens covering all 24 official EU languages plus 11 more (35 in total), on the MareNostrum5
+  supercomputer under a EuroHPC grant. The release ships base and instruction-tuned weights, the
+  multilingual web pretraining data, the EuroBlocks instruction datasets, and the pretraining and
+  evaluation codebases, all under Apache-2.0.
+github:
+- url: https://github.com/deep-spin/Megatron-LM-pretrain
+- url: https://github.com/deep-spin/eurollm-eval
+huggingface_model:
+- url: https://huggingface.co/utter-project/EuroLLM-22B-2512
+- url: https://huggingface.co/utter-project/EuroLLM-9B
+- url: https://huggingface.co/utter-project/EuroLLM-1.7B
+huggingface_dataset:
+- url: https://huggingface.co/datasets/utter-project/EuroWeb-2512
+- url: https://huggingface.co/datasets/utter-project/EuroBlocks-SFT-2512
+arxiv:
+- url: https://arxiv.org/abs/2602.05879
+comments: 'The EuroLLM-22B release (models 2512, technical report arXiv:2602.05879, published 2026-02-05)
+  is a full open-source release in the OLMo/Apertus mould: Apache-2.0 weights, released multilingual
+  web pretraining data (EuroWeb-2512), released instruction data (EuroBlocks-SFT-2512), and a released
+  pretraining pipeline (deep-spin/Megatron-LM-pretrain, a Megatron-LM fork) plus evaluation codebase
+  (deep-spin/eurollm-eval). Verified 2026-09-04 via the EuroLLM-22B-2512 model card, the Hugging Face
+  model/dataset APIs, and the technical report.'

--- a/sources/scores/eurollm.yaml
+++ b/sources/scores/eurollm.yaml
@@ -1,0 +1,138 @@
+product: eurollm
+openness:
+  score: 5
+  class: open_source
+  components:
+    weights:
+      value: open
+      detail: Apache-2.0, BF16 safetensors, ungated
+    data:
+      value: open
+      detail: multilingual web pretraining data released as EuroWeb-2512 + EuroBlocks-SFT instruction data
+    code:
+      value: open
+      detail: pretraining pipeline deep-spin/Megatron-LM-pretrain + evaluation codebase deep-spin/eurollm-eval
+    license:
+    - name: Apache-2.0
+      detail: OSI
+  confidence: high
+  note: 'EuroLLM-22B is a full open-source release on the OLMo/Pythia/Apertus tier: the pretraining
+    corpus, the code that consumed it, and an OSI license over the weights. The technical report (arXiv:2602.05879)
+    states outright, "we release our base and instruction-tuned models, our multilingual web pretraining
+    data and updated EuroBlocks instruction datasets, as well as our pre-training and evaluation codebases".
+    Each was confirmed: the 22B-2512 weights are Apache-2.0 BF16 safetensors and ungated on Hugging Face;
+    the multilingual web pretraining data ships as the public utter-project/EuroWeb-2512 dataset (with a
+    matching EuroLLM-Multilingual-Data-2512) and the instruction data as EuroBlocks-SFT-2512; and the
+    pretraining pipeline is the public deep-spin/Megatron-LM-pretrain repository (a Megatron-LM fork,
+    the same shape as Apertus''s Megatron-LM recipe) alongside the public deep-spin/eurollm-eval harness.
+    With data open, code open and the license OSI, the recipe lands the family at 5. The corpus mixture''s
+    later high-quality and parallel components are documented in the report rather than fully released,
+    but the released web pretraining data plus the training pipeline satisfy data:open by a released
+    dataset rather than by reconstruction scripts.'
+  last_verified: '2026-09-04'
+  raw: weights:open(Apache-2.0, BF16 safetensors, ungated);data:open(EuroWeb-2512 multilingual web pretraining
+    data + EuroBlocks-SFT instruction data);code:open(deep-spin/Megatron-LM-pretrain pretraining pipeline
+    + deep-spin/eurollm-eval);license:Apache-2.0(OSI)
+  sources:
+  - url: https://huggingface.co/api/models/utter-project/EuroLLM-22B-2512
+    shows: '`private: false`, `gated: false`, `license: apache-2.0`, `safetensors.total` 22,637,328,384
+      BF16 parameters, LlamaForCausalLM, 35 language tags including all 24 official EU languages. Establishes
+      that the weights are downloadable, ungated and OSI-licensed.'
+    accessed: '2026-09-04'
+    http_status: 200
+    content_sha256: 5194a2f48a03b38b4e11ab77c6859007a4e8399de8408d9fefa200d14df958b8
+    establishes: [weights, license]
+  - url: https://huggingface.co/utter-project/EuroLLM-22B-2512
+    shows: 'Model card "Model Card for EuroLLM-22B": "License: Apache License 2.0"; 22B parameter multilingual
+      transformer trained from scratch on ~4T tokens on the MareNostrum5 supercomputer; describes the three
+      pretraining phases (initial 3.6T, annealing 400B, annealing-to-zero 100B) and the data sources (web,
+      parallel, Wikipedia, Arxiv, books, math, code, Apollo).'
+    accessed: '2026-09-04'
+    http_status: 200
+    content_sha256: d1a3dc2ce9cf358b536898d6e11b193e3b0da7a86bbcd29992d8fc9f232d8c17
+    establishes: [weights, license]
+  - url: https://arxiv.org/abs/2602.05879
+    shows: 'EuroLLM-22B Technical Report abstract: "To support future research, we release our base and
+      instruction-tuned models, our multilingual web pretraining data and updated EuroBlocks instruction
+      datasets, as well as our pre-training and evaluation codebases." Establishes the data and code release
+      as a first-party claim by the model''s authors.'
+    accessed: '2026-09-04'
+    http_status: 200
+    content_sha256: 6be57584f9eec5c9a0e861595d0c2684d5122f5256b6db33458277729048d9d8
+    establishes: [data, code]
+  - url: https://arxiv.org/pdf/2602.05879
+    shows: 'Technical report body links the released pretraining codebase github.com/deep-spin/Megatron-LM-pretrain
+      and evaluation codebase github.com/deep-spin/eurollm-eval, and the released data
+      huggingface.co/datasets/utter-project/EuroLLM-Multilingual-Data-2512 and EuroBlocks-SFT-2512.
+      deep-spin/Megatron-LM-pretrain was independently confirmed to be a public Megatron-LM fork (pretrain_gpt.py,
+      megatron/), and deep-spin/eurollm-eval a public repository.'
+    accessed: '2026-09-04'
+    http_status: 200
+    content_sha256: 904a51563c7103be383bc60761a34820b6256ca016725505f10b399cf7f5c289
+    establishes: [data, code]
+  - url: https://huggingface.co/api/datasets/utter-project/EuroWeb-2512
+    shows: '`private: false`, `gated: false`, size category 1B<n<10B; the released multilingual web pretraining
+      dataset for the EuroLLM-22B (2512) release, with ~16K downloads in the trailing 30 days. Establishes
+      data:open by a released dataset.'
+    accessed: '2026-09-04'
+    http_status: 200
+    content_sha256: 285566722fe13e247b7af2d6519b0467b81ba234e0f9af65e92c6174a93fa606
+    establishes: [data]
+adoption:
+  level: 3
+  reach: 100K-1M
+  signal_type: usage_volume
+  confidence: medium
+  note: '127,672 downloads in the trailing 30 days summed across the family''s shipped SKUs on the
+    utter-project Hugging Face org: EuroLLM-22B-Instruct-2512 31,111; 9B-Instruct-2512 28,779; 1.7B-Instruct
+    27,659; 9B-Instruct 18,632; 1.7B 11,974; 9B-2512 2,866; 9B 2,832; 22B-2512 2,603; 22B-Instruct-Preview
+    1,111; 22B-Preview 105. Bands at level 3 (100K-1M) on the model adoption scale; confidence medium
+    because the total sits not far above the 100K floor and download figures move month to month. The
+    instruction-tuned 9B/1.7B SKUs carry the bulk of the traffic while the new 22B flagship is still ramping.'
+  last_verified: '2026-09-04'
+  sources:
+  - url: https://huggingface.co/api/models?author=utter-project&full=false&limit=100
+    shows: 'Trailing-30-day `downloads` per EuroLLM SKU on the utter-project org, summing to 127,672 across
+      the ten shipped base and instruct variants (22B/9B/1.7B).'
+    accessed: '2026-09-04'
+    http_status: 200
+    content_sha256: 5792ec1a12a4544956ef53aa5a7024c2f90766b603b8def5046d2ea2dd5ee2ad
+capability:
+  score: 3
+  basis: benchmark
+  basis_detail: MMLU / instruction-tuned English + multilingual suite
+  relative_to: apertus
+  relation: at
+  value: EuroLLM-22B-Instruct MMLU 69.8, MMLU-Pro 50.8, ARC-C 89.8, GSM8K 85.5 (English, Table 3); the
+    strongest fully-open European model, beating Apertus-70B on MMLU (67.9) with roughly one third of the
+    parameters, but trailing the frontier open-weights (Qwen-3-32B 84.0, Gemma-3-27B 80.4, Llama-3.3-70B
+    84.6) by ~10-15 pts on MMLU.
+  confidence: high
+  note: 'Mid-tier capability, the same profile and band as Apertus: competitive with the prior open
+    generation and unusually strong multilingually across the 35 supported languages, but below the 2026
+    frontier on reasoning and knowledge. The value proposition is full openness and European-language
+    breadth rather than raw SOTA. The EuroLLM-22B technical report''s Table 3 measures EuroLLM-22B and the
+    Apertus baselines on the same instruction-tuned English suite, and states EuroLLM-22B "is the strongest
+    model among the fully open European systems considered" while "the EuroLLM family still trails the very
+    best open-weights models overall". Placed level with Apertus, both at 3.'
+  last_verified: '2026-09-04'
+  comparison:
+    last_attested: '2026-09-04'
+    sources:
+    - url: https://arxiv.org/pdf/2602.05879
+      shows: 'Table 3 (English benchmarks) reports EuroLLM-22B and Apertus-8B/Apertus-70B on one suite:
+        EuroLLM-22B MMLU 69.8 vs Apertus-70B 67.9, MMLU-Pro 50.8 vs 41.9, ARC-C 89.8 vs 84.7; the paper
+        names EuroLLM-22B the strongest fully-open European system and competitive with Apertus-70B at
+        ~1/3 the parameters. Apertus''s own placement (score 3) is reaffirmed rather than moved.'
+      accessed: '2026-09-04'
+      http_status: 200
+      content_sha256: 904a51563c7103be383bc60761a34820b6256ca016725505f10b399cf7f5c289
+  sources:
+  - url: https://arxiv.org/pdf/2602.05879
+    shows: 'Table 3: EuroLLM-22B-Instruct English scores (IFEval 67.2, Hellaswag 69.7, MMLU 69.8, MMLU-Pro
+      50.8, BBH 55.3, ARC-C 89.8, GPQA 26.8, GSM8K 85.5, MATH-500 54.5, HumanEval 53.9) against Apertus,
+      OLMo-3, Llama-3, Gemma-3 and Qwen-3 baselines; prose "EuroLLM-22B is the strongest model among the
+      fully open European systems" and "still trails the very best open-weights models overall".'
+    accessed: '2026-09-04'
+    http_status: 200
+    content_sha256: 904a51563c7103be383bc60761a34820b6256ca016725505f10b399cf7f5c289

--- a/sources/scores/eurollm.yaml
+++ b/sources/scores/eurollm.yaml
@@ -32,8 +32,8 @@ openness:
     the whole corpus or full reconstruction scripts). Code: the only EuroLLM-specific code published is the
     deep-spin/eurollm-eval evaluation harness, which the rubric classes as closed on its own; the report also
     cites deep-spin/Megatron-LM-pretrain as the pre-training codebase, but that repository is a generic fork
-    of NVIDIA/Megatron-LM whose last commit predates the 2512 release by a year (2025-01-06) and carries no
-    EuroLLM training configs, so no pretraining recipe actually ships. Weights open, data documented, code
+    of NVIDIA/Megatron-LM whose last commit predates the 2512 release by about a year and carries no EuroLLM
+    training configs, so no pretraining recipe actually ships. Weights open, data documented, code
     partial and an OSI license fall through the recipe to 3, open_weights. Apache-2.0 covers the weights only:
     the released datasets carry no license tag, eurollm-eval has no LICENSE file, and the Megatron fork is
     NVIDIA-licensed.'

--- a/sources/scores/eurollm.yaml
+++ b/sources/scores/eurollm.yaml
@@ -1,99 +1,107 @@
 product: eurollm
 openness:
-  score: 5
-  class: open_source
+  score: 3
+  class: open_weights
   components:
     weights:
       value: open
       detail: Apache-2.0, BF16 safetensors, ungated
     data:
-      value: open
-      detail: multilingual web pretraining data released as EuroWeb-2512 + EuroBlocks-SFT instruction data
+      value: documented-not-released
+      detail: EuroWeb-2512 web subset released, remaining parallel/curated/synthetic and long-context components
+        documented in the report but withheld
     code:
+      value: partial
+      detail: deep-spin/eurollm-eval harness published, deep-spin/Megatron-LM-pretrain a generic year-stale
+        Megatron-LM fork with no EuroLLM configs
+    checkpoints:
       value: open
-      detail: pretraining pipeline deep-spin/Megatron-LM-pretrain + evaluation codebase deep-spin/eurollm-eval
+      detail: intermediate Megatron-Core checkpoints per pretraining phase, eurollm-22b/9b/1.7b-mcore-phase1/2/3
     license:
     - name: Apache-2.0
       detail: OSI
   confidence: high
-  note: 'EuroLLM-22B is a full open-source release on the OLMo/Pythia/Apertus tier: the pretraining
-    corpus, the code that consumed it, and an OSI license over the weights. The technical report (arXiv:2602.05879)
-    states outright, "we release our base and instruction-tuned models, our multilingual web pretraining
-    data and updated EuroBlocks instruction datasets, as well as our pre-training and evaluation codebases".
-    Each was confirmed: the 22B-2512 weights are Apache-2.0 BF16 safetensors and ungated on Hugging Face;
-    the multilingual web pretraining data ships as the public utter-project/EuroWeb-2512 dataset (with a
-    matching EuroLLM-Multilingual-Data-2512) and the instruction data as EuroBlocks-SFT-2512; and the
-    pretraining pipeline is the public deep-spin/Megatron-LM-pretrain repository (a Megatron-LM fork,
-    the same shape as Apertus''s Megatron-LM recipe) alongside the public deep-spin/eurollm-eval harness.
-    With data open, code open and the license OSI, the recipe lands the family at 5. The corpus mixture''s
-    later high-quality and parallel components are documented in the report rather than fully released,
-    but the released web pretraining data plus the training pipeline satisfy data:open by a released
-    dataset rather than by reconstruction scripts.'
+  note: 'Open weights under an OSI license, but not a full open-source release, so the ladder lands at 3
+    rather than 5. The weights ship as ungated Apache-2.0 BF16 safetensors and the family publishes intermediate
+    Megatron-Core checkpoints for every pretraining phase (eurollm-22b/9b/1.7b-mcore-phase1/2/3), which is
+    the checkpoints:open leg both OLMo and Apertus record. But the two legs that would lift the score above
+    the category''s open-weights centre both fall short. Data: only the EuroWeb-2512 multilingual web subset
+    is released; the technical report itemizes parallel, code, math, 1.7M synthetic-math, Wikipedia, ArXiv,
+    Books, Apollo and Cosmopedia sources plus ~60B long-context tokens that are described but not shipped,
+    so the corpus as a whole is documented-not-released rather than open (the peers at the 4/5 rungs released
+    the whole corpus or full reconstruction scripts). Code: the only EuroLLM-specific code published is the
+    deep-spin/eurollm-eval evaluation harness, which the rubric classes as closed on its own; the report also
+    cites deep-spin/Megatron-LM-pretrain as the pre-training codebase, but that repository is a generic fork
+    of NVIDIA/Megatron-LM whose last commit predates the 2512 release by a year (2025-01-06) and carries no
+    EuroLLM training configs, so no pretraining recipe actually ships. Weights open, data documented, code
+    partial and an OSI license fall through the recipe to 3, open_weights. Apache-2.0 covers the weights only:
+    the released datasets carry no license tag, eurollm-eval has no LICENSE file, and the Megatron fork is
+    NVIDIA-licensed.'
   last_verified: '2026-09-04'
-  raw: weights:open(Apache-2.0, BF16 safetensors, ungated);data:open(multilingual web pretraining data
-    released as EuroWeb-2512 + EuroBlocks-SFT instruction data);code:open(pretraining pipeline deep-spin/Megatron-LM-pretrain
-    + evaluation codebase deep-spin/eurollm-eval);license:Apache-2.0(OSI)
+  raw: weights:open(Apache-2.0, BF16 safetensors, ungated);data:documented-not-released(EuroWeb-2512 web
+    subset released, remaining parallel/curated/synthetic and long-context components documented in the report
+    but withheld);code:partial(deep-spin/eurollm-eval harness published, deep-spin/Megatron-LM-pretrain a generic
+    year-stale Megatron-LM fork with no EuroLLM configs);checkpoints:open(intermediate Megatron-Core checkpoints
+    per pretraining phase, eurollm-22b/9b/1.7b-mcore-phase1/2/3);license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/api/models/utter-project/EuroLLM-22B-2512
     shows: '`private: false`, `gated: false`, `license: apache-2.0`, `safetensors.total` 22,637,328,384
-      BF16 parameters, LlamaForCausalLM, 35 language tags including all 24 official EU languages. Establishes
-      that the weights are downloadable, ungated and OSI-licensed.'
+      BF16 parameters, LlamaForCausalLM. Establishes that the weights are downloadable, ungated and OSI-licensed.'
     accessed: '2026-09-04'
     http_status: 200
     content_sha256: 5194a2f48a03b38b4e11ab77c6859007a4e8399de8408d9fefa200d14df958b8
     establishes: [weights, license]
   - url: https://huggingface.co/utter-project/EuroLLM-22B-2512
     shows: 'Model card "Model Card for EuroLLM-22B": "License: Apache License 2.0"; 22B parameter multilingual
-      transformer trained from scratch on ~4T tokens on the MareNostrum5 supercomputer; describes the three
-      pretraining phases (initial 3.6T, annealing 400B, annealing-to-zero 100B) and the data sources (web,
-      parallel, Wikipedia, Arxiv, books, math, code, Apollo).'
+      transformer trained from scratch on ~4T tokens; describes the three pretraining phases (initial 3.6T,
+      annealing 400B, annealing-to-zero 100B) and the data sources (web, parallel, Wikipedia, Arxiv, books,
+      math, code, Apollo) without releasing the non-web components.'
     accessed: '2026-09-04'
     http_status: 200
     content_sha256: d1a3dc2ce9cf358b536898d6e11b193e3b0da7a86bbcd29992d8fc9f232d8c17
-    establishes: [weights, license]
-  - url: https://arxiv.org/abs/2602.05879
-    shows: 'EuroLLM-22B Technical Report abstract: "To support future research, we release our base and
-      instruction-tuned models, our multilingual web pretraining data and updated EuroBlocks instruction
-      datasets, as well as our pre-training and evaluation codebases." Establishes the data and code release
-      as a first-party claim by the model''s authors.'
-    accessed: '2026-09-04'
-    http_status: 200
-    content_sha256: 6be57584f9eec5c9a0e861595d0c2684d5122f5256b6db33458277729048d9d8
-    establishes: [data, code]
+    establishes: [weights, license, data]
   - url: https://arxiv.org/pdf/2602.05879
-    shows: 'Technical report body links the released pretraining codebase github.com/deep-spin/Megatron-LM-pretrain
-      and evaluation codebase github.com/deep-spin/eurollm-eval, and the released data
-      huggingface.co/datasets/utter-project/EuroLLM-Multilingual-Data-2512 and EuroBlocks-SFT-2512.
-      deep-spin/Megatron-LM-pretrain was independently confirmed to be a public Megatron-LM fork (pretrain_gpt.py,
-      megatron/), and deep-spin/eurollm-eval a public repository.'
+    shows: 'Technical report lists the pretraining corpus components (web, parallel, code, math, synthetic
+      math, Wikipedia, ArXiv, Books, Apollo, Cosmopedia, ~60B long-context) and cites github.com/deep-spin/Megatron-LM-pretrain
+      (pre-training) and github.com/deep-spin/eurollm-eval (evaluation) as codebases. Only the web subset
+      (EuroWeb-2512) and the eval harness are actually released; the pretraining repo is a generic Megatron-LM
+      fork (independently verified: last commit 2025-01-06, no EuroLLM configs).'
     accessed: '2026-09-04'
     http_status: 200
     content_sha256: 904a51563c7103be383bc60761a34820b6256ca016725505f10b399cf7f5c289
     establishes: [data, code]
   - url: https://huggingface.co/api/datasets/utter-project/EuroWeb-2512
-    shows: '`private: false`, `gated: false`, size category 1B<n<10B; the released multilingual web pretraining
-      dataset for the EuroLLM-22B (2512) release, with ~16K downloads in the trailing 30 days. Establishes
-      data:open by a released dataset.'
+    shows: '`private: false`, `gated: false`, size category 1B<n<10B, no license tag; the released multilingual
+      web pretraining subset for the 2512 release. Establishes that a documented subset of the corpus is
+      released while the remainder is not.'
     accessed: '2026-09-04'
     http_status: 200
     content_sha256: 285566722fe13e247b7af2d6519b0467b81ba234e0f9af65e92c6174a93fa606
     establishes: [data]
+  - url: https://huggingface.co/api/models/utter-project/eurollm-22b-mcore-phase1
+    shows: '`private: false`, `gated: false`; a public Megatron-Core intermediate checkpoint for the 22B
+      model''s first pretraining phase, one of the eurollm-22b/9b/1.7b-mcore-phase1/2/3 series. Establishes
+      checkpoints:open.'
+    accessed: '2026-09-04'
+    http_status: 200
+    content_sha256: c0051aa8d2d87196007bfc63173047cd10d92494b306a2148304b9c14a40a205
+    establishes: [checkpoints]
 adoption:
   level: 3
   reach: 100K-1M
   signal_type: usage_volume
   confidence: medium
-  note: '127,672 downloads in the trailing 30 days summed across the family''s shipped SKUs on the
+  note: '127,672 downloads in the trailing 30 days summed across the ten declared family SKUs on the
     utter-project Hugging Face org: EuroLLM-22B-Instruct-2512 31,111; 9B-Instruct-2512 28,779; 1.7B-Instruct
     27,659; 9B-Instruct 18,632; 1.7B 11,974; 9B-2512 2,866; 9B 2,832; 22B-2512 2,603; 22B-Instruct-Preview
-    1,111; 22B-Preview 105. Bands at level 3 (100K-1M) on the model adoption scale; confidence medium
-    because the total sits not far above the 100K floor and download figures move month to month. The
-    instruction-tuned 9B/1.7B SKUs carry the bulk of the traffic while the new 22B flagship is still ramping.'
+    1,111; 22B-Preview 105. Bands at level 3 (100K-1M) on the model adoption scale; confidence medium because
+    the total sits not far above the 100K floor and download figures move month to month. The product declares
+    exactly these ten SKUs so the warehouse sums the same set.'
   last_verified: '2026-09-04'
   sources:
   - url: https://huggingface.co/api/models?author=utter-project&full=false&limit=100
     shows: 'Trailing-30-day `downloads` per EuroLLM SKU on the utter-project org, summing to 127,672 across
-      the ten shipped base and instruct variants (22B/9B/1.7B).'
+      the ten declared base and instruct variants (22B/9B/1.7B, current and preview).'
     accessed: '2026-09-04'
     http_status: 200
     content_sha256: 5792ec1a12a4544956ef53aa5a7024c2f90766b603b8def5046d2ea2dd5ee2ad
@@ -104,26 +112,27 @@ capability:
   relative_to: apertus
   relation: at
   value: EuroLLM-22B-Instruct MMLU 69.8, MMLU-Pro 50.8, ARC-C 89.8, GSM8K 85.5 (English, Table 3); the
-    strongest fully-open European model, beating Apertus-70B on MMLU (67.9) with roughly one third of the
-    parameters, but trailing the frontier open-weights (Qwen-3-32B 84.0, Gemma-3-27B 80.4, Llama-3.3-70B
-    84.6) by ~10-15 pts on MMLU.
+    strongest fully-open European model, ahead of Apertus on eight of ten English benchmarks (e.g. MMLU 69.8
+    vs Apertus-70B 67.9) at roughly one third of Apertus-70B's parameters, but trailing the frontier
+    open-weights (Qwen-3-32B 84.0, Gemma-3-27B 80.4, Llama-3.3-70B 84.6) by ~10-15 pts on MMLU.
   confidence: high
-  note: 'Mid-tier capability, the same profile and band as Apertus: competitive with the prior open
-    generation and unusually strong multilingually across the 35 supported languages, but below the 2026
-    frontier on reasoning and knowledge. The value proposition is full openness and European-language
+  note: 'Mid-tier capability, the same band as Apertus though edging ahead of it on benchmarks: competitive
+    with the prior open generation and unusually strong multilingually across the 35 supported languages, but
+    below the 2026 frontier on reasoning and knowledge. The value proposition is openness and European-language
     breadth rather than raw SOTA. The EuroLLM-22B technical report''s Table 3 measures EuroLLM-22B and the
-    Apertus baselines on the same instruction-tuned English suite, and states EuroLLM-22B "is the strongest
-    model among the fully open European systems considered" while "the EuroLLM family still trails the very
-    best open-weights models overall". Placed level with Apertus, both at 3.'
+    Apertus baselines on the same instruction-tuned English suite, where EuroLLM-22B leads on eight of ten
+    benchmarks and the paper names it "the strongest model among the fully open European systems considered"
+    while "the EuroLLM family still trails the very best open-weights models overall". Kept at 3 rather than
+    lifted to 4: beating Apertus by single-digit margins on most benchmarks places it at the top of the same
+    band, not in a higher capability tier, since it still trails the frontier open-weights.'
   last_verified: '2026-09-04'
   comparison:
     last_attested: '2026-09-04'
     sources:
     - url: https://arxiv.org/pdf/2602.05879
       shows: 'Table 3 (English benchmarks) reports EuroLLM-22B and Apertus-8B/Apertus-70B on one suite:
-        EuroLLM-22B MMLU 69.8 vs Apertus-70B 67.9, MMLU-Pro 50.8 vs 41.9, ARC-C 89.8 vs 84.7; the paper
-        names EuroLLM-22B the strongest fully-open European system and competitive with Apertus-70B at
-        ~1/3 the parameters. Apertus''s own placement (score 3) is reaffirmed rather than moved.'
+        EuroLLM-22B MMLU 69.8 vs Apertus-70B 67.9, MMLU-Pro 50.8 vs 41.9, ARC-C 89.8 vs 84.7; EuroLLM-22B
+        leads on eight of ten benchmarks. Apertus''s own placement (score 3) is reaffirmed rather than moved.'
       accessed: '2026-09-04'
       http_status: 200
       content_sha256: 904a51563c7103be383bc60761a34820b6256ca016725505f10b399cf7f5c289

--- a/sources/scores/eurollm.yaml
+++ b/sources/scores/eurollm.yaml
@@ -11,9 +11,9 @@ openness:
       detail: EuroWeb-2512 web subset released, remaining parallel/curated/synthetic and long-context components
         documented in the report but withheld
     code:
-      value: partial
-      detail: deep-spin/eurollm-eval harness published, deep-spin/Megatron-LM-pretrain a generic year-stale
-        Megatron-LM fork with no EuroLLM configs
+      value: closed
+      detail: only deep-spin/eurollm-eval evaluation harness is EuroLLM-specific, deep-spin/Megatron-LM-pretrain
+        a generic year-stale Megatron-LM fork with no EuroLLM configs
     checkpoints:
       value: open
       detail: intermediate Megatron-Core checkpoints per pretraining phase, eurollm-22b/9b/1.7b-mcore-phase1/2/3
@@ -30,18 +30,18 @@ openness:
     Books, Apollo and Cosmopedia sources plus ~60B long-context tokens that are described but not shipped,
     so the corpus as a whole is documented-not-released rather than open (the peers at the 4/5 rungs released
     the whole corpus or full reconstruction scripts). Code: the only EuroLLM-specific code published is the
-    deep-spin/eurollm-eval evaluation harness, which the rubric classes as closed on its own; the report also
-    cites deep-spin/Megatron-LM-pretrain as the pre-training codebase, but that repository is a generic fork
-    of NVIDIA/Megatron-LM whose last commit predates the 2512 release by about a year and carries no EuroLLM
-    training configs, so no pretraining recipe actually ships. Weights open, data documented, code
-    partial and an OSI license fall through the recipe to 3, open_weights. Apache-2.0 covers the weights only:
+    deep-spin/eurollm-eval evaluation harness, and the rubric classes an evaluation harness alone as closed; the
+    report also cites deep-spin/Megatron-LM-pretrain as the pre-training codebase, but that repository is a generic
+    fork of NVIDIA/Megatron-LM whose last commit predates the 2512 release by about a year and carries no EuroLLM
+    training configs, so it contributes nothing to this dimension and no pretraining recipe actually ships. Weights
+    open, data documented, code closed and an OSI license fall through the recipe to 3, open_weights. Apache-2.0 covers the weights only:
     the released datasets carry no license tag, eurollm-eval has no LICENSE file, and the Megatron fork is
     NVIDIA-licensed.'
   last_verified: '2026-09-04'
   raw: weights:open(Apache-2.0, BF16 safetensors, ungated);data:documented-not-released(EuroWeb-2512 web
     subset released, remaining parallel/curated/synthetic and long-context components documented in the report
-    but withheld);code:partial(deep-spin/eurollm-eval harness published, deep-spin/Megatron-LM-pretrain a generic
-    year-stale Megatron-LM fork with no EuroLLM configs);checkpoints:open(intermediate Megatron-Core checkpoints
+    but withheld);code:closed(only deep-spin/eurollm-eval evaluation harness is EuroLLM-specific, deep-spin/Megatron-LM-pretrain
+    a generic year-stale Megatron-LM fork with no EuroLLM configs);checkpoints:open(intermediate Megatron-Core checkpoints
     per pretraining phase, eurollm-22b/9b/1.7b-mcore-phase1/2/3);license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/api/models/utter-project/EuroLLM-22B-2512

--- a/sources/scores/eurollm.yaml
+++ b/sources/scores/eurollm.yaml
@@ -30,9 +30,9 @@ openness:
     but the released web pretraining data plus the training pipeline satisfy data:open by a released
     dataset rather than by reconstruction scripts.'
   last_verified: '2026-09-04'
-  raw: weights:open(Apache-2.0, BF16 safetensors, ungated);data:open(EuroWeb-2512 multilingual web pretraining
-    data + EuroBlocks-SFT instruction data);code:open(deep-spin/Megatron-LM-pretrain pretraining pipeline
-    + deep-spin/eurollm-eval);license:Apache-2.0(OSI)
+  raw: weights:open(Apache-2.0, BF16 safetensors, ungated);data:open(multilingual web pretraining data
+    released as EuroWeb-2512 + EuroBlocks-SFT instruction data);code:open(pretraining pipeline deep-spin/Megatron-LM-pretrain
+    + evaluation codebase deep-spin/eurollm-eval);license:Apache-2.0(OSI)
   sources:
   - url: https://huggingface.co/api/models/utter-project/EuroLLM-22B-2512
     shows: '`private: false`, `gated: false`, `license: apache-2.0`, `safetensors.total` 22,637,328,384


### PR DESCRIPTION
## What

Adds the EuroLLM multilingual model family to the `base_pretrained` category, resolving #265.

EuroLLM-22B (technical report arXiv:2602.05879) is a European, Apache-2.0 **open-weights** family (22B/9B/1.7B, 35 languages including all 24 official EU ones, trained from scratch on ~4T tokens on MareNostrum5). After two rounds of maintainer review the openness landed at **3 (`open_weights`)**:

- **weights** open (Apache-2.0 BF16 safetensors, ungated); **checkpoints** open (per-phase Megatron-Core checkpoints).
- **data** `documented-not-released` — only the `EuroWeb-2512` web subset ships; the parallel/curated/synthetic and long-context components are documented in the report but withheld.
- **code** `closed` — the only EuroLLM-specific code is the `deep-spin/eurollm-eval` evaluation harness, which the rubric classes as `closed`; the cited `deep-spin/Megatron-LM-pretrain` is a generic, year-stale Megatron-LM fork with no EuroLLM configs, so it contributes nothing to this dimension.
- Apache-2.0 covers the weights only (datasets untagged, eval repo has no LICENSE, the fork is NVIDIA-licensed).

Adoption **3** (127,672 HF downloads/30d summed across the ten declared family SKUs); capability **3**, at the top of Apertus's band (strongest fully-open European model, ahead of Apertus on 8/10 English benchmarks but below the frontier open-weights). Adds a new `eurollm` organization record with its owned identity handles only — `utter-project` (HF) and `eurollm.io` (homepage); no GitHub handle, since `deep-spin` is the lab's account, not EuroLLM's.

## Checklist

- [x] `uv run python -m build.validate` prints `0 error(s)`
- [x] New/changed scores cite sources (`url`, `shows`, `accessed`)
- [x] I did not edit `build/notebook_data.json` or `notebooks/ai-stack-map.py` (a bot regenerates them on merge)
- [x] Product appears in exactly one category roster and one org roster
- [x] Label: none (hand work)

Also passes `check_recipe` (base_pretrained 32/32 reproduce), `check_rubric`, `check_components`, `check_verification`, `check_capability`, `check_adoption`, and the identity coverage ratchet.