### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-09-05
+
+Moved discovery off hand curation, and built the identity graph and Postgres serving layer
+underneath it — **616 products across 18 categories**, from **348 organizations**.
+
 ### Added
 
 - `mirror.code_unchanged_from` in `warehouse/dependencies.yaml`: a marker letting a mirror contract
@@ -270,6 +275,7 @@ Initial release: the first full snapshot of the AI Stack Map corpus, at the star
 **458 products across 15 categories**, from **249 organizations**, each scored on openness,
 adoption, and capability. Tagged at commit `2e9d6eb`.
 
-[unreleased]: https://github.com/currentai-org/os-ai-map/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/currentai-org/os-ai-map/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/currentai-org/os-ai-map/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/currentai-org/os-ai-map/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/currentai-org/os-ai-map/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "os-ai-map"
-version = "0.2.0"
+version = "0.3.0"
 description = "Open Source AI Map: curated data + modeling behind the AI Stack Map"
 license = "MIT"
 requires-python = ">=3.12"

--- a/skills/publish-release/SKILL.md
+++ b/skills/publish-release/SKILL.md
@@ -43,8 +43,12 @@ Read the Unreleased notes and pick the largest applicable step. This project fol
 | **MINOR** (`Y`) | A backward-compatible addition. | New products, categories, or data sources; a new optional schema field; a new skill or workflow. |
 | **PATCH** (`Z`) | A correction that changes no structure. | Score-value corrections; prose or doc fixes; evidence refreshes; build-helper bug fixes. |
 
-If the Unreleased section is empty, there is nothing to release — stop. Before `1.0.0`, a
-MAJOR-worthy change bumps the MINOR instead (`0.y` may break); say so in the changelog.
+If the Unreleased section is empty, there is nothing to release — stop.
+
+Before `1.0.0` the repository is in rapid iteration and `0.y` may break, so a MAJOR-worthy
+change is simply a MINOR bump. Do not annotate it in the changelog and do not raise it as a
+decision at release time — pick the number from the table and move on. If a *named* downstream
+consumer has to act, tell them directly instead. Revisit at 1.0.0.
 
 ## Steps
 

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ wheels = [
 
 [[package]]
 name = "os-ai-map"
-version = "0.2.0"
+version = "0.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "datasets" },


### PR DESCRIPTION
Cuts 0.3.0 from the Unreleased notes cleaned up in #499.

## Why MINOR

New categories, 144 new products, new data sources (Hugging Face Hub, OpenRouter), new
workflows, and the Neon serving layer are all backward-compatible additions under the version
table in `skills/publish-release/SKILL.md`.

The `Removed` block does drop the `maturity` gap type, which would be MAJOR-worthy after 1.0.
Pre-1.0 that is simply a MINOR bump, and the `Deprecated` block gives consumers a migration
window by dual-publishing `maturity` and `mature` for one release.

## The skill amendment

The pre-1.0 clause previously read: "a MAJOR-worthy change bumps the MINOR instead (`0.y` may
break); say so in the changelog." The annotation is noise while the repo is iterating quickly,
so the clause now says to pick the number from the table, skip the changelog note, and tell a
named downstream consumer directly if one has to act. Revisit at 1.0.0.

## Contents

Four files, exactly what the skill's steps call for:

- `CHANGELOG.md` — `## [Unreleased]` becomes `## [0.3.0] - 2026-09-05` with a summary line in
  0.2.0's style, a fresh empty `## [Unreleased]` above it, and the link definitions rewired so
  `[unreleased]` compares from `v0.3.0` and `[0.3.0]` compares `v0.2.0...v0.3.0`. All five
  subsections had entries, so none needed dropping.
- `pyproject.toml` — `0.2.0` → `0.3.0`
- `uv.lock` — re-locked in the same commit (`os-ai-map v0.2.0 -> v0.3.0`)
- `skills/publish-release/SKILL.md` — the amendment above

## The release

> Moved discovery off hand curation, and built the identity graph and Postgres serving layer
> underneath it — **616 products across 18 categories**, from **348 organizations**.

Corpus figures verified against `build/notebook_data.json`, not the badges.

## Test plan

- `uv run python -m build.validate` — 0 errors, 2 warnings (both pre-existing `model_families`
  pattern overlaps, unrelated)
- `uv run pytest tests/test_release_metadata.py -q` — 3 passed, re-run after the summary edit.
  That is the three in-tree records agreeing; the fourth is the tag.
- `uv run pytest -q` — full suite, exit 0

## After merge

Tag `v0.3.0` on the merged `main` commit, not on this branch tip.