### PR TITLE
identity: adopt 51 first-party Hugging Face handles (#483)

### DIFF
--- a/sources/org_handles.yaml
+++ b/sources/org_handles.yaml
@@ -3,6 +3,9 @@ handles:
 - org: 01-ai
   platform: homepage_domain
   handle: 01.ai
+- org: 01-ai
+  platform: huggingface
+  handle: 01-ai
 - org: 4paradigm
   platform: github
   handle: 4paradigm
@@ -36,6 +39,9 @@ handles:
 - org: ai21-labs
   platform: homepage_domain
   handle: ai21.com
+- org: ai21-labs
+  platform: huggingface
+  handle: ai21labs
 - org: aider-ai
   platform: github
   handle: aider-ai
@@ -48,6 +54,9 @@ handles:
 - org: alibaba-cloud
   platform: homepage_domain
   handle: alibabacloud.com
+- org: alibaba-cloud
+  platform: huggingface
+  handle: Qwen
 - org: all-hands-ai
   platform: github
   handle: all-hands-ai
@@ -75,6 +84,9 @@ handles:
   platform: homepage_domain
   handle: anthropic.com
   note: shared with anthropic-internal, the internal/eval record; anthropic is the public org
+- org: anthropic
+  platform: huggingface
+  handle: Anthropic
 - org: antirez
   platform: github
   handle: antirez
@@ -147,6 +159,9 @@ handles:
 - org: barcelona-supercomputing-center
   platform: homepage_domain
   handle: bsc.es
+- org: barcelona-supercomputing-center
+  platform: huggingface
+  handle: BSC-LT
 - org: beam-cloud
   platform: github
   handle: beam-cloud
@@ -165,6 +180,9 @@ handles:
 - org: bigcode-project
   platform: homepage_domain
   handle: bigcode-project.org
+- org: bigcode-project
+  platform: huggingface
+  handle: bigcode
 - org: bitsandbytes-foundation
   platform: github
   handle: bitsandbytes-foundation
@@ -201,6 +219,9 @@ handles:
 - org: bytedance-seed-volcano-engine
   platform: homepage_domain
   handle: volcengine.com
+- org: bytedance-seed-volcano-engine
+  platform: huggingface
+  handle: ByteDance-Seed
 - org: center-for-ai-safety
   platform: github
   handle: centerforaisafety
@@ -243,6 +264,9 @@ handles:
 - org: cohere
   platform: homepage_domain
   handle: cohere.com
+- org: cohere
+  platform: huggingface
+  handle: CohereLabs
 - org: comet-ml
   platform: github
   handle: comet-ml
@@ -333,6 +357,9 @@ handles:
 - org: deepseek
   platform: homepage_domain
   handle: deepseek.com
+- org: deepseek
+  platform: huggingface
+  handle: deepseek-ai
 - org: deepset
   platform: github
   handle: deepset-ai
@@ -466,12 +493,18 @@ handles:
 - org: google
   platform: homepage_domain
   handle: google.com
+- org: google
+  platform: huggingface
+  handle: google
 - org: google-cloud
   platform: homepage_domain
   handle: cloud.google.com
 - org: google-research
   platform: homepage_domain
   handle: research.google
+- org: google-research
+  platform: huggingface
+  handle: google-research-datasets
 - org: groq
   platform: homepage_domain
   handle: groq.com
@@ -511,9 +544,21 @@ handles:
 - org: hugging-face
   platform: github
   handle: huggingface
+- org: hugging-face
+  platform: huggingface
+  handle: HuggingFaceFW
+- org: hugging-face
+  platform: huggingface
+  handle: HuggingFaceH4
+- org: hugging-face
+  platform: huggingface
+  handle: HuggingFaceTB
 - org: ibm
   platform: homepage_domain
   handle: ibm.com
+- org: ibm
+  platform: huggingface
+  handle: ibm-granite
 - org: inclusion-ai
   platform: github
   handle: inclusionAI
@@ -679,8 +724,14 @@ handles:
 - org: livebench
   platform: homepage_domain
   handle: livebench.ai
+- org: livebench
+  platform: huggingface
+  handle: livebench
 - org: livecodebench-team
   platform: github
+  handle: livecodebench
+- org: livecodebench-team
+  platform: huggingface
   handle: livecodebench
 - org: llamaindex
   platform: github
@@ -700,6 +751,9 @@ handles:
 - org: llm360
   platform: homepage_domain
   handle: llm360.ai
+- org: llm360
+  platform: huggingface
+  handle: LLM360
 - org: lm-studio
   platform: github
   handle: lmstudio-ai
@@ -757,18 +811,30 @@ handles:
 - org: meta
   platform: homepage_domain
   handle: meta.com
+- org: meta
+  platform: huggingface
+  handle: meta-llama
 - org: microsoft
   platform: github
   handle: microsoft
 - org: microsoft
   platform: homepage_domain
   handle: microsoft.com
+- org: microsoft
+  platform: huggingface
+  handle: microsoft
 - org: microsoft-azure
   platform: homepage_domain
   handle: azure.microsoft.com
 - org: minimax
   platform: homepage_domain
   handle: minimax.io
+- org: minimax
+  platform: huggingface
+  handle: MiniMaxAI
+- org: ministere-culture
+  platform: huggingface
+  handle: ministere-culture
 - org: mintplex-labs
   platform: github
   handle: mintplex-labs
@@ -785,12 +851,18 @@ handles:
   platform: homepage_domain
   handle: mistral.ai
   note: shared with mistral-ai-api, a flagged merge candidate; mistral-ai is the canonical org
+- org: mistral-ai
+  platform: huggingface
+  handle: mistralai
 - org: mit-han-lab
   platform: github
   handle: mit-han-lab
 - org: mit-han-lab
   platform: homepage_domain
   handle: hanlab.mit.edu
+- org: ml-foundations
+  platform: huggingface
+  handle: mlfoundations
 - org: mlc-ai
   platform: github
   handle: mlc-ai
@@ -827,6 +899,9 @@ handles:
 - org: moonshot-ai
   platform: homepage_domain
   handle: moonshot.ai
+- org: moonshot-ai
+  platform: huggingface
+  handle: moonshotai
 - org: morphic
   platform: github
   handle: miurla
@@ -881,6 +956,9 @@ handles:
 - org: northeastern-university-brown-wellesley
   platform: github
   handle: nuprl
+- org: northeastern-university-brown-wellesley
+  platform: huggingface
+  handle: nuprl
 - org: northflank
   platform: homepage_domain
   handle: northflank.com
@@ -896,12 +974,18 @@ handles:
 - org: nous-research
   platform: homepage_domain
   handle: nousresearch.com
+- org: nous-research
+  platform: huggingface
+  handle: NousResearch
 - org: nvidia
   platform: github
   handle: nvidia
 - org: nvidia
   platform: homepage_domain
   handle: nvidia.com
+- org: nvidia
+  platform: huggingface
+  handle: nvidia
 - org: nx-ai
   platform: github
   handle: NX-AI
@@ -920,10 +1004,16 @@ handles:
 - org: onnxsim
   platform: github
   handle: onnxsim
+- org: open-thoughts
+  platform: huggingface
+  handle: open-thoughts
 - org: open-web-math
   platform: github
   handle: keirp
   note: derived from a repo-level GitHub URL, not an account page
+- org: open-web-math
+  platform: huggingface
+  handle: open-web-math
 - org: open-webui
   platform: github
   handle: open-webui
@@ -937,6 +1027,9 @@ handles:
   platform: homepage_domain
   handle: openai.com
   note: shared with openai-internal, the internal/eval record; openai is the public org
+- org: openai
+  platform: huggingface
+  handle: openai
 - org: openassistant
   platform: github
   handle: LAION-AI
@@ -944,6 +1037,12 @@ handles:
 - org: openassistant
   platform: homepage_domain
   handle: open-assistant.io
+- org: openassistant
+  platform: huggingface
+  handle: OpenAssistant
+- org: openbmb
+  platform: huggingface
+  handle: openbmb
 - org: openclaw
   platform: github
   handle: openclaw
@@ -958,6 +1057,9 @@ handles:
   handle: opencompass.org.cn
 - org: openguardrails
   platform: github
+  handle: openguardrails
+- org: openguardrails
+  platform: huggingface
   handle: openguardrails
 - org: openinfra-foundation
   platform: github
@@ -1004,6 +1106,9 @@ handles:
 - org: oramasearch
   platform: homepage_domain
   handle: orama.com
+- org: oscar-corpus
+  platform: huggingface
+  handle: oscar-corpus
 - org: ostris
   platform: github
   handle: ostris
@@ -1052,6 +1157,9 @@ handles:
 - org: pixeltable
   platform: homepage_domain
   handle: docs.pixeltable.com
+- org: pleias
+  platform: huggingface
+  handle: PleIAs
 - org: predibase
   platform: github
   handle: predibase
@@ -1072,6 +1180,9 @@ handles:
   platform: homepage_domain
   handle: nlp.cs.princeton.edu
   note: shared with princeton-nlp-openai, a collaboration record; princeton-nlp is the lab's own org
+- org: princeton-nlp-openai
+  platform: huggingface
+  handle: princeton-nlp
 - org: promptfoo
   platform: github
   handle: promptfoo
@@ -1159,6 +1270,9 @@ handles:
 - org: rwkv
   platform: homepage_domain
   handle: rwkv.com
+- org: rwkv
+  platform: huggingface
+  handle: RWKV
 - org: sambanova-systems
   platform: homepage_domain
   handle: sambanova.ai
@@ -1183,9 +1297,15 @@ handles:
 - org: sglang-lmsys-uc-berkeley
   platform: github
   handle: sgl-project
+- org: sglang-lmsys-uc-berkeley
+  platform: huggingface
+  handle: lmsys
 - org: shanghai-ai-laboratory
   platform: homepage_domain
   handle: shlab.org.cn
+- org: shanghai-ai-laboratory
+  platform: huggingface
+  handle: internlm
 - org: sierra
   platform: github
   handle: sierra-research
@@ -1246,6 +1366,9 @@ handles:
 - org: swiss-ai-initiative
   platform: homepage_domain
   handle: swiss-ai.org
+- org: swiss-ai-initiative
+  platform: huggingface
+  handle: swiss-ai
 - org: tatsu-lab
   platform: github
   handle: tatsu-lab
@@ -1255,6 +1378,12 @@ handles:
 - org: technology-innovation-institute
   platform: homepage_domain
   handle: tii.ae
+- org: technology-innovation-institute
+  platform: huggingface
+  handle: tiiuae
+- org: teknium
+  platform: huggingface
+  handle: teknium
 - org: tencent
   platform: github
   handle: Tencent
@@ -1282,6 +1411,9 @@ handles:
 - org: thinking-machines-lab
   platform: homepage_domain
   handle: thinkingmachines.ai
+- org: thinking-machines-lab
+  platform: huggingface
+  handle: thinkingmachines
 - org: thu-ml
   platform: github
   handle: thu-ml
@@ -1294,9 +1426,18 @@ handles:
 - org: tiger-data
   platform: homepage_domain
   handle: tigerdata.com
+- org: tiger-lab
+  platform: huggingface
+  handle: TIGER-Lab
+- org: tinyllama
+  platform: huggingface
+  handle: TinyLlama
 - org: together-ai
   platform: homepage_domain
   handle: together.ai
+- org: together-ai
+  platform: huggingface
+  handle: togethercomputer
 - org: traccia-ai
   platform: github
   handle: traccia-ai
@@ -1339,6 +1480,9 @@ handles:
 - org: unum-cloud
   platform: homepage_domain
   handle: unum.cloud
+- org: uonlp
+  platform: huggingface
+  handle: uonlp
 - org: upstash
   platform: github
   handle: upstash
@@ -1411,6 +1555,9 @@ handles:
 - org: xiaomi
   platform: homepage_domain
   handle: mimo.xiaomi.com
+- org: xiaomi
+  platform: huggingface
+  handle: XiaomiMiMo
 - org: xlang-ai-lab
   platform: github
   handle: xlang-ai
@@ -1432,9 +1579,15 @@ handles:
 - org: zentropi
   platform: homepage_domain
   handle: zentropi.ai
+- org: zentropi
+  platform: huggingface
+  handle: zentropi-ai
 - org: zhipu-z-ai
   platform: homepage_domain
   handle: z.ai
+- org: zhipu-z-ai
+  platform: huggingface
+  handle: zai-org
 - org: zilliz
   platform: github
   handle: milvus-io

--- a/sources/org_handles.yaml
+++ b/sources/org_handles.yaml
@@ -1180,9 +1180,10 @@ handles:
   platform: homepage_domain
   handle: nlp.cs.princeton.edu
   note: shared with princeton-nlp-openai, a collaboration record; princeton-nlp is the lab's own org
-- org: princeton-nlp-openai
+- org: princeton-nlp
   platform: huggingface
   handle: princeton-nlp
+  note: shared with princeton-nlp-openai, a collaboration record; princeton-nlp is the lab's own org
 - org: promptfoo
   platform: github
   handle: promptfoo


### PR DESCRIPTION
## What

Two-pass review of the 69 Hugging Face handle proposals in #483. A handle asserts that an organization **publishes under** an account, so I adopt the ones where the account is the org's own official account and hold the rest — dataset hosting, collaboration, benchmark maintenance, or a mirror is not ownership. **Adds 51 handle rows** to `sources/org_handles.yaml`; nothing else changes.

**Coverage:** Hugging Face org coverage rises **2/62 → 51/62** with org-resolution **precision unchanged at 1.000**. The eleven still-uncovered orgs are the held cases below, plus `princeton-nlp-openai` — intentionally uncovered because the shared `princeton-nlp` account belongs to the canonical `princeton-nlp` org (see the shared-account note under Adopted). `github` (211/299) and `homepage` (6/27) coverage unchanged. The 52→51 step after the Princeton correction is a data-quality improvement, not a regression: the metric should never turn a shared account into a second org's ownership claim.

## Adopted (51)

The obvious first-party namespaces — `Qwen`, `Anthropic`, `deepseek-ai`, `google`, `meta-llama`, `microsoft`, `nvidia`, `openai`, `mistralai`, `CohereLabs`, `ByteDance-Seed`, `ibm-granite`, `MiniMaxAI`, `moonshotai`, `openbmb`, `PleIAs`, `swiss-ai`, `thinkingmachines`, `01-ai`, `ai21labs`, `LLM360`, `bigcode`, `HuggingFaceFW/H4/TB`, `google-research-datasets`, `ministere-culture` — plus the benchmark/lab accounts that are unambiguously their org's own: `livebench`, `livecodebench`, `TIGER-Lab`, `lmsys`, `nuprl`, `NousResearch`, `open-thoughts`, `open-web-math`, `oscar-corpus`, `OpenAssistant`, `openguardrails`, `uonlp`, `teknium`, `TinyLlama`, `mlfoundations`, `XiaomiMiMo`, `zentropi-ai`, `RWKV`.

Included despite a name that doesn't string-match the org, because the account is unmistakably first-party (the same case as `Qwen ← alibaba-cloud`): `tiiuae ← technology-innovation-institute`, `togethercomputer ← together-ai`, `internlm ← shanghai-ai-laboratory`, `zai-org ← zhipu-z-ai`, `BSC-LT ← barcelona-supercomputing-center`.

**Shared account:** the HF `princeton-nlp` handle is assigned to the canonical org `princeton-nlp` (which already owns the GitHub and domain handles), with `princeton-nlp-openai` recorded as a collaboration record in a note — not to `princeton-nlp-openai`, which would let one shared account read as independently owned by a second org record.

## Held (18) — for a human ruling

Person / secondary / benchmark / consortium / hosting accounts, or the org is `unknown`:

| proposal | why held |
|---|---|
| `Rowan → allen-institute-for-ai` | personal account (hosts HellaSwag), not AI2's org account |
| `common-pile → eleutherai` | collaborative project account; EleutherAI's own is `EleutherAI` (itself a flagged multi-org conflict) |
| `deepmind → google` | one hosted dataset; DeepMind is its own entity and `google` already covers Google |
| `ai2-adapt-dev → google-research` | looks mis-attributed — this is an Allen AI dev account, not Google Research |
| `codeparrot → hendrycks-et-al-uc-berkeley` | community/course account hosting APPS |
| `harborframework → laude-institute` | account ownership by the Laude Institute is unconfirmed |
| `OpenLLM-France → linagora` | consortium/community account, not Linagora's own |
| `codellama → meta` | Code Llama is Meta's, but a secondary mismatched-name account; `meta-llama` already covers Meta |
| `cruxeval-org → meta` | benchmark org, not a Meta account |
| `gaia-benchmark → meta` | benchmark org, not a Meta account |
| `marin-community → stanford-crfm` | community account |
| `proj-persona → tencent-ai-lab` | dataset (PersonaHub) account, attribution unconfirmed |
| `BlinkDL → rwkv` | personal account of the RWKV author (`RWKV` is adopted) |
| `Goose-World → rwkv` | secondary account (`RWKV` is adopted) |
| `THUDM → zhipu-z-ai` | Tsinghua lab account — provenance link, not clean ownership (`zai-org` is adopted) |
| `Idavidrein → unknown` · `MMMU → unknown` · `truthfulqa → unknown` | org is literally `unknown`; no ownership to assert |

The three multi-org **Conflicts** the proposer already withheld (`EleutherAI`, `allenai`, `cais`) are likewise left for hand-resolution.

## Checklist

- [x] `uv run python -m build.validate` prints `0 error(s)`
- [x] Identity gates pass: `identity_eval --floors` clears every floor, precision 1.000; `tests/test_identity_eval.py` 137 passed
- [x] Additions-only diff to `sources/org_handles.yaml` (no existing entry reordered or rewritten)
- [x] Label: none (hand review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwdFew5P7Pf6MABS2UaPLT