### PR TITLE
Give the Neon serving layer stable hashed ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,15 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
 
 ### Changed
 
+- Every surrogate `id` in the Neon serving layer is now derived from the row's natural key —
+  the first 63 bits of `sha256("<table>:<key>")` — instead of from its position in a sorted
+  list. Adding one product used to renumber every row after it, so an id that had reached a
+  URL, a cache or a CMS reference pointed at a different product after the next publish. The
+  id and foreign-key columns widen from `integer` to `bigint` to hold the hash, the publish
+  fails naming both keys if two ever collide, and the ordinal the old ids carried moves into
+  `layers.sort_order`, `categories.sort_order`, `long_tail_top.sort_order` and `stages.num`.
+  `schema_version` is 3. The slug stays the canonical identity for links and for anything
+  another system stores (#365).
 - Reclassified `org` recall in the identity eval from a coverage floor to a regression invariant at
   ≥ 0.99, graded on live runs only. Recoverability is decided by the same handle route the graph
   emits on, so recall answers "does the resolver use the evidence we gave it" and never "have we
@@ -195,6 +204,11 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
 
 ### Removed
 
+- The `registry_*` tables from the Neon load. They were there so Neon and the warehouse would
+  carry the same declarations, but nothing on the site read them and the designers never asked
+  for them; the registry surface stays in the warehouse as `currentai.registry.*` and on disk
+  as `build/registry/*.csv`. Neon now holds the 15 site tables from the target model plus
+  `publish_runs` — 41 tables down to 15 (#365).
 - The `maturity` gap type (#87, #318).
 
 ### Fixed

--- a/build/neon_schema.py
+++ b/build/neon_schema.py
@@ -32,8 +32,9 @@ so a mistaken join across them finds nothing rather than appearing to work.
 
 The natural key per table: `products.slug`, `categories.slug`, `layers` and `gaps` by their
 label, `stages` by their stage number, `long_tail_top` by its name, `product_lineage` by
-`(product_slug, relation, target)`, `sources` by `(product_slug, metric, url)`. Organizations
-key on `slug` and aliases on `alias` directly, with no surrogate at all.
+`(product_slug, relation, target)`, `sources` by
+`(product_slug, metric, url, shows, accessed)`. Organizations key on `slug` and aliases on
+`alias` directly, with no surrogate at all.
 
 The ids are 63-bit, so the columns are `BIGINT` where the designers' model says `integer`.
 Postgres has no unsigned integer type, which is why 63 bits and not 64: the top bit would
@@ -43,20 +44,34 @@ make half the ids negative.
 but a link, a bookmark, a CMS row or anything a person reads should carry the slug. The id
 is a join key, and it changes if the natural key it is derived from ever changes.
 
-One source list can carry the same URL twice on the same axis (69 such pairs today), so a
-repeat gets `#2`, `#3` appended to its key before hashing. That keeps every row addressable,
-at the cost that removing one of a duplicated pair moves the other's id. The real remedy is
-not to record the same source twice.
+A source's key carries `shows` and `accessed` because the URL alone does not identify the
+row: one source list can hold the same URL twice on the same axis (69 pairs today), and each
+of those pairs is a re-verification recording a different claim or a different date. They are
+two observations, and the key is what tells them apart. `_disambiguate` remains as a last
+resort for a future corpus and fires on nothing today, which a test asserts against the real
+payload — if it ever did fire it would number by position, and a deleted row would hand its id
+to its surviving twin.
 
 ## The ordinal the id used to carry now has its own column
 
-`layers.id`, `categories.id`, `stages.id` and `long_tail_top.id` were positions, and three
-of those positions were load-bearing: the layer stack order, the map's curated category
-order, the stage number a category's `stage` FK pointed at, and the long tail's ranking. A
-hashed id carries none of that, so it moved into `layers.sort_order`,
-`categories.sort_order`, `long_tail_top.sort_order` and `stages.num` — a departure from the
-designers' model, added because dropping the information would have been the worse one.
-`ORDER BY sort_order` is what the old `ORDER BY id` meant.
+`layers.id`, `categories.id`, `stages.id` and `long_tail_top.id` were positions, and each of
+those positions carried something: the layer stack order, the map's curated category order,
+the long tail's ranking, and — most sharply — the stage number, because `categories.stage`
+was literally the number and `stages.id` was literally the number it pointed at. A hashed id
+carries none of that.
+
+The designers' model has nowhere else to put it. `layers` is `{id, label}`, `stages` is
+`{id, label, desc}`, `long_tail_top` has no ordering field, and `stages` has no number, so
+`label` is a display name and the `descriptions.stages` legend keys on a number the table
+would no longer hold. Drop the information and a consumer cannot render the stack bottom-up,
+cannot reproduce the curated order, cannot rank the tail, and cannot say which stage "Stage 3"
+is. So it moved into `layers.sort_order`, `categories.sort_order`, `long_tail_top.sort_order`
+and `stages.num`. `ORDER BY sort_order` is what the old `ORDER BY id` meant.
+
+Four columns the designers' model does not declare, and nothing reads Neon today — the front
+end still consumes `notebook_data.json`. This is preservation for the consumer that comes
+next, because a publish that drops the information destroys it, and the cost of carrying it is
+four integers per row.
 
 ## The constraints are real, and a violation fails the run
 
@@ -141,6 +156,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -174,8 +190,9 @@ class IdCollision(RuntimeError):
 
 # --- stable ids -----------------------------------------------------------------------
 
-# The composite natural keys (`sources`, `product_lineage`) join their parts with this. Not a
-# character any slug, relation or metric name contains, so the join is unambiguous.
+# The composite natural keys (`sources`, `product_lineage`) join their parts with this. The
+# join is unambiguous because each key puts its controlled values first and leaves at most one
+# unbounded component last, not because the separator is unusual — see `_source_key`.
 KEY_SEPARATOR = "|"
 
 
@@ -226,12 +243,18 @@ def _id_map(table: str, keys: Iterable[str]) -> dict[str, int]:
 
 
 def _disambiguate(keys: Iterable[str]) -> list[str]:
-    """Append `#2`, `#3` to a key that repeats, so every row has one key of its own.
+    """Append `#2`, `#3` to a key that repeats. A last resort that should never fire.
 
-    Only `sources` needs this: a product's source list can carry the same URL twice on the
-    same axis. The consequence is that removing one of a duplicated pair moves the other's
-    id, which is a reason to dedupe the source list rather than a reason to number rows by
-    position again.
+    It numbers by walk position, so if it ever does fire it carries the bug the natural keys
+    exist to avoid: delete the earlier of a repeated pair and the later one is promoted into
+    the un-suffixed key, **inheriting the deleted row's id**. A stored reference then resolves
+    to a different row with no gate firing, which is worse than the positional scheme this
+    module replaced, because that one renumbered visibly and en masse.
+
+    So the keys handed to it must already be unique. `sources` is the only caller and its key
+    includes `shows` and `accessed`, under which no two rows in the corpus collide —
+    `tests/test_publish_neon.py` asserts that on the real payload. This stays as a guard
+    against a future corpus, not as a working part of the scheme.
     """
     seen: dict[str, int] = {}
     out = []
@@ -241,28 +264,51 @@ def _disambiguate(keys: Iterable[str]) -> list[str]:
     return out
 
 
+_PRIMARY_KEY = re.compile(r'PRIMARY KEY \(([^)]*)\)')
+
+
+def primary_key(table: str) -> tuple[str, ...]:
+    """The columns in a table's declared PRIMARY KEY, or `()` where it declares none.
+
+    Read from the constraint the DDL actually emits rather than restated, so a key that moves
+    moves this too. `gaps_categories` and `long_tail_counts` have no key in the DBML and none
+    to invent, so they come back empty.
+    """
+    for clause in SITE_TABLES[table].constraints:
+        match = _PRIMARY_KEY.match(clause)
+        if match:
+            return tuple(part.strip().strip('"') for part in match.group(1).split(","))
+    return ()
+
+
 def check_ids_unique(tables: dict[str, list[dict]]) -> None:
-    """Fail the publish if any table's `id` column repeats. The last gate before COPY.
+    """Fail the publish if any table repeats its primary key. The last gate before COPY.
+
+    Keyed off each table's declared PRIMARY KEY rather than off a column literally named
+    `id`, so it also covers the four whose key is `product_id`, `slug` or `alias`. The two
+    tables the DBML gives no key are the two it skips, and nothing else is exempt.
 
     `_id_map` catches a collision where both natural keys are in hand, which is the case that
-    can name them. This is the backstop for every other way a duplicate id could reach a
-    table — a builder that stopped going through `_id_map`, a key computed twice from
-    different fields — and it runs over the rows that are actually about to be written.
+    can name them. This is the backstop for every other way a duplicate could reach a table —
+    a builder that stopped going through `_id_map`, a key computed twice from different
+    fields — and it runs over the rows that are actually about to be written.
     """
     for name, rows in tables.items():
-        seen: dict[int, dict] = {}
+        key_columns = primary_key(name)
+        if not key_columns:
+            continue
+        seen: dict[tuple, dict] = {}
         for row in rows:
-            ident = row.get("id")
-            if ident is None:
-                break  # this table has no id column at all
-            first = seen.get(ident)
+            key = tuple(row.get(column) for column in key_columns)
+            first = seen.get(key)
             if first is not None:
+                shown = key[0] if len(key) == 1 else key
                 raise IdCollision(
-                    f"{name}: id {ident} is used by two rows, {first!r} and {row!r}. "
-                    f"The table's primary key would reject one of them at COPY time; "
-                    f"this publish has stopped instead."
+                    f"{name}: primary key {shown!r} is used by two rows, {first!r} and "
+                    f"{row!r}. Postgres would reject one of them at COPY time; this publish "
+                    f"has stopped instead."
                 )
-            seen[ident] = row
+            seen[key] = row
 
 
 # --- enums ----------------------------------------------------------------------------
@@ -587,12 +633,51 @@ def _capability(payload: dict) -> list[dict]:
     return out
 
 
+def _source_key(slug: str, metric: str, source: dict) -> str:
+    """`(product_slug, metric, url, shows, accessed)` — the natural key of one source row.
+
+    The URL alone does not identify the row. A product's source list can carry the same URL
+    twice on the same axis (69 pairs today), and every one of those pairs is a
+    re-verification: the same page read on a different date, or recorded as showing something
+    different. They are two observations, not one row duplicated, so the key has to carry what
+    tells them apart.
+
+    Keying on the URL alone and numbering the repeats would mean that deleting the earlier of
+    a pair promoted the later one into the un-suffixed key and handed it the deleted row's id.
+    Anything holding the old id would then resolve to a row with a different claim and a
+    different date, with no gate firing — the exact failure the hashed ids exist to prevent.
+
+    Two consequences, both intended. Editing a source's `shows` or `accessed` moves that row's
+    id, because it is a different observation of the same URL and the module's rule is that an
+    id moves when its natural key does. And the key is order-independent: reordering a source
+    list, or deleting a sibling, leaves every other row's id alone.
+
+    The parts are joined slug, metric, accessed, url, shows: the three controlled values
+    first, then the free text, with the only genuinely unbounded one (`shows`, which holds
+    prose) last. That ordering is what makes the joined string unambiguous, rather than any
+    property of the separator — a `|` inside `shows` cannot shift a boundary, because there is
+    nothing after it.
+    """
+    return KEY_SEPARATOR.join(
+        (
+            slug,
+            metric,
+            source.get("accessed") or "",
+            source.get("url") or "",
+            source.get("shows") or "",
+        )
+    )
+
+
 def _sources(payload: dict) -> list[dict]:
     """Every source on every axis, one row each, in the deterministic walk order.
 
     The target model has a `notes` column the payload has no field for; the payload's
     `establishes`, `content_sha256` and `http_status` have no column. `shows` is the one that
     maps, and `notes` stays NULL rather than being filled with an adjacent field.
+
+    The grain is one *observation*, which is why the key carries `shows` and `accessed`: see
+    `_source_key`.
     """
     ids = product_ids(payload)
     walked: list[tuple[str, str, dict]] = []
@@ -601,10 +686,7 @@ def _sources(payload: dict) -> list[dict]:
             for source in _axis(product, metric).get("sources") or []:
                 if isinstance(source, dict):
                     walked.append((slug, metric, source))
-    keys = _disambiguate(
-        KEY_SEPARATOR.join((slug, metric, source.get("url") or ""))
-        for slug, metric, source in walked
-    )
+    keys = _disambiguate(_source_key(slug, metric, source) for slug, metric, source in walked)
     source_ids = _id_map("sources", keys)
 
     out = []
@@ -674,9 +756,8 @@ def _categories(payload: dict) -> list[dict]:
         out.append(
             {
                 "id": ident,
-                # Not in the PDF. Added because every deep link and every join from the
-                # registry group is by slug, and an id assigned by curated order changes
-                # whenever the order does.
+                # Not in the PDF. Added because every deep link is by slug, and the id it
+                # sits beside is a hash rather than something a person can read or guess.
                 "slug": cid,
                 "sort_order": order[cid],
                 "label": category.get("label") or "",

--- a/build/neon_schema.py
+++ b/build/neon_schema.py
@@ -4,28 +4,59 @@
 knows nothing about the gap map. This module is the map half: which tables exist, which
 enums, what every column is, and where each row comes from.
 
-Group B is the designers' target model, transcribed in
+`SITE_TABLES` is the designers' target model, transcribed in
 `Current-AI-Initial-Schema.pdf` (Laith, CLEVER FRANKE) with Carl's amendments. This load
-exists to deprecate `build/notebook_data.json` as the site's transport, so every group-B row
-is derived from that payload's semantics — the same content the front end reads today, at a
+exists to deprecate `build/notebook_data.json` as the site's transport, so every row here is
+derived from that payload's semantics — the same content the front end reads today, at a
 grain a query can use. Rows come from the file rather than from a fresh `build_payload`
 because it is the repo's build artifact and its gate contract: what Postgres serves is
 byte-for-byte what the repo published, not a second derivation that could disagree with it.
 
-Group A is the registry surface: exactly `build.publish_registry.TABLES`, the four
-serializers' declared sets, read from that module rather than from a glob over
-`build/registry/`, so Neon and the OSO warehouse carry the same tables by construction.
-Group A names are prefixed `registry_` in Postgres, because both groups share one schema and
-both have a `products`, a `categories` and an `organizations`.
+That is the whole surface. The registry tables the serializers write to `build/registry/*.csv`
+were loaded here too for a while, prefixed `registry_`, so Neon and the warehouse would carry
+the same declarations. Nothing on the site ever read them and the designers never asked for
+them, so they are gone: the registry surface lives in the warehouse as `currentai.registry.*`
+and in `build/registry/*.csv`, and Neon serves the site's tables and nothing else.
 
-## Keys are natural where the payload has one
+## Keys are natural where the payload has one, and every surrogate id is derived from one
 
-`products.id` exists for the FK shape the designers specified, but it is assigned by sorted
-slug order on every load, so the same corpus produces the same ids and a diff of two loads
-is readable. The real key is `slug`, which is what a deep link carries. Organizations key on
-`slug`, aliases on `alias`, categories carry a `slug` alongside their id (the PDF omitted it
-and the site needs it). Ids for `sources` and `product_lineage` are positional over a
-deterministic walk, for the same reason.
+`products.id` exists for the FK shape the designers specified. It is not a position: it is
+`stable_id("products", slug)`, the first 63 bits of a SHA-256 over the table name and the
+row's natural key. Ids used to be assigned by sorted slug order, which meant adding one
+product renumbered every row after it — so any id that had escaped into a URL, a cache or a
+CMS reference pointed at a different product after the next publish. Deriving the id from
+the key instead makes it stable across loads and independent of what else is in the corpus.
+
+Hashing the table name in as well means the same slug in two tables gets two different ids,
+so a mistaken join across them finds nothing rather than appearing to work.
+
+The natural key per table: `products.slug`, `categories.slug`, `layers` and `gaps` by their
+label, `stages` by their stage number, `long_tail_top` by its name, `product_lineage` by
+`(product_slug, relation, target)`, `sources` by `(product_slug, metric, url)`. Organizations
+key on `slug` and aliases on `alias` directly, with no surrogate at all.
+
+The ids are 63-bit, so the columns are `BIGINT` where the designers' model says `integer`.
+Postgres has no unsigned integer type, which is why 63 bits and not 64: the top bit would
+make half the ids negative.
+
+**The slug is still the identity.** A stable id is safe to store as an internal reference,
+but a link, a bookmark, a CMS row or anything a person reads should carry the slug. The id
+is a join key, and it changes if the natural key it is derived from ever changes.
+
+One source list can carry the same URL twice on the same axis (69 such pairs today), so a
+repeat gets `#2`, `#3` appended to its key before hashing. That keeps every row addressable,
+at the cost that removing one of a duplicated pair moves the other's id. The real remedy is
+not to record the same source twice.
+
+## The ordinal the id used to carry now has its own column
+
+`layers.id`, `categories.id`, `stages.id` and `long_tail_top.id` were positions, and three
+of those positions were load-bearing: the layer stack order, the map's curated category
+order, the stage number a category's `stage` FK pointed at, and the long tail's ranking. A
+hashed id carries none of that, so it moved into `layers.sort_order`,
+`categories.sort_order`, `long_tail_top.sort_order` and `stages.num` — a departure from the
+designers' model, added because dropping the information would have been the worse one.
+`ORDER BY sort_order` is what the old `ORDER BY id` meant.
 
 ## The constraints are real, and a violation fails the run
 
@@ -82,7 +113,7 @@ There is no migration tool and no need for one yet. Every publish rebuilds the s
 this module and swaps it into place atomically, so a shape change here becomes live on the
 next load with no ALTER anywhere. What that costs is a reader's ability to tell which shape
 it is looking at, so `publish_runs.schema_version` carries `SCHEMA_VERSION` — bump it in the
-same commit as any change to a group-B table, column, or enum. Once something outside this
+same commit as any change to a table, column, constraint or enum here. Once something outside this
 repo depends on the shape, this is the point where a real migration path replaces the swap.
 
 ## What the CMS owns, and why it cannot live here
@@ -108,30 +139,130 @@ failure. Read the map's tables directly, or materialize a copy on the CMS side.
 
 from __future__ import annotations
 
+import hashlib
 import json
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
-from build.publish_registry import TABLES as REGISTRY_TABLES
 from build.vocabulary import axes
 
 ROOT = Path(__file__).resolve().parents[1]
 PAYLOAD_PATH = ROOT / "build" / "notebook_data.json"
 
-# Bump on any change to a group-B table, column, constraint or enum. Recorded on every
+# Bump on any change to a table, column, constraint or enum here. Recorded on every
 # publish_runs row.
 #   1: the initial load.
 #   2: the gallery tables and their three enums removed (CMS-owned); the DBML's primary keys,
 #      NOT NULLs, uniques and foreign keys emitted for the first time.
-SCHEMA_VERSION = 2
-
-# Group A's tables keep their serializer names, prefixed, because both groups share a schema.
-REGISTRY_PREFIX = "registry_"
-
+#   3: the `registry_*` tables dropped from the load — nothing on the site read them and the
+#      registry surface lives in the warehouse. Every surrogate id derived from the row's
+#      natural key by `stable_id` instead of from its position, so ids no longer renumber
+#      when the corpus grows; id and foreign-key columns widened from INTEGER to BIGINT to
+#      hold them; the ordinal those ids used to carry moved into `layers.sort_order`,
+#      `categories.sort_order`, `long_tail_top.sort_order` and `stages.num`.
+SCHEMA_VERSION = 3
 
 class UnmappedValue(ValueError):
     """A payload value with no place in the target enum. Fails the load, names the value."""
+
+
+class IdCollision(RuntimeError):
+    """Two different natural keys hashed to the same id. Fails the load, names both."""
+
+
+# --- stable ids -----------------------------------------------------------------------
+
+# The composite natural keys (`sources`, `product_lineage`) join their parts with this. Not a
+# character any slug, relation or metric name contains, so the join is unambiguous.
+KEY_SEPARATOR = "|"
+
+
+def stable_id(table: str, key: str) -> int:
+    """A surrogate id for a row, derived from its natural key rather than its position.
+
+    The first 63 bits of `sha256("<table>:<key>")`, as a positive integer. Two properties,
+    and the function exists for both:
+
+    1. **Stable across loads.** The same table and key always give the same id, so adding or
+       removing a row renumbers nothing else. An id that has escaped into a URL, a cache or a
+       CMS reference still points at the same row after the next publish, which an id
+       assigned by position did not.
+    2. **Scoped to the table.** The table name is hashed in, so the same slug in two tables
+       gets two different ids. A join that crosses tables by mistake matches nothing instead
+       of appearing to work.
+
+    63 bits rather than 64 because Postgres has no unsigned integer type and the columns are
+    `BIGINT`: keeping the top bit would make half the ids negative. 63 bits over a few
+    thousand rows per table leaves a collision probability far below any other failure mode
+    here, and `_id_map` fails the load rather than trusting that.
+    """
+    digest = hashlib.sha256(f"{table}:{key}".encode()).digest()
+    return int.from_bytes(digest[:8], "big") >> 1
+
+
+def _id_map(table: str, keys: Iterable[str]) -> dict[str, int]:
+    """natural key -> id for one table, refusing a collision rather than losing a row.
+
+    A duplicate key is fine and collapses (the callers pass keys that are unique by
+    construction); two *different* keys landing on the same id is not, because the table's
+    primary key would reject one of them at COPY time with a message naming neither.
+    """
+    out: dict[str, int] = {}
+    by_id: dict[int, str] = {}
+    for key in keys:
+        ident = stable_id(table, key)
+        clash = by_id.get(ident)
+        if clash is not None and clash != key:
+            raise IdCollision(
+                f"{table}: {key!r} and {clash!r} both hash to id {ident}. Two natural keys "
+                f"cannot share a surrogate id, so this publish has stopped rather than drop "
+                f"one of them. Change one of the keys, or widen stable_id."
+            )
+        by_id[ident] = key
+        out[key] = ident
+    return out
+
+
+def _disambiguate(keys: Iterable[str]) -> list[str]:
+    """Append `#2`, `#3` to a key that repeats, so every row has one key of its own.
+
+    Only `sources` needs this: a product's source list can carry the same URL twice on the
+    same axis. The consequence is that removing one of a duplicated pair moves the other's
+    id, which is a reason to dedupe the source list rather than a reason to number rows by
+    position again.
+    """
+    seen: dict[str, int] = {}
+    out = []
+    for key in keys:
+        seen[key] = seen.get(key, 0) + 1
+        out.append(key if seen[key] == 1 else f"{key}#{seen[key]}")
+    return out
+
+
+def check_ids_unique(tables: dict[str, list[dict]]) -> None:
+    """Fail the publish if any table's `id` column repeats. The last gate before COPY.
+
+    `_id_map` catches a collision where both natural keys are in hand, which is the case that
+    can name them. This is the backstop for every other way a duplicate id could reach a
+    table — a builder that stopped going through `_id_map`, a key computed twice from
+    different fields — and it runs over the rows that are actually about to be written.
+    """
+    for name, rows in tables.items():
+        seen: dict[int, dict] = {}
+        for row in rows:
+            ident = row.get("id")
+            if ident is None:
+                break  # this table has no id column at all
+            first = seen.get(ident)
+            if first is not None:
+                raise IdCollision(
+                    f"{name}: id {ident} is used by two rows, {first!r} and {row!r}. "
+                    f"The table's primary key would reject one of them at COPY time; "
+                    f"this publish has stopped instead."
+                )
+            seen[ident] = row
 
 
 # --- enums ----------------------------------------------------------------------------
@@ -216,7 +347,7 @@ def references(column: str, table: str, target: str) -> str:
 
 @dataclass(frozen=True)
 class SiteTable:
-    """One group-B table: its columns, its table-level constraints, and its rows.
+    """One table: its columns, its table-level constraints, and its rows.
 
     A column's second element is its full definition after the name, so it carries `NOT NULL`
     where the DBML declares one — Postgres has no table-level form of it. Keys, uniques and
@@ -257,19 +388,29 @@ def _pg_array(values) -> str:
 
 
 def product_ids(payload: dict) -> dict[str, int]:
-    """slug -> id, assigned by sorted slug so a load is reproducible and a diff is readable."""
+    """slug -> id, hashed from the slug so adding a product renumbers nothing."""
     slugs = sorted(
         {p["slug"] for cid in payload.get("order") or [] for p in payload["categories"][cid]["products"]}
     )
-    return {slug: index for index, slug in enumerate(slugs, start=1)}
+    return _id_map("products", slugs)
 
 
 def category_ids(payload: dict) -> dict[str, int]:
-    """slug -> id, in the map's own curated `order`."""
+    """slug -> id. The curated `order` decides `categories.sort_order`, not the id."""
+    return _id_map("categories", payload.get("order") or [])
+
+
+def category_order(payload: dict) -> dict[str, int]:
+    """slug -> position in the map's own curated order, 1-based."""
     return {cid: index for index, cid in enumerate(payload.get("order") or [], start=1)}
 
 
 def layer_ids(payload: dict) -> dict[str, int]:
+    return _id_map("layers", payload.get("layer_order") or [])
+
+
+def layer_order(payload: dict) -> dict[str, int]:
+    """label -> position in the stack, bottom first, 1-based."""
     return {layer: index for index, layer in enumerate(payload.get("layer_order") or [], start=1)}
 
 
@@ -279,7 +420,15 @@ def gap_ids(payload: dict) -> dict[str, int]:
     A gap kind that no category currently has is still a kind the site renders a label for.
     """
     legend = (payload.get("descriptions") or {}).get("gaps") or {}
-    return {kind: index for index, kind in enumerate(sorted(legend), start=1)}
+    return _id_map("gaps", sorted(legend))
+
+
+def stage_ids() -> dict[int, int]:
+    """Stage number -> id. The number itself stays readable in `stages.num`."""
+    from build.serialize import _STAGE_NAMES
+
+    by_key = _id_map("stages", [str(num) for num in sorted(_STAGE_NAMES)])
+    return {num: by_key[str(num)] for num in sorted(_STAGE_NAMES)}
 
 
 def _walk_products(payload: dict):
@@ -296,7 +445,7 @@ def _by_slug(payload: dict) -> list[tuple[str, str, dict]]:
     return rows
 
 
-# --- group B row builders -------------------------------------------------------------
+# --- row builders -------------------------------------------------------------
 
 
 def _products(payload: dict) -> list[dict]:
@@ -446,34 +595,38 @@ def _sources(payload: dict) -> list[dict]:
     maps, and `notes` stays NULL rather than being filled with an adjacent field.
     """
     ids = product_ids(payload)
-    out = []
-    next_id = 1
+    walked: list[tuple[str, str, dict]] = []
     for slug, _cid, product in _by_slug(payload):
         for metric in axes():
             for source in _axis(product, metric).get("sources") or []:
-                if not isinstance(source, dict):
-                    continue
-                out.append(
-                    {
-                        "id": next_id,
-                        "url": source.get("url") or "",
-                        "shows": source.get("shows") or "",
-                        "notes": "",
-                        "accessed": source.get("accessed") or "",
-                        "product_id": ids[slug],
-                        "metric_type": enum_value(
-                            "metric_name", metric, column="sources.metric_type"
-                        ),
-                    }
-                )
-                next_id += 1
+                if isinstance(source, dict):
+                    walked.append((slug, metric, source))
+    keys = _disambiguate(
+        KEY_SEPARATOR.join((slug, metric, source.get("url") or ""))
+        for slug, metric, source in walked
+    )
+    source_ids = _id_map("sources", keys)
+
+    out = []
+    for key, (slug, metric, source) in zip(keys, walked, strict=True):
+        out.append(
+            {
+                "id": source_ids[key],
+                "url": source.get("url") or "",
+                "shows": source.get("shows") or "",
+                "notes": "",
+                "accessed": source.get("accessed") or "",
+                "product_id": ids[slug],
+                "metric_type": enum_value("metric_name", metric, column="sources.metric_type"),
+            }
+        )
     return out
 
 
 def _product_lineage(payload: dict) -> list[dict]:
+    """One row per edge, keyed by `(product_slug, relation, target)` — the edge itself."""
     ids = product_ids(payload)
-    out = []
-    next_id = 1
+    walked: list[tuple[str, str, str, str]] = []
     for slug, _cid, product in _by_slug(payload):
         lineage = product.get("lineage")
         if not isinstance(lineage, dict):
@@ -481,58 +634,79 @@ def _product_lineage(payload: dict) -> list[dict]:
         for relation, targets in lineage.items():
             mapped = enum_value("lineage_relation", relation, column="product_lineage.relation")
             for target in targets or []:
-                out.append(
-                    {
-                        "id": next_id,
-                        "product_id": ids[slug],
-                        "relation": mapped,
-                        "target": target if isinstance(target, str) else str(target),
-                    }
-                )
-                next_id += 1
-    return out
+                text = target if isinstance(target, str) else str(target)
+                walked.append((slug, relation, mapped, text))
+    keys = _disambiguate(
+        KEY_SEPARATOR.join((slug, relation, target)) for slug, relation, _mapped, target in walked
+    )
+    edge_ids = _id_map("product_lineage", keys)
+    return [
+        {
+            "id": edge_ids[key],
+            "product_id": ids[slug],
+            "relation": mapped,
+            "target": target,
+        }
+        for key, (slug, _relation, mapped, target) in zip(keys, walked, strict=True)
+    ]
 
 
 def _categories(payload: dict) -> list[dict]:
     cats = category_ids(payload)
+    order = category_order(payload)
     layers = layer_ids(payload)
+    stages = stage_ids()
     legend = (payload.get("descriptions") or {}).get("categories") or {}
     out = []
-    for cid, index in cats.items():
+    for cid, ident in cats.items():
         category = payload["categories"][cid]
         layer = category.get("layer") or ""
         if layer not in layers:
             raise UnmappedValue(
                 f"category {cid!r} names layer {layer!r}, which is not in layer_order"
             )
+        stage_num = (category.get("stage") or {}).get("num")
+        if stage_num not in stages:
+            raise UnmappedValue(
+                f"category {cid!r} is at stage {stage_num!r}, which is not a stage on the "
+                f"ladder; categories.stage is NOT NULL and references stages.id"
+            )
         out.append(
             {
-                "id": index,
+                "id": ident,
                 # Not in the PDF. Added because every deep link and every join from the
                 # registry group is by slug, and an id assigned by curated order changes
                 # whenever the order does.
                 "slug": cid,
+                "sort_order": order[cid],
                 "label": category.get("label") or "",
                 "arc": category.get("arc") or "",
                 "layer": layers[layer],
                 "description": legend.get(cid) or "",
-                "stage": (category.get("stage") or {}).get("num"),
+                "stage": stages[stage_num],
             }
         )
     return out
 
 
 def _layers(payload: dict) -> list[dict]:
-    return [{"id": index, "label": layer} for layer, index in layer_ids(payload).items()]
+    ids = layer_ids(payload)
+    order = layer_order(payload)
+    return [{"id": ident, "sort_order": order[layer], "label": layer} for layer, ident in ids.items()]
 
 
 def _stages(payload: dict) -> list[dict]:
-    """The stage ladder, id = stage number. Names and descriptions are methodology constants."""
+    """The stage ladder. Names and descriptions are methodology constants.
+
+    `num` is the stage number the whole methodology speaks in ("Stage 3"), which used to be
+    the id. It is a column of its own now that the id is a hash.
+    """
     from build.serialize import _STAGE_NAMES
 
+    ids = stage_ids()
     legend = (payload.get("descriptions") or {}).get("stages") or {}
     return [
-        {"id": num, "label": name, "desc": legend.get(str(num)) or ""}
+        {"id": ids[num], "num": num, "label": name, "desc": legend.get(str(num)) or ""}
         for num, name in sorted(_STAGE_NAMES.items())
     ]
 
@@ -540,8 +714,8 @@ def _stages(payload: dict) -> list[dict]:
 def _gaps(payload: dict) -> list[dict]:
     legend = (payload.get("descriptions") or {}).get("gaps") or {}
     return [
-        {"id": index, "label": kind, "desc": legend.get(kind) or ""}
-        for kind, index in gap_ids(payload).items()
+        {"id": ident, "label": kind, "desc": legend.get(kind) or ""}
+        for kind, ident in gap_ids(payload).items()
     ]
 
 
@@ -549,22 +723,24 @@ def _gaps_categories(payload: dict) -> list[dict]:
     cats = category_ids(payload)
     gaps = gap_ids(payload)
     out = []
-    for cid, index in cats.items():
+    for cid, ident in cats.items():
         for kind in payload["categories"][cid].get("gaps") or []:
             if kind not in gaps:
                 raise UnmappedValue(
                     f"category {cid!r} carries gap {kind!r}, which the payload's gap legend "
                     f"does not describe"
                 )
-            out.append({"cat_id": index, "gap_id": gaps[kind]})
+            out.append({"cat_id": ident, "gap_id": gaps[kind]})
     return out
 
 
 def _long_tail_top(payload: dict) -> list[dict]:
     top = (payload.get("long_tail") or {}).get("top") or []
+    ids = _id_map("long_tail_top", [row.get("name") or "" for row in top])
     return [
         {
-            "id": index,
+            "id": ids[row.get("name") or ""],
+            "sort_order": index,
             "name": row.get("name") or "",
             "type": row.get("type") or "",
             "usage_label": row.get("usage_label") or "",
@@ -579,35 +755,46 @@ def _long_tail_counts(payload: dict) -> list[dict]:
     return [{"count": value, "type": key} for key, value in sorted(counts.items())]
 
 
-# --- group B table set ----------------------------------------------------------------
+# --- the table set ----------------------------------------------------------------
 
 SITE_TABLES: dict[str, SiteTable] = {
     "layers": SiteTable(
-        (("id", "INTEGER"), ("label", "VARCHAR")),
+        # `sort_order` is the stack position the id used to be, bottom first. Not in the
+        # designers' model; added when the id became a hash and stopped carrying it.
+        (("id", "BIGINT"), ("sort_order", "INTEGER NOT NULL"), ("label", "VARCHAR")),
         _layers,
         constraints=('PRIMARY KEY ("id")',),
     ),
     "stages": SiteTable(
-        (("id", "INTEGER"), ("label", "VARCHAR"), ("desc", "TEXT")),
+        # `num` is the stage number the methodology speaks in, 0-5, which used to be the id.
+        (
+            ("id", "BIGINT"),
+            ("num", "INTEGER NOT NULL"),
+            ("label", "VARCHAR"),
+            ("desc", "TEXT"),
+        ),
         _stages,
-        constraints=('PRIMARY KEY ("id")',),
+        constraints=('PRIMARY KEY ("id")', 'UNIQUE ("num")'),
     ),
     "gaps": SiteTable(
-        (("id", "INTEGER"), ("label", "VARCHAR"), ("desc", "TEXT")),
+        (("id", "BIGINT"), ("label", "VARCHAR"), ("desc", "TEXT")),
         _gaps,
         constraints=('PRIMARY KEY ("id")',),
     ),
     "categories": SiteTable(
         (
-            ("id", "INTEGER"),
+            ("id", "BIGINT"),
+            # The map's curated order, which the id used to carry. `ORDER BY sort_order` is
+            # what `ORDER BY id` used to mean.
+            ("sort_order", "INTEGER NOT NULL"),
             # NOT NULL as well as UNIQUE: a nullable unique column admits any number of
             # NULLs, which would defeat the deep links the amendment exists for.
             ("slug", "VARCHAR NOT NULL"),
             ("label", "VARCHAR"),
             ("arc", "VARCHAR"),
-            ("layer", "INTEGER NOT NULL"),
+            ("layer", "BIGINT NOT NULL"),
             ("description", "TEXT"),
-            ("stage", "INTEGER NOT NULL"),
+            ("stage", "BIGINT NOT NULL"),
         ),
         _categories,
         constraints=(
@@ -618,7 +805,7 @@ SITE_TABLES: dict[str, SiteTable] = {
         ),
     ),
     "gaps_categories": SiteTable(
-        (("cat_id", "INTEGER NOT NULL"), ("gap_id", "INTEGER NOT NULL")),
+        (("cat_id", "BIGINT NOT NULL"), ("gap_id", "BIGINT NOT NULL")),
         _gaps_categories,
         constraints=(
             references("cat_id", "categories", "id"),
@@ -639,13 +826,13 @@ SITE_TABLES: dict[str, SiteTable] = {
     ),
     "products": SiteTable(
         (
-            ("id", "INTEGER"),
+            ("id", "BIGINT"),
             ("slug", "VARCHAR NOT NULL"),
             ("org_slug", "VARCHAR NOT NULL"),
             ("name", "VARCHAR"),
             ("org", "VARCHAR"),
             ("type", "VARCHAR"),
-            ("category", "INTEGER NOT NULL"),
+            ("category", "BIGINT NOT NULL"),
             ("description", "TEXT"),
             ("maturity", "REAL"),
             ("mature", "BOOLEAN"),
@@ -663,7 +850,7 @@ SITE_TABLES: dict[str, SiteTable] = {
     ),
     "openness": SiteTable(
         (
-            ("product_id", "INTEGER"),
+            ("product_id", "BIGINT"),
             ("score", "INTEGER"),
             ("class", "VARCHAR"),
             ("components", "TEXT"),
@@ -679,7 +866,7 @@ SITE_TABLES: dict[str, SiteTable] = {
     ),
     "adoption": SiteTable(
         (
-            ("product_id", "INTEGER"),
+            ("product_id", "BIGINT"),
             ("level", "INTEGER"),
             ("reach", "VARCHAR"),
             ("signal_type", "VARCHAR"),
@@ -692,7 +879,7 @@ SITE_TABLES: dict[str, SiteTable] = {
     ),
     "capability": SiteTable(
         (
-            ("product_id", "INTEGER"),
+            ("product_id", "BIGINT"),
             ("score", "INTEGER"),
             ("basis", "VARCHAR"),
             ("basis_detail", "TEXT"),
@@ -708,12 +895,12 @@ SITE_TABLES: dict[str, SiteTable] = {
     ),
     "sources": SiteTable(
         (
-            ("id", "INTEGER"),
+            ("id", "BIGINT"),
             ("url", "TEXT"),
             ("shows", "TEXT"),
             ("notes", "TEXT"),
             ("accessed", "DATE"),
-            ("product_id", "INTEGER NOT NULL"),
+            ("product_id", "BIGINT NOT NULL"),
             ("metric_type", enum_type("metric_name") + " NOT NULL"),
         ),
         _sources,
@@ -721,8 +908,8 @@ SITE_TABLES: dict[str, SiteTable] = {
     ),
     "product_lineage": SiteTable(
         (
-            ("id", "INTEGER"),
-            ("product_id", "INTEGER NOT NULL"),
+            ("id", "BIGINT"),
+            ("product_id", "BIGINT NOT NULL"),
             ("relation", enum_type("lineage_relation")),
             ("target", "VARCHAR"),
         ),
@@ -736,7 +923,9 @@ SITE_TABLES: dict[str, SiteTable] = {
     ),
     "long_tail_top": SiteTable(
         (
-            ("id", "INTEGER"),
+            ("id", "BIGINT"),
+            # The ranking the id used to carry.
+            ("sort_order", "INTEGER NOT NULL"),
             ("name", "VARCHAR"),
             ("type", "VARCHAR"),
             ("usage_label", "VARCHAR"),
@@ -751,23 +940,18 @@ SITE_TABLES: dict[str, SiteTable] = {
     ),
 }
 
-# Group A's names as they appear in Postgres.
-REGISTRY_TABLE_NAMES: tuple[str, ...] = tuple(f"{REGISTRY_PREFIX}{n}" for n in REGISTRY_TABLES)
-# The full surface, group B then group A, in a stable load order. Group B first so a failure
-# in the part the site actually reads is the first thing a log shows.
-ALL_TABLES: tuple[str, ...] = tuple(SITE_TABLES) + REGISTRY_TABLE_NAMES
-
-
 def build_site_tables(payload: dict) -> dict[str, list[dict]]:
-    """Every group-B table's rows, keyed by table name."""
-    return {name: spec.rows(payload) for name, spec in SITE_TABLES.items()}
+    """Every table's rows, keyed by table name, with its ids checked for collisions."""
+    tables = {name: spec.rows(payload) for name, spec in SITE_TABLES.items()}
+    check_ids_unique(tables)
+    return tables
 
 
 def write_site_csvs(payload: dict, out_dir: Path) -> None:
-    """Write one CSV per group-B table, so the same loader handles both groups.
+    """Write one CSV per table, so everything reaches Postgres through one COPY path.
 
-    Group A arrives as CSVs the serializers wrote; rendering group B the same way means
-    there is one COPY path, one type story and one place a quoting bug could live.
+    Rendering to CSV rather than inserting row by row means there is one type story and one
+    place a quoting bug could live, and it reuses the serializers' writer.
     """
     from build.serialize_registry import write_tables
 

--- a/build/publish_neon.py
+++ b/build/publish_neon.py
@@ -677,6 +677,12 @@ def main() -> int:
     parser.add_argument(
         "--site-dir", type=Path, default=SITE_DIR, help="where the site tables' CSVs are rendered"
     )
+    parser.add_argument(
+        "--payload",
+        type=Path,
+        default=PAYLOAD_PATH,
+        help=f"the payload every table is rendered from (default {PAYLOAD_PATH.name})",
+    )
     args = parser.parse_args()
 
     try:
@@ -686,7 +692,7 @@ def main() -> int:
         return 2
 
     try:
-        plans, missing = plan(args.site_dir)
+        plans, missing = plan(args.site_dir, args.payload)
     except IdCollision as error:
         # Two natural keys on one surrogate id. The COPY would fail on the primary key and
         # name neither of them, so the publish stops here with both in hand.

--- a/build/publish_neon.py
+++ b/build/publish_neon.py
@@ -9,9 +9,13 @@ never replaced by them.
 
 This module is a generic CSV-to-Postgres loader with an atomic schema swap. It knows nothing
 about the gap map: the tables, enums, grain, keys and column types all live in
-`build/neon_schema.py`, which is the one place to change when the data model moves. Two
-groups today — the designers' target model, built from the payload, and the registry tables
-`publish_registry` publishes, prefixed `registry_` so the two surfaces cannot collide.
+`build/neon_schema.py`, which is the one place to change when the data model moves. One
+surface today — the designers' target model, built from the payload.
+
+The registry tables `publish_registry` sends to OSO were loaded here too for a while, prefixed
+`registry_`. Nothing on the site read them, so they are gone: the registry surface lives in
+the warehouse as `currentai.registry.*` and in `build/registry/*.csv`, and Neon serves the
+site's tables plus `publish_runs`.
 
 Nothing computed is here. `scores.openness_facts` and `scores.openness_computed` stay on
 OSO, and no table in this schema recomputes an axis. See
@@ -83,20 +87,13 @@ Grants are applied to the staging schema *before* the swap. A rename carries pri
 with it, so the new schema is readable the instant it becomes visible rather than after a
 follow-up statement that could fail on its own.
 
-## Column types: declared for the target model, inferred for the registry
+## Column types are declared, never inferred
 
-`neon_schema.SITE_TABLES` declares its own types and its enums, because that module defines
-the shape.
-The serializers declare column *names* only, so a registry column's type is inferred:
-TEXT by default and as the fallback, and BOOLEAN, INTEGER/BIGINT, DOUBLE PRECISION or DATE
-only when every non-empty value in the column parses as one. Identity columns (`slug`,
-anything ending `_slug` or `_id`) are pinned to TEXT whatever they look like — a
-numeric-looking artifact id is a string with digits in it, and letting one run of the data
-decide otherwise would change the column type from under a query the next time a
-non-numeric id arrives.
+`neon_schema.SITE_TABLES` declares every column's type and its enums, because that module
+defines the shape. Nothing here guesses a type from a run of the data.
 
 In CSV mode an unquoted empty field is NULL, so an absent value arrives as NULL rather than
-as an empty string, on both groups.
+as an empty string.
 
 Environment:
     NEON_DATABASE_URL   required for a publish (not for --check)
@@ -124,17 +121,13 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from build.neon_schema import (
     ENUMS,
+    IdCollision,
     PAYLOAD_PATH,
-    REGISTRY_PREFIX,
     SCHEMA_VERSION,
     SITE_TABLES,
     load_payload,
     write_site_csvs,
 )
-from build.publish_registry import TABLES as PUBLISHED_TABLES
-from build.serialize_registry import OUT_DIR
-from build.serialize_registry import TABLES as REGISTRY_TABLES
-from build.serialize_registry import build_registry, write_tables
 
 ROOT = Path(__file__).resolve().parents[1]
 # The gap map's own schema on a shared Neon instance. Hyphenated, hence quoted everywhere.
@@ -145,7 +138,7 @@ PROTECTED_SCHEMAS = frozenset(
     {"drizzle", "payload", "public", "information_schema", "pg_catalog", "pg_toast"}
 )
 # Where the site tables' CSVs are rendered. Separate from build/registry/, which belongs to
-# the serializers and is published to OSO from.
+# the serializers and is published to the warehouse from.
 SITE_DIR = ROOT / "build" / "neon"
 DSN_ENV = "NEON_DATABASE_URL"
 READ_ROLE_ENV = "NEON_READ_ROLE"
@@ -171,50 +164,6 @@ RUN_COLUMNS: tuple[tuple[str, str], ...] = (
     ("row_counts", "JSONB"),
 )
 
-# Never inferred away from TEXT, however this run's values happen to look.
-_TEXT_NAMES = frozenset({"slug", "artifact_id", "alias", "handle", "pattern", "target"})
-
-_INT = re.compile(r"^-?\d+$")
-_INT32 = 2**31 - 1
-_TRUE_FALSE = frozenset({"true", "false"})
-
-
-def is_text_column(name: str) -> bool:
-    """Identity columns stay TEXT. Slugs and ids are strings that sometimes hold digits."""
-    return name in _TEXT_NAMES or name.endswith("_slug") or name.endswith("_id")
-
-
-def _all_parse(values: list[str], parse) -> bool:
-    for value in values:
-        try:
-            parse(value)
-        except (TypeError, ValueError):
-            return False
-    return True
-
-
-def infer_column_type(name: str, values: list[str]) -> str:
-    """The narrowest type every non-empty value in the column satisfies, else TEXT.
-
-    An all-empty column is TEXT: nothing in the data argues for anything narrower, and a
-    guess would be reversed by the first real value.
-    """
-    if is_text_column(name):
-        return "TEXT"
-    present = [v for v in values if v != ""]
-    if not present:
-        return "TEXT"
-    if all(v.lower() in _TRUE_FALSE for v in present):
-        return "BOOLEAN"
-    if all(_INT.match(v) for v in present):
-        return "INTEGER" if all(abs(int(v)) <= _INT32 for v in present) else "BIGINT"
-    if _all_parse(present, float):
-        return "DOUBLE PRECISION"
-    if _all_parse(present, lambda v: datetime.strptime(v, "%Y-%m-%d")):
-        return "DATE"
-    return "TEXT"
-
-
 @dataclass(frozen=True)
 class TablePlan:
     """One CSV, resolved to a table: its name, columns, constraints and row count."""
@@ -228,104 +177,55 @@ class TablePlan:
 
 def plan_table(
     path: Path,
-    declared: tuple[tuple[str, str], ...] | None = None,
-    name: str | None = None,
+    declared: tuple[tuple[str, str], ...],
     constraints: tuple[str, ...] = (),
 ) -> TablePlan:
-    """Plan one CSV. `declared` supplies the column types; without it they are inferred.
+    """Plan one CSV against the columns `neon_schema` declares for it.
 
-    `name` is the destination table, which is not always the file's stem: group A's tables
-    are prefixed so they cannot collide with group B's `products`/`categories`/`organizations`
-    in the shared schema.
-
-    A declared spec is still checked against the file's header, because a spec that has
-    drifted from the CSV it describes would otherwise COPY values into the wrong columns —
-    which Postgres would accept wherever the types happened to line up.
+    The spec is checked against the file's header, because a spec that has drifted from the
+    CSV it describes would otherwise COPY values into the wrong columns — which Postgres
+    would accept wherever the types happened to line up.
     """
     with path.open(newline="", encoding="utf-8") as handle:
         reader = csv.reader(handle)
         header = next(reader, [])
         rows = list(reader)
-    if declared is not None:
-        expected = [name for name, _type in declared]
-        if header != expected:
-            raise ValueError(
-                f"{path.name}: header {header} does not match the declared columns {expected}"
-            )
-        columns = declared
-    else:
-        columns = tuple(
-            (name, infer_column_type(name, [row[index] if index < len(row) else "" for row in rows]))
-            for index, name in enumerate(header)
+    expected = [name for name, _type in declared]
+    if header != expected:
+        raise ValueError(
+            f"{path.name}: header {header} does not match the declared columns {expected}"
         )
     return TablePlan(
-        name=name or path.stem,
-        columns=columns,
+        name=path.stem,
+        columns=declared,
         row_count=len(rows),
         path=path,
         constraints=constraints,
     )
 
 
-def ensure_registry_csvs(directory: Path) -> None:
-    """Regenerate the registry serializer's own CSVs when they are absent.
-
-    Only that one. The rubric, routing and scores serializers each have their own
-    preconditions, and a publisher that silently invoked all four would hide which one
-    produced a surprising table — so their absence is reported by `plan` rather than
-    papered over here.
-    """
-    if all((directory / f"{name}.csv").exists() for name in REGISTRY_TABLES):
-        return
-    from build.validate import load_sources
-
-    tables, errors, _warnings = build_registry(load_sources(ROOT))
-    if errors:
-        raise RuntimeError(
-            f"the registry does not serialize cleanly ({len(errors)} error(s)); "
-            f"run build.serialize_registry to see them"
-        )
-    write_tables(tables, directory)
-
-
 def plan(
-    directory: Path = OUT_DIR,
     site_dir: Path = SITE_DIR,
     payload_path: Path = PAYLOAD_PATH,
 ) -> tuple[list[TablePlan], list[str]]:
-    """(plans, missing) over both groups, group B first, each in its declared order.
+    """(plans, missing) over the site tables, in their declared parents-first order.
 
     Never a glob. `missing` names the declared tables whose CSV has not been written, which
-    a real publish refuses and `--check` reports — a table is absent because a serializer
-    has not run, and loading the rest would publish a partial map that looks complete.
+    a real publish refuses and `--check` reports — loading the rest would publish a partial
+    map that looks complete.
 
-    The site tables are rendered to CSV here from `build/notebook_data.json`, so both groups
-    reach the database through one COPY path.
+    The CSVs are rendered here from `build/notebook_data.json`, so every table reaches the
+    database through one COPY path.
     """
-    ensure_registry_csvs(directory)
-    plans: list[TablePlan] = []
-    missing: list[str] = []
+    if not payload_path.exists():
+        return [], list(SITE_TABLES)
 
-    if payload_path.exists():
-        write_site_csvs(load_payload(payload_path), site_dir)
-        for name, spec in SITE_TABLES.items():
-            plans.append(
-                plan_table(
-                    site_dir / f"{name}.csv",
-                    declared=spec.columns,
-                    constraints=spec.constraints,
-                )
-            )
-    else:
-        missing.extend(SITE_TABLES)
-
-    for name in PUBLISHED_TABLES:
-        path = directory / f"{name}.csv"
-        if path.exists():
-            plans.append(plan_table(path, name=f"{REGISTRY_PREFIX}{name}"))
-        else:
-            missing.append(f"{REGISTRY_PREFIX}{name}")
-    return plans, missing
+    write_site_csvs(load_payload(payload_path), site_dir)
+    plans = [
+        plan_table(site_dir / f"{name}.csv", declared=spec.columns, constraints=spec.constraints)
+        for name, spec in SITE_TABLES.items()
+    ]
+    return plans, []
 
 
 def quote_ident(name: str) -> str:
@@ -388,9 +288,6 @@ def create_table_sql(
     reason, so the reference resolves inside the schema being built rather than against
     whatever `os-ai-map` happens to hold at the time.
 
-    `constraints` is empty for the registry group: the serializers declare column names only,
-    so there is nothing to derive a key from, and inventing one would be this module guessing
-    at another module's grain.
     """
     quoted_schema = quote_schema(schema)
     parts = [
@@ -777,7 +674,6 @@ def main() -> int:
     )
     parser.add_argument("--dsn-env", default=DSN_ENV, help=f"env var holding the DSN (default {DSN_ENV})")
     parser.add_argument("--schema", default=DEFAULT_SCHEMA, help=f"target schema (default {DEFAULT_SCHEMA})")
-    parser.add_argument("--dir", type=Path, default=OUT_DIR, help="directory of serialized CSVs")
     parser.add_argument(
         "--site-dir", type=Path, default=SITE_DIR, help="where the site tables' CSVs are rendered"
     )
@@ -789,42 +685,35 @@ def main() -> int:
         print(str(error), file=sys.stderr)
         return 2
 
-    plans, missing = plan(args.dir, args.site_dir)
+    try:
+        plans, missing = plan(args.site_dir)
+    except IdCollision as error:
+        # Two natural keys on one surrogate id. The COPY would fail on the primary key and
+        # name neither of them, so the publish stops here with both in hand.
+        print(f"id collision: {error}", file=sys.stderr)
+        return 1
 
     if args.check:
-        # A plan, not a gate on completeness: on a PR only the registry serializer's CSVs
-        # exist, because the check job validates the other three without writing. So the
-        # unwritten tables are reported as pending rather than failed.
-        total_declared = len(PUBLISHED_TABLES) + len(SITE_TABLES)
+        # A plan, not a gate on completeness: without the payload there is nothing to render,
+        # so the tables are reported as pending rather than failed.
         print(
-            f"would load {total_declared} tables into {args.schema}_staging, "
+            f"would load {len(SITE_TABLES)} tables into {args.schema}_staging, "
             f"then swap to {args.schema}:"
         )
         for plan_ in plans:
-            group = "map" if plan_.name in SITE_TABLES else "registry"
             keys = f"{len(plan_.constraints):>2} constraints" if plan_.constraints else ""
             print(
                 f"  {plan_.name:<28} {plan_.row_count:>6} rows  "
-                f"{len(plan_.columns):>2} columns  [{group}] {keys}"
+                f"{len(plan_.columns):>2} columns  {keys}"
             )
         print(f"  {len(ENUMS)} enums: {', '.join(ENUMS)}")
         print(
             f"  {sum(len(p.constraints) for p in plans)} table constraints "
-            f"(primary keys, uniques and foreign keys, on the map group)"
+            f"(primary keys, uniques and foreign keys)"
         )
-        # Only the inferred types are worth printing. The map group's are declared in
-        # build/neon_schema.py, where a reader can see them next to the grain they describe;
-        # the registry group's are a guess this run made about the data, which is the thing
-        # a reviewer needs to see change.
-        for plan_ in plans:
-            if plan_.name in SITE_TABLES:
-                continue
-            for column, sql_type in plan_.columns:
-                if sql_type != "TEXT":
-                    print(f"    inferred {plan_.name}.{column} -> {sql_type}")
         print(f"  {RUN_TABLE:<28} {1:>6} row   {len(RUN_COLUMNS):>2} columns  [run record]")
         for name in missing:
-            print(f"  {name:<28}  pending: not serialized yet")
+            print(f"  {name:<28}  pending: build/notebook_data.json has not been built")
         return 0
 
     # Configuration before inputs: with no DSN there is nowhere to publish whatever the
@@ -836,9 +725,9 @@ def main() -> int:
 
     if missing:
         print(
-            f"missing tables: {missing}. Run build.serialize_registry, build.serialize_rubric, "
-            f"build.serialize_routing and build.serialize_scores first — loading the rest "
-            f"would publish a partial map that looks complete.",
+            f"missing tables: {missing}. Every one is rendered from build/notebook_data.json, "
+            f"so build the payload first — loading the rest would publish a partial map that "
+            f"looks complete.",
             file=sys.stderr,
         )
         return 2

--- a/docs/operations/deploy-models.md
+++ b/docs/operations/deploy-models.md
@@ -128,7 +128,7 @@ Pushing the declarations is step 1, not the whole job:
 ```bash
 # push the repo's declarations and wait for the static models to materialize
 uv run python -m build.serialize_rubric && uv run python -m build.publish_registry
-# load the same declarations into Neon, which is what the site reads
+# load the site's tables into Neon, which is what the front end reads
 uv run python -m build.publish_neon           # --check to plan without connecting
 # then walk the chain above, in order, and prove it with check_parity
 ```

--- a/docs/reference/where-scores-live.md
+++ b/docs/reference/where-scores-live.md
@@ -64,6 +64,11 @@ read `os-ai-map` can also read the superseded corpus under `os-ai-map_previous`.
 meant to, and the publisher does not stop anything from trying — do not build against that
 name.
 
+**Nothing reads Neon yet.** The front end still consumes `build/notebook_data.json`, so the
+four ordering columns above are preservation for the consumer that comes next rather than
+something in use today. A publish that dropped the information would destroy it, and carrying
+it costs four integers per row.
+
 **Neon serves the site's tables, and nothing else.** The target model from CLEVER FRANKE,
 with Carl's amendments: `products`, `organizations`, `categories`, `layers`, `stages`, `gaps`,
 `gaps_categories`, `openness`, `adoption`, `capability`, `sources`, `product_lineage`,
@@ -94,10 +99,16 @@ by mistake matches nothing rather than appearing to work.
 
 The natural key per table: `products.slug`, `categories.slug`, `layers` and `gaps` by their
 label, `stages` by their stage number, `long_tail_top` by its name, `product_lineage` by
-`(product_slug, relation, target)`, `sources` by `(product_slug, metric, url)`. Organizations
-key on `slug` and aliases on `alias`, with no surrogate at all. A source list that carries the
-same URL twice on the same axis gets `#2` appended before hashing, so both rows are
-addressable.
+`(product_slug, relation, target)`, `sources` by
+`(product_slug, metric, url, shows, accessed)`. Organizations key on `slug` and aliases on
+`alias`, with no surrogate at all.
+
+A source's key carries `shows` and `accessed` because the URL alone does not identify the row.
+One source list can hold the same URL twice on the same axis — 69 pairs today — and every one
+of those pairs is a re-verification that recorded a different claim or a different date. They
+are two observations of one page, and those two fields are what tell them apart. The
+consequence worth knowing: editing a source's `shows` or `accessed` moves that row's id,
+because it is a different observation and an id moves when its natural key does.
 
 **The slug remains canonical.** A deep link, a bookmark, a CMS reference, anything another
 system stores or a person reads should carry the slug, not the id. The id is a join key, and
@@ -168,8 +179,8 @@ Four places, all deliberate, all in `build/neon_schema.py`:
 | Departure | Why |
 |---|---|
 | `id` and every column referencing one are `bigint`, not `integer` | The ids are 63-bit hashes. 63 rather than 64 because Postgres has no unsigned integer and half the ids would otherwise be negative. |
-| `categories.slug`, which the DBML omits | Every deep link and every join from the registry group is by slug, and it carries a `UNIQUE` for the same reason. |
-| `layers.sort_order`, `categories.sort_order`, `long_tail_top.sort_order`, `stages.num` | The old positional ids carried the layer stack order, the map's curated category order, the long tail's ranking and the stage number. A hashed id carries none of that, so it moved into columns of its own. `ORDER BY sort_order` is what `ORDER BY id` used to mean. |
+| `categories.slug`, which the DBML omits | Every deep link is by slug, and so is every join from the warehouse's registry tables; it carries a `UNIQUE` for the same reason. |
+| `layers.sort_order`, `categories.sort_order`, `long_tail_top.sort_order`, `stages.num` | The old positional ids carried the layer stack order, the map's curated category order, the long tail's ranking and the stage number — `categories.stage` *was* the stage number, and `stages.id` was the number it pointed at. A hashed id carries none of that, and the model has nowhere else for it: `layers` is `{id, label}`, `stages` has no number, and neither `categories` nor `long_tail_top` has an ordering field. So it moved into columns of its own; `ORDER BY sort_order` is what `ORDER BY id` used to mean. |
 | `gallery`, `gallery_products`, `gallery_gaps` and their three enums are absent | The CMS owns authored content; a schema rebuilt from source can only hold rows it produced. See below. |
 
 ### Two things the designers should know about the data

--- a/docs/reference/where-scores-live.md
+++ b/docs/reference/where-scores-live.md
@@ -64,18 +64,17 @@ read `os-ai-map` can also read the superseded corpus under `os-ai-map_previous`.
 meant to, and the publisher does not stop anything from trying — do not build against that
 name.
 
-**Two groups of table, one schema.**
+**Neon serves the site's tables, and nothing else.** The target model from CLEVER FRANKE,
+with Carl's amendments: `products`, `organizations`, `categories`, `layers`, `stages`, `gaps`,
+`gaps_categories`, `openness`, `adoption`, `capability`, `sources`, `product_lineage`,
+`aliases`, `long_tail_top`, `long_tail_counts`. Every row is derived from
+`build/notebook_data.json`, so what Postgres serves is what the repo published.
 
-*The map* — the target model from CLEVER FRANKE, with Carl's amendments: `products`,
-`organizations`, `categories`, `layers`, `stages`, `gaps`, `gaps_categories`, `openness`,
-`adoption`, `capability`, `sources`, `product_lineage`, `aliases`, `long_tail_top`,
-`long_tail_counts`. Every row is derived from `build/notebook_data.json`, so what Postgres
-serves is what the repo published.
-
-*The registry*, prefixed `registry_` — the same tables `publish_registry` publishes to OSO,
-derived from that module rather than from a directory listing, so the two surfaces carry the
-same registry by construction. The prefix exists because both groups have a `products`, a
-`categories` and an `organizations`.
+The registry tables were loaded here too for a while, prefixed `registry_`, so Neon and the
+warehouse would carry the same declarations. Nothing on the site read them, so they are gone.
+**The registry surface lives in the warehouse** as `currentai.registry.*`, and on disk as
+`build/registry/*.csv` — not in Neon. A question about what the repo declares is answerable
+there; Neon answers what the site renders.
 
 Plus `publish_runs`: exactly one row, describing the load you are looking at — the swap
 replaces the table along with everything else, so it is a stamp on the current corpus and not
@@ -84,11 +83,31 @@ an accumulating history. It carries `run_id`, `published_at`, `schema_version`,
 `row_counts` JSONB. That row is how you tell which commit and which shape the serving layer is
 showing.
 
-**Keys are natural where the payload has one.** `products.id` exists for the FK shape the
-designers specified, but it is assigned by sorted slug on every load, so the same corpus gives
-the same ids and a diff of two loads is readable. The real key is `slug`. Organizations key on
-`slug`, aliases on `alias`, and `categories` carries a `slug` alongside its id — the PDF omitted
-it, and every deep link and every join from the registry group needs it.
+**Ids are stable across loads, and the slug is still the identity.** Every surrogate `id` in
+the map group is `stable_id(table, natural_key)` — the first 63 bits of a SHA-256 over the
+table name and the row's own key. Ids used to be positions in a sorted list, so adding one
+product renumbered every row after it and any id that had reached a URL, a cache or a CMS row
+pointed at a different product after the next publish. A hashed id does not move when the
+corpus grows, so it is safe to store as an internal reference. Hashing the table name in as
+well means the same slug in two tables gets two different ids, and a join that crosses tables
+by mistake matches nothing rather than appearing to work.
+
+The natural key per table: `products.slug`, `categories.slug`, `layers` and `gaps` by their
+label, `stages` by their stage number, `long_tail_top` by its name, `product_lineage` by
+`(product_slug, relation, target)`, `sources` by `(product_slug, metric, url)`. Organizations
+key on `slug` and aliases on `alias`, with no surrogate at all. A source list that carries the
+same URL twice on the same axis gets `#2` appended before hashing, so both rows are
+addressable.
+
+**The slug remains canonical.** A deep link, a bookmark, a CMS reference, anything another
+system stores or a person reads should carry the slug, not the id. The id is a join key, and
+it changes if the natural key it is derived from ever changes. `categories` carries a `slug`
+alongside its id for exactly this reason — the PDF omitted it, and every deep link and every
+join from the warehouse's registry tables needs it.
+
+Before writing, the publisher asserts that no table has a repeated id and fails the run naming
+the table and both natural keys if one does. A duplicate would otherwise be rejected by the
+primary key at COPY time, in a message naming neither.
 
 **The five enums are enforced.** `alias_kind`, `freshness_basis`, `lineage_relation`,
 `capability_relation` and `metric_name` are created in the schema, and a payload value with no
@@ -142,6 +161,17 @@ dropped when that is reclaimed. `publish_neon.reclaim_previous` detects exactly 
 refuses to run rather than dropping the view — the failure is loud, but it is still a failure.
 Read the map's tables directly, or materialize a copy CMS-side.
 
+### Where this departs from the designers' model
+
+Four places, all deliberate, all in `build/neon_schema.py`:
+
+| Departure | Why |
+|---|---|
+| `id` and every column referencing one are `bigint`, not `integer` | The ids are 63-bit hashes. 63 rather than 64 because Postgres has no unsigned integer and half the ids would otherwise be negative. |
+| `categories.slug`, which the DBML omits | Every deep link and every join from the registry group is by slug, and it carries a `UNIQUE` for the same reason. |
+| `layers.sort_order`, `categories.sort_order`, `long_tail_top.sort_order`, `stages.num` | The old positional ids carried the layer stack order, the map's curated category order, the long tail's ranking and the stage number. A hashed id carries none of that, so it moved into columns of its own. `ORDER BY sort_order` is what `ORDER BY id` used to mean. |
+| `gallery`, `gallery_products`, `gallery_gaps` and their three enums are absent | The CMS owns authored content; a schema rebuilt from source can only hold rows it produced. See below. |
+
 ### Two things the designers should know about the data
 
 **`sources.notes` is always NULL.** The target model has the column and the payload has no
@@ -185,13 +215,9 @@ ALTER anywhere. What that costs is a reader's ability to tell which shape it has
 to a table, column or enum. Once something outside this repo depends on the shape, that is the
 point where a real migration path replaces the swap.
 
-Column types for the map group are declared in `build/neon_schema.py`, next to the grain they
-describe. The registry group's are inferred from the data, because the serializers declare
-column names and not types: TEXT unless every non-empty value in the column parses as BOOLEAN,
-INTEGER, DOUBLE PRECISION or DATE, and identity columns (`slug`, anything ending `_slug` or
-`_id`) pinned to TEXT whatever they look like. A digits-only artifact id is a string with
-digits in it. An empty CSV field loads as NULL on both groups, so "absent" and "empty" are the
-same value.
+Every column's type is declared in `build/neon_schema.py`, next to the grain it describes;
+nothing is inferred from a run of the data. An empty CSV field loads as NULL, so "absent" and
+"empty" are the same value.
 
 ## Openness — computed and gated
 

--- a/tests/test_publish_neon.py
+++ b/tests/test_publish_neon.py
@@ -25,6 +25,7 @@ from build.neon_schema import (
     IdCollision,
     UnmappedValue,
     build_site_tables,
+    check_ids_unique,
     enum_value,
     load_payload,
     product_ids,
@@ -420,7 +421,16 @@ def _fixture_payload(extra_slug: str | None = None) -> dict:
             "product": "Mid",
             "org_slug": "acme",
             "type": "model",
-            "openness": {"score": 3, "sources": [{"url": "https://example.test/mid"}]},
+            "openness": {
+                "score": 3,
+                "sources": [
+                    {
+                        "url": "https://example.test/mid",
+                        "shows": "the licence",
+                        "accessed": "2026-08-13",
+                    }
+                ],
+            },
             "lineage": {"derived_from": ["some-base"]},
         },
         {"slug": "zeta-product", "product": "Zeta", "org_slug": "acme", "type": "model"},
@@ -443,7 +453,7 @@ def _fixture_payload(extra_slug: str | None = None) -> dict:
         },
         "descriptions": {"categories": {}, "gaps": {}, "stages": {}},
         "organizations": {"acme": {"display_name": "Acme", "type": "company"}},
-        "aliases": {},
+        "aliases": {"products": {"mid": "mid-product"}},
         "long_tail": {"top": [{"name": "Tail One"}], "counts": {"model": 1}},
     }
 
@@ -485,7 +495,7 @@ def test_the_foreign_keys_in_a_fixture_corpus_resolve_to_the_hashed_parents():
     }
     assert [row["product_id"] for row in tables["sources"]] == [mid]
     assert [row["id"] for row in tables["sources"]] == [
-        stable_id("sources", "mid-product|openness|https://example.test/mid")
+        stable_id("sources", "mid-product|openness|2026-08-13|https://example.test/mid|the licence")
     ]
     assert [row["id"] for row in tables["product_lineage"]] == [
         stable_id("product_lineage", "mid-product|derived_from|some-base")
@@ -495,18 +505,67 @@ def test_the_foreign_keys_in_a_fixture_corpus_resolve_to_the_hashed_parents():
     ]
 
 
-def test_a_repeated_source_url_still_gets_an_id_of_its_own():
-    """A product can list the same URL twice on the same axis, and both rows need a key."""
+def test_the_same_url_read_twice_is_two_observations_with_two_ids():
+    """A source list can carry the same URL twice on the same axis. Each entry is a separate
+    re-verification, so `shows` and `accessed` are part of the key rather than tie-breakers."""
     payload = _fixture_payload()
     product = payload["categories"]["a_category"]["products"][0]
     product["openness"]["sources"] = [
-        {"url": "https://example.test/mid"},
-        {"url": "https://example.test/mid"},
+        {"url": "https://example.test/mid", "shows": "the licence", "accessed": "2026-08-13"},
+        {"url": "https://example.test/mid", "shows": "the licence", "accessed": "2026-08-14"},
     ]
     ids = [row["id"] for row in build_site_tables(payload)["sources"]]
-    assert len(set(ids)) == 2
-    assert ids[0] == stable_id("sources", "mid-product|openness|https://example.test/mid")
-    assert ids[1] == stable_id("sources", "mid-product|openness|https://example.test/mid#2")
+    assert ids == [
+        stable_id("sources", "mid-product|openness|2026-08-13|https://example.test/mid|the licence"),
+        stable_id("sources", "mid-product|openness|2026-08-14|https://example.test/mid|the licence"),
+    ]
+
+
+def test_deleting_one_re_verification_leaves_the_others_id_alone():
+    """The defect the fuller key exists to prevent. Keyed on the URL alone, deleting the
+    earlier of a pair promoted the later one into the un-suffixed key and handed it the
+    deleted row's id — so a stored reference resolved to a row with a different claim and a
+    different date, and nothing raised, because the ids were still unique."""
+    both = _fixture_payload()
+    product = both["categories"]["a_category"]["products"][0]
+    first = {"url": "https://example.test/mid", "shows": "the licence", "accessed": "2026-08-13"}
+    second = {"url": "https://example.test/mid", "shows": "a wider claim", "accessed": "2026-08-14"}
+    product["openness"]["sources"] = [first, second]
+    before = {row["id"]: row["shows"] for row in build_site_tables(both)["sources"]}
+
+    survivor_only = _fixture_payload()
+    survivor_only["categories"]["a_category"]["products"][0]["openness"]["sources"] = [second]
+    after = {row["id"]: row["shows"] for row in build_site_tables(survivor_only)["sources"]}
+
+    survivor = next(ident for ident, shows in before.items() if shows == "a wider claim")
+    deleted = next(ident for ident, shows in before.items() if shows == "the licence")
+    assert list(after) == [survivor], "the survivor kept its own id"
+    assert deleted not in after, "the deleted row's id was not handed to anyone"
+
+
+def test_the_disambiguator_never_fires_on_the_real_corpus():
+    """`_disambiguate` numbers by walk position, so it carries the very bug the natural keys
+    exist to avoid. It is a guard against a future corpus, not a working part of the scheme —
+    a red here means two source rows are genuinely indistinguishable and the key needs
+    widening, not that the suffix should be relied on."""
+    from build.neon_schema import _axis, _by_slug, _source_key
+    from build.vocabulary import axes
+
+    payload = load_payload()
+    keys = [
+        _source_key(slug, metric, source)
+        for slug, _cid, product in _by_slug(payload)
+        for metric in axes()
+        for source in _axis(product, metric).get("sources") or []
+        if isinstance(source, dict)
+    ]
+    duplicates = {key for key in keys if keys.count(key) > 1} if len(keys) != len(set(keys)) else set()
+    assert not duplicates, f"{len(duplicates)} source keys repeat, so the suffix would fire"
+    # The suffix is appended, so only a key already ending `#<digits>` shares its namespace.
+    # A `#` anywhere else — a fragment in a URL, a note in `shows` — cannot be mistaken for one.
+    collidable = [key for key in keys if re.search(r"#\d+$", key)]
+    assert not collidable, f"{len(collidable)} keys end in a suffix shape the disambiguator uses"
+    assert len(build_site_tables(payload)["sources"]) == len(keys)
 
 
 @pytest.mark.parametrize(
@@ -569,6 +628,44 @@ def test_a_collision_exits_the_publisher_with_1(monkeypatch, tmp_path, capsys):
     )
     assert publisher.main() == 1
     assert "id collision" in capsys.readouterr().err
+
+
+def test_the_guard_covers_every_table_the_dbml_gives_a_key(monkeypatch):
+    """Keyed off the declared PRIMARY KEY rather than off a column named `id`, so the four
+    whose key is `product_id`, `slug` or `alias` are inside it too. The two tables the DBML
+    gives no key are the only ones exempt."""
+    from build.neon_schema import primary_key
+
+    keyed = {name for name in SITE_TABLES if primary_key(name)}
+    assert keyed == set(SITE_TABLES) - {"gaps_categories", "long_tail_counts"}
+    assert primary_key("openness") == ("product_id",)
+    assert primary_key("organizations") == ("slug",)
+    assert primary_key("aliases") == ("alias",)
+    assert primary_key("gaps_categories") == ()
+
+
+@pytest.mark.parametrize(
+    "table,column",
+    [("openness", "product_id"), ("organizations", "slug"), ("aliases", "alias")],
+)
+def test_a_duplicate_on_a_non_id_primary_key_is_caught_too(table, column):
+    """The `id`-only version of this guard skipped seven tables while claiming to cover
+    every way a duplicate could reach one."""
+    tables = build_site_tables(_fixture_payload())
+    rows = tables[table]
+    assert rows, f"{table} has no rows in the fixture corpus"
+    tables[table] = [rows[0], dict(rows[0])]
+    with pytest.raises(IdCollision) as error:
+        check_ids_unique(tables)
+    assert table in str(error.value)
+    assert str(rows[0][column]) in str(error.value)
+
+
+def test_a_table_with_no_declared_key_is_skipped_not_half_scanned():
+    """`gaps_categories` and `long_tail_counts` have no key in the DBML and none to invent."""
+    tables = build_site_tables(_fixture_payload())
+    tables["long_tail_counts"] = tables["long_tail_counts"] * 2
+    check_ids_unique(tables)
 
 
 def test_the_ordinal_the_id_used_to_carry_kept_a_column_of_its_own():
@@ -1132,6 +1229,28 @@ def test_every_not_null_the_dbml_declares_is_in_the_generated_ddl(table, column)
     definition = dict(spec.columns)[column]
     assert "NOT NULL" in definition, f"{table}.{column} is nullable"
     assert f'"{column}"' in sql
+
+
+def test_a_missing_payload_reports_every_table_pending_rather_than_planning_none(tmp_path):
+    """`build/notebook_data.json` is tracked, so this branch is nearly unreachable — which
+    makes it likelier to rot unnoticed, not less. Every table is rendered from the payload, so
+    without it there is nothing to load and the tables are reported, not silently skipped."""
+    plans, missing = plan(
+        site_dir=tmp_path / "site", payload_path=tmp_path / "no-such-payload.json"
+    )
+    assert plans == []
+    assert missing == list(SITE_TABLES)
+
+
+def test_a_publish_with_no_payload_exits_2_and_says_what_to_build(tmp_path):
+    """Loading the rest would publish a partial map that looks complete."""
+    result = _run(
+        ["--site-dir", str(tmp_path / "site"), "--payload", str(tmp_path / "absent.json")],
+        {DSN_ENV: FAKE_DSN},
+    )
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "missing tables" in result.stderr
+    assert "notebook_data.json" in result.stderr
 
 
 def test_every_planned_table_is_one_the_schema_module_declares(tmp_path):

--- a/tests/test_publish_neon.py
+++ b/tests/test_publish_neon.py
@@ -1,7 +1,7 @@
 """The Neon publisher, without a database.
 
-Everything that decides what reaches the serving layer is a pure function here — the type
-a column gets, the DDL for a table, the statement sequence the cutover runs — so all of it
+Everything that decides what reaches the serving layer is a pure function here — the id a
+row gets, the DDL for a table, the statement sequence the cutover runs — so all of it
 is tested against strings rather than against a live Postgres. The two things that cannot
 be checked that way are covered by running the CLI as a subprocess: that `--check` plans
 without connecting, and that a DSN never reaches stdout or stderr.
@@ -16,24 +16,25 @@ from pathlib import Path
 
 import pytest
 
+import build.neon_schema
 from build.neon_schema import (
-    ALL_TABLES,
     ENUM_MAPS,
     ENUMS,
-    REGISTRY_PREFIX,
     SCHEMA_VERSION,
     SITE_TABLES,
+    IdCollision,
     UnmappedValue,
+    build_site_tables,
     enum_value,
     load_payload,
     product_ids,
+    stable_id,
 )
 from build.publish_neon import (
     DEFAULT_SCHEMA,
     DSN_ENV,
     LOCK_TIMEOUT,
     PROTECTED_SCHEMAS,
-    PUBLISHED_TABLES,
     RUN_COLUMNS,
     RUN_TABLE,
     SWAP_ATTEMPTS,
@@ -43,7 +44,6 @@ from build.publish_neon import (
     copy_sql,
     external_dependents,
     grant_sql,
-    infer_column_type,
     is_retryable,
     plan,
     plan_table,
@@ -65,43 +65,6 @@ ROOT = Path(__file__).resolve().parent.parent
 FAKE_DSN = "postgresql://mapuser:pw-tripwire-9f31@nowhere-tripwire.example.invalid/gapmapdb"
 
 
-# --- type inference ------------------------------------------------------------------
-
-@pytest.mark.parametrize(
-    ("name", "values", "expected"),
-    [
-        ("weight_adopt", ["0.6", "0.3", ""], "DOUBLE PRECISION"),
-        ("table_count", ["1", "12", "300"], "INTEGER"),
-        ("big", ["9999999999"], "BIGINT"),
-        ("decided_on", ["2026-08-30", ""], "DATE"),
-        ("is_mature", ["true", "false"], "BOOLEAN"),
-        ("is_mature", ["True", "FALSE"], "BOOLEAN"),
-        ("note", ["a note", ""], "TEXT"),
-        ("mixed", ["1", "one"], "TEXT"),
-        ("blank", ["", ""], "TEXT"),
-        ("almost_date", ["2026-08-30", "August"], "TEXT"),
-    ],
-)
-def test_a_column_gets_the_narrowest_type_every_value_satisfies(name, values, expected):
-    assert infer_column_type(name, values) == expected
-
-
-@pytest.mark.parametrize(
-    "name", ["slug", "product_slug", "category_slug", "artifact_id", "declaration_version_id"]
-)
-def test_identity_columns_stay_text_however_numeric_this_run_looks(name):
-    """A digits-only artifact id is a string with digits in it.
-
-    Inferring INTEGER off one run's values would change the column type from under a query
-    the first time a non-numeric id arrives.
-    """
-    assert infer_column_type(name, ["1", "2", "3"]) == "TEXT"
-
-
-def test_an_empty_column_is_text_not_a_guess():
-    assert infer_column_type("artifact_url", []) == "TEXT"
-
-
 # --- DDL ------------------------------------------------------------------------------
 
 def test_create_table_sql_names_the_schema_and_every_typed_column():
@@ -114,7 +77,10 @@ def test_create_table_sql_names_the_schema_and_every_typed_column():
 
 
 def test_copy_sql_lists_the_columns_and_reads_a_header():
-    plan = plan_table(_write_csv("products", "slug,display_name\na,A\nb,B\n"))
+    plan = plan_table(
+        _write_csv("products", "slug,display_name\na,A\nb,B\n"),
+        declared=(("slug", "VARCHAR"), ("display_name", "VARCHAR")),
+    )
     sql = copy_sql("gapmap_staging", plan)
     assert 'COPY "gapmap_staging"."products" ("slug", "display_name")' in sql
     assert "FORMAT csv, HEADER true" in sql
@@ -308,9 +274,10 @@ def _run(args: list[str], env_extra: dict[str, str] | None = None) -> subprocess
 def test_check_plans_without_a_dsn_and_prints_the_row_counts():
     result = _run(["--check"])
     assert result.returncode == 0, result.stderr
-    assert "would load" in result.stdout
+    assert f"would load {len(SITE_TABLES)} tables" in result.stdout
     assert "products" in result.stdout
     assert RUN_TABLE in result.stdout
+    assert "registry_" not in result.stdout, "Neon serves the site's tables and nothing else"
 
 
 def test_a_publish_with_no_dsn_exits_2_and_says_which_variable():
@@ -323,15 +290,7 @@ def test_a_publish_with_no_dsn_exits_2_and_says_which_variable():
 def test_no_part_of_the_dsn_ever_reaches_stdout_or_stderr(tmp_path):
     """The publish will fail — the host does not resolve — and the failure is the point:
     a libpq error quotes the host, one delimiter from the password."""
-    result = _run(
-        [
-            "--dir",
-            str(_complete_dir(tmp_path / "csv")),
-            "--site-dir",
-            str(tmp_path / "site"),
-        ],
-        {DSN_ENV: FAKE_DSN},
-    )
+    result = _run(["--site-dir", str(tmp_path / "site")], {DSN_ENV: FAKE_DSN})
     assert result.returncode == 1, result.stdout + result.stderr
     output = result.stdout + result.stderr
     for secret in (FAKE_DSN, "pw-tripwire-9f31", "nowhere-tripwire.example.invalid", "mapuser"):
@@ -339,87 +298,6 @@ def test_no_part_of_the_dsn_ever_reaches_stdout_or_stderr(tmp_path):
 
 
 # --- the table set --------------------------------------------------------------------
-
-def test_the_registry_group_is_the_set_publish_registry_publishes_to_oso():
-    """Neon and the warehouse must carry the same registry surface.
-
-    Derived from `publish_registry.TABLES`, never from a glob over the output directory: a
-    glob makes the published surface depend on which serializers happened to have run, so a
-    directory left by a partial run would quietly publish a smaller map.
-    """
-    from build.publish_registry import TABLES as OSO_TABLES
-
-    assert PUBLISHED_TABLES == OSO_TABLES
-    for name in OSO_TABLES:
-        assert f"{REGISTRY_PREFIX}{name}" in ALL_TABLES
-
-
-def test_every_serializers_tables_are_in_the_set():
-    from build.serialize_registry import TABLES as REGISTRY
-    from build.serialize_routing import TABLES as ROUTING
-    from build.serialize_rubric import TABLES as RUBRIC
-    from build.serialize_scores import TABLES as SCORES
-
-    for spec in (REGISTRY, RUBRIC, ROUTING, SCORES):
-        assert set(spec).issubset(set(PUBLISHED_TABLES))
-
-
-def test_the_two_groups_do_not_collide():
-    """Both surfaces share one schema and both have a products, a categories and an
-    organizations. The prefix is what keeps them apart."""
-    assert set(SITE_TABLES) & set(PUBLISHED_TABLES), "the overlap is the reason for the prefix"
-    assert len(set(ALL_TABLES)) == len(ALL_TABLES)
-    assert not set(SITE_TABLES) & {f"{REGISTRY_PREFIX}{n}" for n in PUBLISHED_TABLES}
-
-
-def test_a_declared_table_with_no_csv_is_reported_missing_not_skipped(tmp_path):
-    """A table is absent because a serializer has not run. Loading the rest would publish
-    a partial map that looks complete.
-
-    Into an empty directory the registry serializer's own tables are regenerated, so what is
-    left missing is the rubric, routing and scores sets — exactly the ones this module will
-    not run for you.
-    """
-    from build.serialize_registry import TABLES as OWN
-
-    plans, missing = plan(tmp_path, site_dir=tmp_path / "site")
-    loaded = {p.name for p in plans if p.name not in SITE_TABLES}
-    assert loaded == {f"{REGISTRY_PREFIX}{n}" for n in OWN}
-    assert set(missing) == {
-        f"{REGISTRY_PREFIX}{n}" for n in PUBLISHED_TABLES if n not in OWN
-    }
-    assert missing, "the other three serializers have not run, so something must be missing"
-
-
-def test_plans_come_back_in_the_declared_order_map_group_first(tmp_path):
-    """The map group loads first, so a failure in the part the site reads shows up first."""
-    plans, _missing = plan(site_dir=tmp_path / "site")
-    names = [p.name for p in plans]
-    assert names == [name for name in ALL_TABLES if name in set(names)]
-    assert names[: len(SITE_TABLES)] == list(SITE_TABLES)
-
-
-def test_a_publish_missing_a_csv_exits_2_and_names_the_serializers(tmp_path):
-    result = _run(
-        ["--dir", str(tmp_path), "--site-dir", str(tmp_path / "site")], {DSN_ENV: FAKE_DSN}
-    )
-    assert result.returncode == 2
-    assert "missing tables" in result.stderr
-    assert "serialize_scores" in result.stderr
-
-
-def _complete_dir(directory: Path) -> Path:
-    """A header-only CSV per declared registry table, so the completeness gate passes.
-
-    Header-only is a real state — a serializer emits a header for every table it declares,
-    filled or not — and it lets a test exercise what happens after planning without running
-    four serializers.
-    """
-    directory.mkdir(parents=True, exist_ok=True)
-    for name in PUBLISHED_TABLES:
-        (directory / f"{name}.csv").write_text("slug\n", encoding="utf-8")
-    return directory
-
 
 # --- enums ----------------------------------------------------------------------------
 
@@ -493,19 +371,233 @@ def test_every_relation_the_payload_actually_carries_is_mapped():
 
 # --- keys -----------------------------------------------------------------------------
 
-def test_product_ids_are_assigned_by_sorted_slug_so_a_load_is_reproducible():
-    """Surrogate ids exist for the designers' FK shape, but an id that moved between loads
-    would make a diff of two loads unreadable."""
+def test_stable_id_is_deterministic():
+    """The whole point: the same table and key give the same id on every load, forever."""
+    assert stable_id("products", "vllm") == stable_id("products", "vllm")
+    assert stable_id("products", "vllm") != stable_id("products", "sglang")
+
+
+def test_stable_id_is_scoped_to_its_table():
+    """The table name is hashed in, so a category and a product sharing a slug do not share
+    an id — a join that crosses tables by mistake matches nothing rather than working."""
+    assert stable_id("products", "olmo-3") != stable_id("categories", "olmo-3")
+    assert stable_id("categories", "evaluation") != stable_id("gaps", "evaluation")
+
+
+def test_an_id_is_a_positive_bigint_because_postgres_has_no_unsigned_integer():
+    """63 bits, not 64: keeping the top bit would make half the ids negative."""
+    for key in ("vllm", "olmo-3", "", "x" * 500, "a|b|c"):
+        ident = stable_id("products", key)
+        assert 0 <= ident < 2**63
+
+
+def test_product_ids_are_derived_from_the_slug_not_from_a_position():
     payload = load_payload()
     ids = product_ids(payload)
-    assert sorted(ids.values()) == list(range(1, len(ids) + 1))
-    assert [slug for slug, _id in sorted(ids.items(), key=lambda kv: kv[1])] == sorted(ids)
     assert product_ids(payload) == ids
+    for slug, ident in ids.items():
+        assert ident == stable_id("products", slug)
+
+
+def test_publishing_the_same_corpus_twice_gives_identical_ids():
+    """A publish that renumbered would move every id that had escaped into a URL or a cache."""
+    payload = load_payload()
+    first = build_site_tables(payload)
+    second = build_site_tables(load_payload())
+    for name, rows in first.items():
+        assert [row.get("id") for row in rows] == [row.get("id") for row in second[name]]
+
+
+def _fixture_payload(extra_slug: str | None = None) -> dict:
+    """A two-product corpus, optionally with a third product sorting before both.
+
+    Small on purpose: the property under test is that inserting a row leaves the others
+    alone, and a fixture makes the inserted row's position in the sort explicit.
+    """
+    products = [
+        {
+            "slug": "mid-product",
+            "product": "Mid",
+            "org_slug": "acme",
+            "type": "model",
+            "openness": {"score": 3, "sources": [{"url": "https://example.test/mid"}]},
+            "lineage": {"derived_from": ["some-base"]},
+        },
+        {"slug": "zeta-product", "product": "Zeta", "org_slug": "acme", "type": "model"},
+    ]
+    if extra_slug:
+        products.insert(0, {"slug": extra_slug, "product": "New", "org_slug": "acme", "type": "model"})
+    return {
+        "generated": "2026-09-04",
+        "order": ["a_category"],
+        "layer_order": ["model_components"],
+        "categories": {
+            "a_category": {
+                "label": "A Category",
+                "arc": "build",
+                "layer": "model_components",
+                "stage": {"num": 2},
+                "gaps": [],
+                "products": products,
+            }
+        },
+        "descriptions": {"categories": {}, "gaps": {}, "stages": {}},
+        "organizations": {"acme": {"display_name": "Acme", "type": "company"}},
+        "aliases": {},
+        "long_tail": {"top": [{"name": "Tail One"}], "counts": {"model": 1}},
+    }
+
+
+def test_inserting_a_product_alphabetically_first_moves_no_existing_id():
+    """The bug this replaces: ids were positions in a sorted slug list, so adding one product
+    renumbered every row after it and any id in a URL, a cache or a CMS row pointed at a
+    different product after the next publish."""
+    before = build_site_tables(_fixture_payload())
+    after = build_site_tables(_fixture_payload(extra_slug="aaa-new-product"))
+
+    for name, rows in before.items():
+        keyed = {row.get("id"): row for row in rows if row.get("id") is not None}
+        after_ids = {row.get("id") for row in after[name]}
+        for ident, row in keyed.items():
+            assert ident in after_ids, f"{name}: {row} was renumbered by the insertion"
+
+    products_before = {row["slug"]: row["id"] for row in before["products"]}
+    products_after = {row["slug"]: row["id"] for row in after["products"]}
+    assert products_before.items() <= products_after.items()
+    assert set(products_after) - set(products_before) == {"aaa-new-product"}
+
+
+def test_the_foreign_keys_in_a_fixture_corpus_resolve_to_the_hashed_parents():
+    """The FKs are the reason the ids have to move together: a child row hashed from one key
+    and a parent from another would produce a dangling reference the COPY would reject."""
+    tables = build_site_tables(_fixture_payload())
+    assert {row["category"] for row in tables["products"]} == {
+        stable_id("categories", "a_category")
+    }
+    assert {row["layer"] for row in tables["categories"]} == {
+        stable_id("layers", "model_components")
+    }
+    assert {row["stage"] for row in tables["categories"]} == {stable_id("stages", "2")}
+    mid = stable_id("products", "mid-product")
+    assert {row["product_id"] for row in tables["openness"]} == {
+        mid,
+        stable_id("products", "zeta-product"),
+    }
+    assert [row["product_id"] for row in tables["sources"]] == [mid]
+    assert [row["id"] for row in tables["sources"]] == [
+        stable_id("sources", "mid-product|openness|https://example.test/mid")
+    ]
+    assert [row["id"] for row in tables["product_lineage"]] == [
+        stable_id("product_lineage", "mid-product|derived_from|some-base")
+    ]
+    assert [row["id"] for row in tables["long_tail_top"]] == [
+        stable_id("long_tail_top", "Tail One")
+    ]
+
+
+def test_a_repeated_source_url_still_gets_an_id_of_its_own():
+    """A product can list the same URL twice on the same axis, and both rows need a key."""
+    payload = _fixture_payload()
+    product = payload["categories"]["a_category"]["products"][0]
+    product["openness"]["sources"] = [
+        {"url": "https://example.test/mid"},
+        {"url": "https://example.test/mid"},
+    ]
+    ids = [row["id"] for row in build_site_tables(payload)["sources"]]
+    assert len(set(ids)) == 2
+    assert ids[0] == stable_id("sources", "mid-product|openness|https://example.test/mid")
+    assert ids[1] == stable_id("sources", "mid-product|openness|https://example.test/mid#2")
+
+
+@pytest.mark.parametrize(
+    "table",
+    [name for name, spec in SITE_TABLES.items() if "id" in dict(spec.columns)],
+)
+def test_every_id_column_is_a_bigint(table):
+    """63-bit ids do not fit an INTEGER. The departure from the designers' `integer` is
+    deliberate and is recorded in docs/reference/where-scores-live.md."""
+    assert dict(SITE_TABLES[table].columns)["id"].startswith("BIGINT")
+
+
+@pytest.mark.parametrize(
+    "table,column",
+    [
+        ("categories", "layer"),
+        ("categories", "stage"),
+        ("gaps_categories", "cat_id"),
+        ("gaps_categories", "gap_id"),
+        ("products", "category"),
+        ("openness", "product_id"),
+        ("adoption", "product_id"),
+        ("capability", "product_id"),
+        ("sources", "product_id"),
+        ("product_lineage", "product_id"),
+    ],
+)
+def test_every_foreign_key_column_is_a_bigint_too(table, column):
+    """A narrower child column than its parent would reject the very ids it references."""
+    assert dict(SITE_TABLES[table].columns)[column].startswith("BIGINT")
+
+
+def test_a_collision_fails_the_build_naming_the_table_and_both_keys(monkeypatch):
+    """Two natural keys on one id would be rejected by the primary key at COPY time, in a
+    message naming neither. This stops first, with both in hand."""
+    real = build.neon_schema.stable_id
+    monkeypatch.setattr(
+        build.neon_schema,
+        "stable_id",
+        lambda table, key: 7 if table == "products" else real(table, key),
+    )
+    with pytest.raises(IdCollision) as error:
+        build_site_tables(_fixture_payload())
+    message = str(error.value)
+    assert "products" in message
+    assert "mid-product" in message and "zeta-product" in message
+
+
+def test_a_collision_exits_the_publisher_with_1(monkeypatch, tmp_path, capsys):
+    """A collision must not reach the COPY. `plan` renders the map group's CSVs, so the guard
+    runs before anything connects — on a `--check` as well as on a publish."""
+    import build.publish_neon as publisher
+
+    monkeypatch.setattr(build.neon_schema, "stable_id", lambda table, key: 7)
+    with pytest.raises(IdCollision):
+        plan(site_dir=tmp_path / "site")
+
+    monkeypatch.setattr(
+        sys, "argv", ["publish_neon", "--check", "--site-dir", str(tmp_path / "cli")]
+    )
+    assert publisher.main() == 1
+    assert "id collision" in capsys.readouterr().err
+
+
+def test_the_ordinal_the_id_used_to_carry_kept_a_column_of_its_own():
+    """`layers.id`, `categories.id`, `stages.id` and `long_tail_top.id` were positions, and
+    three of those positions meant something. A hash carries none of it."""
+    payload = load_payload()
+    tables = build_site_tables(payload)
+    assert [row["sort_order"] for row in tables["layers"]] == list(
+        range(1, len(payload["layer_order"]) + 1)
+    )
+    assert [row["sort_order"] for row in tables["categories"]] == list(
+        range(1, len(payload["order"]) + 1)
+    )
+    assert [row["slug"] for row in tables["categories"]] == list(payload["order"])
+    assert [row["num"] for row in tables["stages"]] == sorted(row["num"] for row in tables["stages"])
+    assert [row["sort_order"] for row in tables["long_tail_top"]] == list(
+        range(1, len(tables["long_tail_top"]) + 1)
+    )
+
+
+def test_the_schema_version_records_the_id_change():
+    """No migration tool: the swap rebuilds the schema, so `publish_runs.schema_version` is
+    how a reader tells positional ids from hashed ones."""
+    assert SCHEMA_VERSION >= 3
 
 
 def test_categories_carry_a_slug_the_pdf_omitted():
-    """Every deep link and every join from the registry group is by slug, and an id assigned
-    by curated order changes whenever the order does."""
+    """Every deep link is by slug, and the id it sits beside is a hash rather than something
+    a person can read."""
     assert "slug" in dict(SITE_TABLES["categories"].columns)
 
 
@@ -678,9 +770,10 @@ def test_the_awkward_value_survives_a_full_csv_round_trip():
 
 
 def test_the_embedded_newline_is_not_counted_as_an_extra_row():
-    plan_ = plan_table(_write_csv("awkward", _AWKWARD))
+    plan_ = plan_table(
+        _write_csv("awkward", _AWKWARD), declared=(("slug", "VARCHAR"), ("note", "TEXT"))
+    )
     assert plan_.row_count == 1
-    assert dict(plan_.columns)["note"] == "TEXT"
 
 
 # --- the read-back query --------------------------------------------------------------
@@ -1041,18 +1134,20 @@ def test_every_not_null_the_dbml_declares_is_in_the_generated_ddl(table, column)
     assert f'"{column}"' in sql
 
 
-def test_no_constraint_is_declared_for_the_registry_group(tmp_path):
-    """The serializers declare column names only, so there is nothing to derive a key from,
-    and inventing one would be this module guessing at another module's grain.
+def test_every_planned_table_is_one_the_schema_module_declares(tmp_path):
+    """Neon serves the site's tables and nothing else. The registry surface lives in the
+    warehouse as `currentai.registry.*` and in `build/registry/*.csv`.
 
-    `site_dir` is a tmp path because `plan` renders the map group's CSVs: writing them into
-    the real `build/neon/` would race the `--check` subprocess test under `-n 4`, and the
-    loser reads a half-written header.
+    `site_dir` is a tmp path because `plan` renders the CSVs: writing them into the real
+    `build/neon/` would race the `--check` subprocess test under `-n 4`, and the loser reads
+    a half-written header.
     """
-    plans, _missing = plan(site_dir=tmp_path / "site")
+    plans, missing = plan(site_dir=tmp_path / "site")
+    assert [plan_.name for plan_ in plans] == list(SITE_TABLES)
+    assert missing == []
     for plan_ in plans:
-        if plan_.name not in SITE_TABLES:
-            assert plan_.constraints == ()
+        assert plan_.columns == SITE_TABLES[plan_.name].columns
+        assert plan_.constraints == SITE_TABLES[plan_.name].constraints
 
 
 def test_a_foreign_key_target_is_qualified_with_the_schema_being_built():
@@ -1104,22 +1199,26 @@ def _write_csv(name: str, text: str) -> Path:
     return path
 
 
+_DECLARED = (("slug", "VARCHAR"), ("label", "VARCHAR"))
+
+
 def test_plan_table_reads_the_header_and_counts_data_rows_only():
-    plan = plan_table(_write_csv("categories", "slug,weight_adopt\na,0.6\nb,0.3\n"))
+    plan = plan_table(_write_csv("categories", "slug,label\na,A\nb,B\n"), declared=_DECLARED)
     assert plan.name == "categories"
     assert plan.row_count == 2
-    assert plan.columns == (("slug", "TEXT"), ("weight_adopt", "DOUBLE PRECISION"))
+    assert plan.columns == _DECLARED
 
 
 def test_a_header_only_csv_plans_as_a_real_table_with_no_rows():
-    """A serializer emits a header for every table it declares, filled or not."""
-    plan = plan_table(_write_csv("tail_products", "slug,artifact_id\n"))
+    """An empty table is loaded as an empty table: a serving layer that answers "no rows" is
+    better than one that answers "no such table"."""
+    plan = plan_table(_write_csv("empty", "slug,label\n"), declared=_DECLARED)
     assert plan.row_count == 0
-    assert plan.columns == (("slug", "TEXT"), ("artifact_id", "TEXT"))
+    assert plan.columns == _DECLARED
 
 
-def test_a_short_row_does_not_shift_a_columns_inferred_type():
-    """csv tolerates a row with missing trailing fields; the absent value is empty, not
-    the next column's."""
-    plan = plan_table(_write_csv("ragged", "a,b\n1,2\n3\n"))
-    assert dict(plan.columns)["b"] == "INTEGER"
+def test_a_header_that_has_drifted_from_the_declared_columns_is_refused():
+    """A spec that no longer describes its CSV would COPY values into the wrong columns,
+    which Postgres accepts wherever the types happen to line up."""
+    with pytest.raises(ValueError, match="does not match the declared columns"):
+        plan_table(_write_csv("drifted", "slug,name\na,A\n"), declared=_DECLARED)


### PR DESCRIPTION
## The problem

`id` on every Neon map table was a position: `products.id` was the rank of the slug in a sorted
list, `categories.id` the position in the curated order, `sources.id` a running counter over a
walk. Adding one product renumbered every row after it. Any id that had escaped into a URL, a
cache or a CMS reference pointed at a different row after the next publish, and nothing would
have raised.

## The hash

`build/neon_schema.stable_id(table, key)` — the first 63 bits of `sha256("<table>:<key>")`, as a
positive integer. Two properties, and it exists for both:

1. **Stable across loads.** The same table and key always give the same id, so adding or removing
   a row renumbers nothing else.
2. **Scoped to the table.** The table name is hashed in, so the same slug in two tables gets two
   different ids and a join that crosses tables by mistake matches nothing instead of appearing
   to work.

Natural keys: `products.slug`, `categories.slug`, `layers` and `gaps` by their label, `stages` by
their stage number, `long_tail_top` by its name, `product_lineage` by `(product_slug, relation,
target)`, `sources` by `(product_slug, metric, url, shows, accessed)`. `organizations` keys on
`slug` and `aliases` on `alias`, with no surrogate at all.

### Why a source is keyed by the observation, not the URL

The URL alone does not identify the row. One source list can hold the same URL twice on the same
axis — 69 pairs in today's corpus — and every one of those pairs is a re-verification that
recorded a different claim or a different date. They are two observations of one page.

An earlier revision of this PR keyed on `(product_slug, metric, url)` and numbered the repeats.
Review showed that shipped a worse failure than the positional scheme it replaced: the numbering
is by walk position, so deleting the earlier of a pair promotes the later one into the un-suffixed
key and **hands it the deleted row's id**. Anything holding the old id then resolves to a row with
a different claim and a different date, and no gate fires, because the ids are still unique. The
positional scheme at least renumbered visibly and en masse.

With `shows` and `accessed` in the key, none of the 3,496 source rows collide;
`test_the_disambiguator_never_fires_on_the_real_corpus` asserts that against the real payload, and
`_disambiguate` stays only as a guard against a future corpus. Two consequences, both intended:
editing a source's `shows` or `accessed` moves that row's id (it is a different observation, and
the module's rule is that an id moves when its natural key does), and the key is order-independent
— reordering a source list or deleting a sibling leaves every other row alone.

## The bigint departure

63 bits do not fit an `integer`, so `id` and every column referencing one are `bigint` where the
designers' model says `integer`. 63 rather than 64 because Postgres has no unsigned integer type
and the top bit would make half the ids negative. Recorded in
`docs/reference/where-scores-live.md` alongside the existing `categories.slug` and gallery notes.

**The slug is still the canonical identity.** A stable id is safe as an internal reference, but a
link, a bookmark, a CMS row or anything another system stores should carry the slug. The id is a
join key and it moves if the natural key it is derived from ever changes.

## The ordinal the ids used to carry

`layers.id`, `categories.id`, `stages.id` and `long_tail_top.id` were positions, and each of those
positions carried something:

| Column | What the old id was |
|---|---|
| `layers.sort_order` | `enumerate(payload["layer_order"])` — the stack position, bottom first |
| `categories.sort_order` | `enumerate(payload["order"])` — the map's curated order |
| `long_tail_top.sort_order` | `enumerate(long_tail["top"])` — the ranking |
| `stages.num` | the stage number itself; `categories.stage` *was* the number, and `stages.id` was the number it pointed at |

A hash carries none of it, and the designers' model has nowhere else to put it: the DBML declares
`layers {id, label}`, `stages {id, label, desc}`, and no ordering field on `categories` or
`long_tail_top`. Drop the information and a consumer cannot render the stack bottom-up, cannot
reproduce the curated order, cannot rank the tail, and cannot say which stage "Stage 3" is —
`stages.label` is a display name and the `descriptions.stages` legend keys on the number the table
would no longer hold.

So four columns the designers' model does not declare. **Nothing reads Neon today** — the front
end still consumes `notebook_data.json` — so this is preservation for the consumer that comes
next, not a fix for a live break. It is worth doing now because a publish that drops the
information destroys it, and carrying it costs four integers per row. `ORDER BY sort_order` is
what `ORDER BY id` used to mean.

## The collision guard

`_id_map` refuses two different natural keys on one id, naming the table and both keys, and
`check_ids_unique` runs over the built rows as a backstop before anything is written. It keys off
each table's declared `PRIMARY KEY` rather than off a column named `id`, so the four whose key is
`product_id`, `slug` or `alias` are covered too; the two the DBML gives no key are the only ones
exempt. A collision fails the publish with exit 1 rather than reaching the COPY, where the primary
key would reject one row in a message naming neither. Tested by monkeypatching `stable_id` to a
constant, and by duplicating a row on each non-`id` key.

`publish_runs.schema_version` is 3.

## Also here: the registry tables are out of Neon

The `registry_*` tables were loaded so Neon and the warehouse would carry the same declarations.
Nothing on the site read them and the designers never asked for them, so they are gone. Neon holds
the 15 site tables from the target model plus `publish_runs`; the registry surface stays in the
warehouse as `currentai.registry.*` and on disk as `build/registry/*.csv`. That also removes the
column-type inference path, which existed only for that group — every column's type is declared
now.

`--check` goes from 41 tables to 15.

## Live verification

Three `workflow_dispatch` runs of `registry.yml` on this branch (Neon-only by design). The step
summaries are identical apart from `run_id`, `published_at` and `source_git_sha`, which are
per-run by construction. Runs 1 and 2 are the original commit; run 3 is the review fix, and the
counts did not move.

### Run 1 — [33922814108](https://github.com/currentai-org/os-ai-map/actions/runs/33922814108)

```
### `os-ai-map` tables after the load

| table | rows |
|---|---:|
| `adoption` | 615 |
| `aliases` | 65 |
| `capability` | 615 |
| `categories` | 18 |
| `gaps` | 6 |
| `gaps_categories` | 16 |
| `layers` | 3 |
| `long_tail_counts` | 9 |
| `long_tail_top` | 37 |
| `openness` | 615 |
| `organizations` | 347 |
| `product_lineage` | 175 |
| `products` | 615 |
| `publish_runs` | 1 |
| `sources` | 3,496 |
| `stages` | 6 |

16 tables, 6,638 rows outside `publish_runs`.

### Constraints in `os-ai-map` — 27 total

| constraint | count |
|---|---:|
| FOREIGN KEY | 11 |
| PRIMARY KEY | 13 |
| UNIQUE | 3 |

### `os-ai-map.publish_runs` — 1 row(s), newest first

| published_at | run_id | schema_version | built_at | released_at | source_git_sha | tables |
|---|---|---:|---|---|---|---:|
| 2026-09-04 21:49:45Z | `ab0ef6c1f299` | 3 | 2026-09-04 | 2026-08-16 | `e7668e34151b` | 15 |
```

### Run 2 — [33922889930](https://github.com/currentai-org/os-ai-map/actions/runs/33922889930)

```
### `os-ai-map` tables after the load

| table | rows |
|---|---:|
| `adoption` | 615 |
| `aliases` | 65 |
| `capability` | 615 |
| `categories` | 18 |
| `gaps` | 6 |
| `gaps_categories` | 16 |
| `layers` | 3 |
| `long_tail_counts` | 9 |
| `long_tail_top` | 37 |
| `openness` | 615 |
| `organizations` | 347 |
| `product_lineage` | 175 |
| `products` | 615 |
| `publish_runs` | 1 |
| `sources` | 3,496 |
| `stages` | 6 |

16 tables, 6,638 rows outside `publish_runs`.

### Constraints in `os-ai-map` — 27 total

| constraint | count |
|---|---:|
| FOREIGN KEY | 11 |
| PRIMARY KEY | 13 |
| UNIQUE | 3 |

### `os-ai-map.publish_runs` — 1 row(s), newest first

| published_at | run_id | schema_version | built_at | released_at | source_git_sha | tables |
|---|---|---:|---|---|---|---:|
| 2026-09-04 21:50:48Z | `d270a648b0de` | 3 | 2026-09-04 | 2026-08-16 | `e7668e34151b` | 15 |
```

### Run 3 — [33924189850](https://github.com/currentai-org/os-ai-map/actions/runs/33924189850), after the review fix

Same 16 tables and 6,638 rows outside `publish_runs`; same 27 constraints (11 FOREIGN KEY,
13 PRIMARY KEY, 3 UNIQUE); `sources` still 3,496 rows, which is the check that widening the key
neither dropped nor split a row.

```
| published_at | run_id | schema_version | built_at | released_at | source_git_sha | tables |
|---|---|---:|---|---|---|---:|
| 2026-09-04 22:08:41Z | `2f345abc5316` | 3 | 2026-09-04 | 2026-08-16 | `0b1ec28dff03` | 15 |
```

### A pinned id, so a later run can be compared

The step summary reports counts, not ids, so here is one to check against. `vllm`:

```
os-ai-map.products.id = 2161542275971214610
```

That is `stable_id("products", "vllm")` and it is what the load writes. Any future publish, with
any corpus, must show the same number for that row — and `stable_id("categories", "vllm")` would
be a different number, which is the table-scoping property.

## Test plan

- `uv run pytest tests/test_publish_neon.py tests/test_registry_triggers.py tests/test_schedule_doc.py tests/test_docs_integrity.py -q -n 4` — 189 passed
- `uv run python -m build.publish_neon --check` — 15 tables, 27 constraints, 5 enums
- `uv run pytest -q -n 4 -m "not serial"` — 1830 passed
- All three dispatches above, green, with the same counts

New tests cover: `stable_id` determinism and table scoping; the id fits a positive bigint; the
same corpus published twice yields identical ids; a product inserted alphabetically before the
others moves no existing id; the foreign keys resolve to the hashed parents in a fixture corpus;
the same URL read twice is two observations with two ids; deleting one re-verification leaves the
other's id alone; `_disambiguate` fires on nothing in the real corpus; every id and FK column is
BIGINT in the DDL; the collision guard raises on each non-`id` primary key and the CLI exits 1; a
keyless table is skipped rather than half-scanned; a missing payload reports every table pending
and the publish exits 2; the ordinal columns carry what the ids used to.

Refs #365
CUR-511
