### PR TITLE
Re-pin handle coverage after adopting 51 Hugging Face handles

### DIFF
--- a/tests/fixtures/identity_coverage_baseline.json
+++ b/tests/fixtures/identity_coverage_baseline.json
@@ -4,8 +4,8 @@
     299
   ],
   "huggingface": [
-    2,
-    61
+    51,
+    62
   ],
   "homepage_domain": [
     6,


### PR DESCRIPTION
#498 adopted 51 first-party Hugging Face handles but touched only
`sources/org_handles.yaml`. The ratchet in `tests/fixtures/identity_coverage_baseline.json`
was never moved, so it still read `2/61` against an actual `51/62`.

| Route | Actual | Was pinned | Now pinned |
|---|---|---|---|
| `huggingface` | 51/62 | **2/61** | 51/62 |
| `github` | 211/299 | 211/299 | unchanged |
| `homepage_domain` | 6/27 | 6/27 | unchanged |

**This is a tightening.** The gate was permitting HF coverage to fall from 51 back to 2 without
failing. The handles are already in the corpus and already working: org truth with no handle
route fell from **636 to 477** once they landed.

## Why now

`identity-eval` runs on a schedule for the first time tomorrow at 07:30 UTC. It would have
passed either way, because coverage is at or above the pin on every route — but it would have
been passing against a floor 79 points below reality. A vacuous green is the failure mode the
first scheduled run exists to expose, and it is the one thing the sentinel (#459) cannot catch,
since that only fires on red.

## The design hole this came through

The ratchet bites only when coverage *falls below* the pin. Nothing requires re-pinning after a
gain, so any coverage improvement that forgets to update the baseline leaves the gate
permanently slack. #493 covers the opposite direction — guarding against a silent *lowering* of
the baseline — and neither it nor anything else catches "coverage rose and the pin did not
follow." Filed separately; this PR is the data fix only.

## Test plan

- `uv run python -m build.identity_eval --write-coverage-baseline` — re-pins from the live reading
- `uv run python -m build.identity_eval --edges tests/fixtures/identity_edges_pass.json` — all
  three routes report "at or above baseline" against the new pin
- `uv run pytest tests/test_identity_eval.py -q` — 137 passed