### PR TITLE
Fix check_corpus_diff to compare freshly serialized payloads (#497)

### DIFF
--- a/build/check_corpus_diff.py
+++ b/build/check_corpus_diff.py
@@ -1,11 +1,19 @@
 """The semantic-diff gate: what a PR does to the published narrative.
 
-Compares HEAD's committed build/notebook_data.json against the freshly serialized payload
+Serializes the payload FRESH from the source files at both the base ref and the PR's tree
 and reports, per category, the stage, gap set, product count, and tier deltas. A stage
 move fails the gate unless --allow-stage-move is passed (CI passes it when the PR carries
 the `stage-move` label), so a stage can only move on purpose. Separately, every axis
 assessment row belonging to a product whose source files the PR did not touch must be
 byte-identical before and after; a change there is a silent rewrite and fails the gate.
+
+Both sides are built in memory by `build.serialize.build_payload` (no file is written), so
+the committed `build/notebook_data.json` is never read. That copy used to be the `after`
+side, but the contributor checklist forbids editing it on a product PR, so it was identical
+to the base copy on every such PR and the payload diff was always empty - the gate was blind
+to exactly the stage, gap and tier moves it exists to catch (#497). Serializing both sides
+from source, the way the untouched-row half already did, is what makes the diff real; it also
+keeps a no-op PR comparing equal, since the same serializer runs on each side.
 
 This replaces the corpus-wide digest pins that used to live in tests/ (build/goldens.py):
 they caught silent rewrites by hashing everything, which made every product PR collide.
@@ -119,24 +127,48 @@ def content_row(row) -> str:
     )
 
 
-def _rows_at(root: Path, ref: str | None) -> dict[str, str]:
-    """Axis-assessment rows keyed by product|axis, content-canonicalized, for the tree at
-    ref (None = worktree). Content-canonicalized rather than `canonical_row` for the reason
-    `content_row` documents: identity columns differ across refs by construction."""
+def _payload_at(tree: Path) -> dict:
+    """The published payload, serialized fresh in memory from the source files at `tree`.
+
+    Returns the dict `build/notebook_data.json` is dumped from, without writing it: the gate
+    is side-effect-free and never reads the committed copy. `generated`/`version`/`released`
+    and per-product `freshness` are left out because `diff_payloads` compares only the
+    per-category stage, gaps, product set and tiers - none of those fields - so this gate does
+    not depend on git-log freshness (and so does not need a full-depth checkout for the payload
+    half, only for the touched-row worktree read)."""
+    from build.serialize import build_payload
+    from build.validate import load_sources
+
+    sources = load_sources(tree)
+    frozen = json.loads((tree / "sources" / "snapshots" / "long_tail.json").read_text())
+    return build_payload(sources, frozen)
+
+
+def _rows(rows) -> dict[str, str]:
+    """Axis-assessment rows keyed by product|axis, content-canonicalized (identity columns
+    projected out for the reason `content_row` documents: they differ across refs by
+    construction)."""
+    return {f"{r['product_slug']}|{r['axis']}": content_row(r) for r in rows}
+
+
+def _snapshot_at(root: Path, ref: str | None) -> tuple[dict, dict[str, str]]:
+    """(payload, content-canonicalized rows) built fresh from the tree at `ref`.
+
+    `ref is None` reads the working tree in place; otherwise a detached worktree at `ref`
+    keeps the read honest without touching the checkout. Both halves are serialized from the
+    SAME ref, so a no-op PR compares equal and only a real source change shows."""
     from build import axis_assessments
     if ref is None:
-        rows = axis_assessments.resolve(root, allow_dirty=True)
-    else:
-        # A temporary worktree at ref keeps the comparison honest without touching the checkout.
-        tmp = root / ".ccd-worktree"
-        subprocess.run(["git", "worktree", "add", "--detach", str(tmp), ref], cwd=root, check=True,
+        return _payload_at(root), _rows(axis_assessments.resolve(root, allow_dirty=True))
+    # A temporary worktree at ref keeps the comparison honest without touching the checkout.
+    tmp = root / ".ccd-worktree"
+    subprocess.run(["git", "worktree", "add", "--detach", str(tmp), ref], cwd=root, check=True,
+                   capture_output=True)
+    try:
+        return _payload_at(tmp), _rows(axis_assessments.resolve(tmp, allow_dirty=True))
+    finally:
+        subprocess.run(["git", "worktree", "remove", "--force", str(tmp)], cwd=root, check=True,
                        capture_output=True)
-        try:
-            rows = axis_assessments.resolve(tmp, allow_dirty=True)
-        finally:
-            subprocess.run(["git", "worktree", "remove", "--force", str(tmp)], cwd=root, check=True,
-                           capture_output=True)
-    return {f"{r['product_slug']}|{r['axis']}": content_row(r) for r in rows}
 
 
 def compare_rows(before: dict[str, str], after: dict[str, str], touched: set[str]) -> list[str]:
@@ -152,10 +184,6 @@ def compare_rows(before: dict[str, str], after: dict[str, str], touched: set[str
         elif before[key] != after[key]:
             out.append(f"{key} changed but sources/{{scores,products}}/{slug}.yaml did not")
     return out
-
-
-def untouched_row_changes(root: Path, base_ref: str, touched: set[str]) -> list[str]:
-    return compare_rows(_rows_at(root, base_ref), _rows_at(root, None), touched)
 
 
 def render_sheet(diff: CorpusDiff, row_changes: list[str]) -> str:
@@ -181,13 +209,11 @@ def main(argv: list[str] | None = None, root: Path | None = None) -> int:
     p.add_argument("--sheet", type=Path, default=None)
     args = p.parse_args(argv)
 
-    before_txt = subprocess.run(["git", "show", f"{args.base}:build/notebook_data.json"], cwd=root,
-                                capture_output=True, text=True, check=True).stdout
-    before = json.loads(before_txt)
-    after = json.loads((root / "build" / "notebook_data.json").read_text())
-    diff = diff_payloads(before, after)
+    before_payload, before_rows = _snapshot_at(root, args.base)
+    after_payload, after_rows = _snapshot_at(root, None)
+    diff = diff_payloads(before_payload, after_payload)
     touched = touched_products(root, args.base)
-    row_changes = untouched_row_changes(root, args.base, touched)
+    row_changes = compare_rows(before_rows, after_rows, touched)
     sheet = render_sheet(diff, row_changes)
     (args.sheet.write_text(sheet) if args.sheet else print(sheet))
 

--- a/tests/test_check_corpus_diff.py
+++ b/tests/test_check_corpus_diff.py
@@ -1,4 +1,84 @@
+import subprocess
+from pathlib import Path
+
+import yaml
+
 from build import check_corpus_diff as ccd
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _git(cwd, *args):
+    return subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True).stdout
+
+
+def _clone(dest: Path) -> Path:
+    """A local clone of the repo the tests run in, so a synthetic commit is isolated from it."""
+    subprocess.run(["git", "clone", "--local", "--no-hardlinks", "--quiet", str(ROOT), str(dest)],
+                   check=True, capture_output=True, text=True)
+    _git(dest, "config", "user.email", "ccd-test@example.invalid")
+    _git(dest, "config", "user.name", "ccd test")
+    return dest
+
+
+def _pick_editable_non_leading(repo: Path) -> tuple[str, str]:
+    """A (category, slug) whose score file carries an integer adoption.level and whose tier is
+    not already 'leading', so forcing the axes to 5 lands it in the leading tier for sure."""
+    payload = ccd._payload_at(repo)
+    for cid, cat in payload["categories"].items():
+        for prod in cat.get("products", []):
+            if prod.get("tier") == "leading":
+                continue
+            slug = prod["slug"]
+            doc = yaml.safe_load((repo / "sources" / "scores" / f"{slug}.yaml").read_text())
+            if isinstance((doc.get("adoption") or {}).get("level"), int):
+                return cid, slug
+    raise AssertionError("no editable non-leading product found in the corpus")
+
+
+def test_reports_a_tier_move_from_source_with_notebook_data_untouched(tmp_path):
+    """The #497 regression guard. A source change that alters a product's tier, with
+    build/notebook_data.json deliberately left untouched (as the contributor checklist
+    requires), must be reported. The old gate compared the committed payload against itself
+    and printed an empty sheet here; reserializing from source makes the delta real."""
+    repo = _clone(tmp_path / "repo")
+    base = _git(repo, "rev-parse", "HEAD").strip()
+
+    _cid, slug = _pick_editable_non_leading(repo)
+    score = repo / "sources" / "scores" / f"{slug}.yaml"
+    doc = yaml.safe_load(score.read_text())
+    doc["adoption"]["level"] = 5
+    doc.setdefault("capability", {})["score"] = 5
+    score.write_text(yaml.safe_dump(doc, sort_keys=False, allow_unicode=True))
+    _git(repo, "add", f"sources/scores/{slug}.yaml")
+    _git(repo, "commit", "-m", "synthetic: force a leading tier")
+
+    changed = _git(repo, "diff", "--name-only", f"{base}...HEAD").split()
+    assert changed == [f"sources/scores/{slug}.yaml"]  # notebook_data.json really is untouched
+
+    sheet_path = tmp_path / "sheet.md"
+    rc = ccd.main(["--base", base, "--sheet", str(sheet_path)], root=repo)
+    sheet = sheet_path.read_text()
+    assert f"{slug}:" in sheet and "-> leading" in sheet, sheet
+    assert rc == 0  # a tier move alone is reported but does not fail the gate
+
+
+def test_no_source_change_reports_nothing(tmp_path):
+    """The symmetric half: serializing both sides from source must not manufacture a delta.
+    A commit that touches no source file leaves the sheet empty and the gate green."""
+    repo = _clone(tmp_path / "repo")
+    base = _git(repo, "rev-parse", "HEAD").strip()
+
+    (repo / "docs" / "_ccd_probe.md").write_text("not a source file\n")
+    _git(repo, "add", "docs/_ccd_probe.md")
+    _git(repo, "commit", "-m", "docs-only change")
+
+    sheet_path = tmp_path / "sheet.md"
+    rc = ccd.main(["--base", base, "--sheet", str(sheet_path)], root=repo)
+    sheet = sheet_path.read_text()
+    assert "stage moves: none" in sheet
+    assert "untouched-product row changes: none" in sheet
+    assert rc == 0
 
 
 def _payload(categories):


### PR DESCRIPTION
## What

Fixes #497. `check_corpus_diff` is meant to report what a PR does to the published narrative, but `main()` compared `git show <base>:build/notebook_data.json` against the committed working-tree copy of the same file. On a product PR the contributor checklist forbids editing `build/notebook_data.json`, so both sides were identical and the payload diff was always empty — the gate has been **blind to every stage, gap, tier and product-count move it exists to catch**. (Found while reviewing #494, where the stage delta had to be computed by hand.)

## Change

Serialize the payload **fresh from source at both the base ref and the PR's tree** — the same way the untouched-row half (`_rows_at`) already worked — via `build.serialize.build_payload` in memory. No file is written, so the gate stays **side-effect-free** and never reads the committed payload. Because the same serializer runs on each side, a no-op PR still compares equal.

- `main()` now builds `(payload, rows)` from each ref through one helper, `_snapshot_at`, replacing the `git show …:notebook_data.json` read and the separate row plumbing.
- `freshness` is dropped from the build here: `diff_payloads` compares only stage, gaps, product set and tiers, none of which depend on git-log freshness — so the payload half no longer needs a full-depth checkout (the touched-row worktree read is unchanged).

The CLI (`--base`, `--allow-stage-move`, `--sheet`) and CI invocation are unchanged.

## Tests

- **Regression guard (the blind spot):** a local clone gets a synthetic source change that forces a product to the `leading` tier, committed with `build/notebook_data.json` left untouched (as the checklist requires). The gate must report the tier move. This **fails against the old self-comparison** and passes now.
- **No false positives (the symmetry it buys):** a source-free commit (docs only) still reports nothing — serializing both sides from source does not manufacture a delta.
- The 11 existing pure-function tests are unchanged and still pass (13 total).

## Checklist

- [x] `uv run python -m build.validate` prints `0 error(s)`
- [x] `tests/test_check_corpus_diff.py` — 13 passed (incl. the two new integration tests)
- [x] No behavior change to the CLI or the CI step; only the payload comparison is corrected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwdFew5P7Pf6MABS2UaPLT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwdFew5P7Pf6MABS2UaPLT)_