### PR TITLE
docs: state the ADR-004 merge rule, and drop counts that drift

### DIFF
--- a/docs/architecture/data-architecture.md
+++ b/docs/architecture/data-architecture.md
@@ -250,8 +250,8 @@ cited as proof was the documented example of the bug.
 
 Two related rules follow from the same document and must not be re-derived:
 
-- **Product freshness is the OLDEST confirmed axis, not the newest.** 176 of 472 products carry
-  differing axis dates, so this is the common case. Publishing the newest "says at least one
+- **Product freshness is the OLDEST confirmed axis, not the newest.** Products whose axes carry
+  differing dates are the common case. Publishing the newest "says at least one
   axis was confirmed then, which is a weaker claim wearing the stronger one's label — the same
   overstatement as publishing a held axis as verified".
 - `latest_axis_confirmation` already exists as a DERIVED field emitted only where it differs.

--- a/docs/reference/adoption.md
+++ b/docs/reference/adoption.md
@@ -97,7 +97,7 @@ scale two orders below the other.
 
 Declared per **product type** in `sources/rubrics/<type>.yaml`, serialized by
 `build/serialize_rubric.py` into `currentai.registry.adoption_bands`, and read from there by
-the scoring models. Four declarations rather than sixteen, because the scale is a property of
+the scoring models. Four declarations rather than one per category, because the scale is a property of
 what the thing IS, which is what the rubrics are already keyed on.
 
 | level | `software` / `model` | `dataset` |
@@ -125,7 +125,7 @@ Older notes in this project said datasets ran *two* orders lower. The data says 
 
 ### Why `hardware` declares none
 
-A board has no download count. All 20 hardware products record a qualitative reach — `niche`,
+A board has no download count. Hardware products record a qualitative reach — `niche`,
 `broad`, `mass-market` — and none records a figure, so the type declares `qualitative: true`
 and an empty `bands` list.
 
@@ -189,8 +189,8 @@ in a place nothing was looking.
 alternative considered was one order higher throughout, so that ChatGPT at ~900M weekly actives
 and Poe at ~18M monthly actives did not both land at 5. That was rejected: **a level has to
 mean one magnitude across the whole map**, or `adoption` stops being comparable between a
-package and an app. 19 of the 23 sit at level 5, and that is the map saying these are all
-mass-market surfaces, which they are. A top band holding a wide range is the ordinary cost of a
+package and an app. Most records on this instrument sit at level 5, and that is the map saying
+these are all mass-market surfaces, which they are. A top band holding a wide range is the ordinary cost of a
 five-point scale, not a defect in this instrument.
 
 **The labels carry `users`** for the same reason the stars labels carry `stars` — and here
@@ -208,7 +208,7 @@ A model scores on the surface it powers — `gpt-5` on ChatGPT — and its note 
 loud. What the scale will not accept silently is a figure that is **not an active count**: an
 all-time or cumulative user total, a device installed base, a paid-seat count. Those are the
 `active_users` form of the under-coverage error below, a substitution wearing a measurement's
-label, and three records carry one today with the substitution named in the note:
+label. The records that carry one name the substitution in the note:
 `github-copilot` and `github-copilot-ide` (20M **all-time**, not active) and
 `apple-core-ml-runtime` (2.5B active **devices** — a person with an iPhone and a Mac is two of
 it). `doubao` used to be a fourth, banding on ~330M *total* users; a measured 382M MAU now
@@ -270,10 +270,10 @@ instrument and whether it is `bridged`; `artifact_key` names what a product must
 that source to have anything to read, and `requires_evidence` carries the re-fetch fields.
 
 **The first draft required recomputation for `usage_volume` outright, and its own test caught
-the error.** 15 of the 55 unrouted records already carry a digested source —
+the error.** A sizable minority of the unrouted records already carried a digested source —
 `agent-infra-sandbox` cites `api.npmjs.org/downloads/point/last-month` showing 4,670 downloads,
 with a digest. That claim is perfectly checkable; it just is not re-derivable by a pipeline that
-reads no npm. Failing it would have told 15 authors their careful evidence did not count.
+reads no npm. Failing it would have told those authors their careful evidence did not count.
 
 **Why the escape hatch stays shut.** Without the re-fetch leg, an unbacked record could pass by
 relabelling itself `reported_traction` — moving an unverifiable claim into the one instrument
@@ -380,8 +380,8 @@ not follow from the evidence the score itself recorded.
 
 | model | grain | covers | route |
 |---|---|---|---|
-| `currentai.signal_pypi.package_downloads` | package | 98 software products | PyPI |
-| `currentai.signal_huggingface.product_adoption` | **product** | 112 model / dataset products | Hugging Face |
+| `currentai.signal_pypi.package_downloads` | package | software products declaring a `pypi` artifact | PyPI |
+| `currentai.signal_huggingface.product_adoption` | **product** | model / dataset products declaring a Hugging Face artifact | Hugging Face |
 
 Both read the bands from `registry.adoption_bands` and band on the product's declared type.
 Neither writes anything back to `sources/`: **a computed band is an observation, never a
@@ -390,12 +390,12 @@ score.** Only a person sets `level`, and only per `evidence-and-freshness.md`.
 ### Sum across the family, not per artifact
 
 `signal_routing.yaml` declares `sum_across_artifacts: true` for adoption, because the map's
-unit is the product family rather than a repo. 107 model artifacts belong to 55 products, so
-banding per artifact scores nearly half of them on a single SKU: `gemma` sums to 22.1M across
-six and lands at 5, where its largest single SKU would not.
+unit is the product family rather than a repo. Model artifacts routinely outnumber the products
+that own them, so banding per artifact scores a product on a single SKU: `gemma` sums across its
+SKUs and lands at 5, where its largest single SKU would not.
 
-`product_adoption` does this; `package_downloads` does not yet need to (98 products, 98
-packages), and the hole is latent there rather than closed.
+`product_adoption` does this; `package_downloads` does not yet need to (a routed product declares
+one package), and the hole is latent there rather than closed.
 
 ### Route order, and taking the sum WITHIN the winning route
 
@@ -431,7 +431,7 @@ it does not make the claim automatic, it makes it falsifiable.
 
 ## Signals considered and their traps
 
-- **GitHub stars** — real, already fetched for 258 products, banded nowhere yet. Capped at
+- **GitHub stars** — real, already fetched wherever a repo is declared, banded nowhere yet. Capped at
   level 3 by the rubric because stars measure attention rather than use. **Open route.**
 - **Vendor SDK downloads** — `mistralai`, `anthropic`, `cohere` on PyPI are dated proxies for
   API integration, and the trap is attribution. `cohere-rerank-api` is currently banded on
@@ -489,8 +489,8 @@ product, followed by a band recorded on that signal anyway.**
 
 ### The gate: `build/check_channel_authority.py`
 
-The ladder above was a habit for its first two weeks, and habits are not applied evenly. Eight
-products had already taken remedy 3 — `helm`, `laminar`, `swe-bench` and five others record
+The ladder above was a habit for its first two weeks, and habits are not applied evenly. Some
+products had already taken remedy 3 — `helm`, `laminar` and `swe-bench` among them record
 `reported_traction` with `reach` omitted while their winning route is a bridged usage channel —
 and nothing said whether the ones that had not were exceptions or oversights. The gate is what
 makes the ladder answerable.
@@ -578,8 +578,8 @@ Three questions settle it, and all three are answerable from the package's own J
 
 Where the package turns out to be a client, the server usually has no countable channel at all, so
 the honest outcome is `stars_fallback` and its cap of 3 - understating a widely deployed system,
-and saying so in the note. Thirteen of `storage`'s twenty-seven bands are there for this reason,
-which is the highest share on the map after `dataset_processing_tools`, and it is a property of the
+and saying so in the note. A large share of `storage`'s bands are there for this reason,
+the highest on the map after `dataset_processing_tools`, and it is a property of the
 category rather than a defect in it. Docker pull counts would fix most of them; there is no
 `docker` artifact kind to declare, which is the platform-side ask.
 

--- a/docs/reference/capability.md
+++ b/docs/reference/capability.md
@@ -19,8 +19,8 @@ are prose rather than a bare number, by design. The band is a curator's
 judgment, and the honest thing the axis does is record what that judgment rested on so it can
 be checked and refreshed.
 
-A null score is an abstention, not a gap: 26 products, datasets and a wire protocol among
-them, are not capable of anything the axis measures, and abstain rather than score 0.
+A null score is an abstention, not a gap: some records — datasets and a wire protocol among
+them — are not capable of anything the axis measures, and abstain rather than score 0.
 
 ## The recorded fields
 
@@ -60,7 +60,7 @@ evidence, and a checker that could not tell them apart could not route or gate t
 
 Many bands are not measured at all. As of 2026-08-14, 114 products record a peer comparison
 (with perhaps another ~36 candidates that still live in prose) — "one tier below the Megatron-LM
-anchor", "mid-tier next to langfuse" — and in `finetuning_code` every one of the 27 notes does it.
+anchor", "mid-tier next to langfuse" — and in `finetuning_code` every note does it.
 Peer comparison is **a major capability instrument**, not demonstrably most of the axis, and until
 2026-08-08 it lived inside an English sentence where nothing could check it, refresh it, or notice
 when the product it named moved.
@@ -162,8 +162,8 @@ prefer a nearer peer whose capability is independently evidenced over stretching
 vocabulary to reach the anchor.
 
 The corpus already works this way. `pinecone` is recorded `at milvus`, not against `vespa`,
-which 22 other `storage` bands name; `thunderkittens` and `hummingbird` are both `two_below
-tensorrt` rather than against `apache-tvm`, which 18 `compilers` bands name; `amazon-bedrock-
+which most other `storage` bands name; `thunderkittens` and `hummingbird` are both `two_below
+tensorrt` rather than against `apache-tvm`, which most `compilers` bands name; `amazon-bedrock-
 custom-models-fine-tuning` is `one_below openai-fine-tuning-api`, a hosted peer, rather than
 against `megatron-lm`. In each case the nearer peer is the more informative comparison: a
 hosted fine-tuning service says more about another hosted fine-tuning service than a
@@ -204,10 +204,10 @@ axis is won or lost. Two rules, both learned on 2026-08-18 while banding `compil
 **Count the products per rung before you accept the wording.** A rung holding a third of the
 category is not discriminating between anything; it is a label. `storage`'s top rung was first
 written as "a distributed retrieval platform that also ranks or runs inference in the serving
-path", which admitted seven of twenty-seven products - Vespa and Elasticsearch, but also every
-vector database that fuses scores, since Qdrant has RRF and DBSF, Infinity has tensor reranking and
-Milvus has rerank functions. Reworded to "hosts and evaluates ranking or embedding models inside
-the serving path" it admits two. Nothing about the products changed; the definition stopped being
+path", which on that day admitted seven of the twenty-seven products then in the category - Vespa
+and Elasticsearch, but also every vector database that fuses scores, since Qdrant has RRF and DBSF,
+Infinity has tensor reranking and Milvus has rerank functions. Reworded to "hosts and evaluates
+ranking or embedding models inside the serving path" it admitted two. Nothing about the products changed; the definition stopped being
 satisfiable by almost all of them. The distribution is the diagnostic, and it costs one query.
 
 **Prefer a definition stated as a capability the product either has or has not, over one stated as

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -69,7 +69,7 @@ A held axis reaches the payload as `basis: partial` rather than through the fall
 
 **Changed what it claims, not merely touched.** Some commits move a file without
 reviewing it. The Phase 1a migration reshapes `openness.components` from a string into a
-mapping in all 472 files, carrying a byte-identical `raw:` copy of the string it
+mapping in every score file, carrying a byte-identical `raw:` copy of the string it
 replaced, so no published value moves — and dating by touch would have republished 78 of
 the first batch's 84 products as reviewed on the migration day. A commit date is only
 defensible here because it dates a review, so a commit that reviewed nothing must not
@@ -144,8 +144,8 @@ one product-level date, "everything" is the constraint: a product whose axes wer
 the 9th, 11th and 13th is defensibly current only through the **9th**. Publishing the 13th
 says "at least one axis was confirmed then", which is a weaker claim wearing the stronger
 one's label — the same overstatement as publishing a held axis as verified, in a less obvious
-form. It was `max()` until 2026-08-15, and 176 of the 472 products carry differing axis dates,
-so this is the common case rather than an edge. `latest_axis_confirmation` carries the newest
+form. It was `max()` until 2026-08-15, and products whose axes carry differing dates are the
+common case rather than an edge. `latest_axis_confirmation` carries the newest
 date for anyone who wants "when was this last touched", emitted only where it differs.
 
 Note what `partial` does *not* depend on. It follows from an axis being unconfirmed, not from
@@ -179,7 +179,7 @@ cannot act on gets switched off.
 
 Weekly rather than daily for the same reason parity is weekly: the cadence has to match the work
 it polices. A category is re-read in one run, so all of its axes carry one date and all of them
-age out together, and about four categories cross the 45-day line per week. A daily gate would
+age out together, and a few categories cross the 45-day line each week. A daily gate would
 re-report the same cliff for as many days as the re-read takes, which is nagging rather than
 information.
 
@@ -564,8 +564,8 @@ the evidence and asks only whether the pair exists in the ladder, so deferring c
 ### Two shared utilities, so the mechanism cannot be bypassed
 
 - **`build/components.py`** — the only supported way to edit a `components` field. The
-  block-safe rewriter with the reparse assertion. 277 of the 470 score files fold that
-  scalar across lines, 57 of them across three or more, so any hand-rolled
+  block-safe rewriter with the reparse assertion. Many score files fold that
+  scalar across lines, some across three or more, so any hand-rolled
   `^  components: (.*)$` substitution splices keys mid-string and corrupts the value
   silently. A shared helper means the next script cannot re-invent that. Generic over the
   field, so a score correction and a components edit are the same operation with the same
@@ -590,9 +590,9 @@ different in kind and can be automated — see the table below.
 
 ## What a capability confirmation attests to
 
-Less than the other two axes, and the difference is worth stating before roughly 400 dates get
-written across adoption and capability in step 3. **42 capability axes carry a
-`last_verified` today**, so this is a paragraph now and an audit of 400 dates later.
+Less than the other two axes, and the difference is worth stating before dates get written
+across adoption and capability in step 3 — a paragraph now, rather than an audit of every one
+of those dates later.
 
 Capability is not measured on this map. Measured on 2026-08-08, 322 of 472 products record
 `basis: feature_matrix` against 86 `benchmark`, and `value` is prose in every one of the 372
@@ -601,10 +601,10 @@ the four rubrics, and `signal_routing.yaml` records the axis as effectively unro
 external anchors are unbridged, and both rank *models*, so neither can say anything about a
 training framework or a sandbox.
 
-What actually places many bands is a comparison to a peer. Roughly a hundred products in the
+What actually places many bands is a comparison to a peer. Many products in the
 corpus put themselves against another product in their own category — "one tier below the
-Megatron-LM anchor", "mid-tier next to langfuse" — and in `finetuning_code` every one of the
-27 notes does it. That comparison was the instrument, and it lived in an English sentence.
+Megatron-LM anchor", "mid-tier next to langfuse" — and in `finetuning_code` every note does
+it. That comparison was the instrument, and it lived in an English sentence.
 
 So it is recorded instead:
 
@@ -725,9 +725,9 @@ This follows from a rule already stated above — *"a re-check that changes noth
 the date"* — and refusing to date nulls would contradict it, treating "the answer is none" as
 the one answer that cannot be confirmed.
 
-**It is also load-bearing for coverage.** 43 products carry at least one null axis. If a null
-can never be dated, none of those 43 can ever be fully verified, however carefully anyone reads
-them — and the unreachable set is not random. It is almost entirely the hosted features sold
+**It is also load-bearing for coverage.** Products carrying at least one null axis are a real
+slice of the corpus. If a null can never be dated, none of them can ever be fully verified,
+however carefully anyone reads them — and the unreachable set is not random. It is almost entirely the hosted features sold
 inside a larger platform, which is a real and interesting part of the map, not a rounding error.
 
 Two things a dated abstention must still do:
@@ -781,7 +781,7 @@ The raise exists because the whole corpus was dated in one August sweep and woul
 the 30-day gate together, between 09-07 and 09-12. The rolling re-verifier spreads those dates
 over four weekly batches; once it has, the window reverts.
 
-At 45 days the re-read is continuous rather than occasional: eighteen categories inside forty-five days is roughly three a week. Two things follow. A whole category shares one confirmation
+At 45 days the re-read is continuous rather than occasional: every category inside forty-five days is roughly three a week. Two things follow. A whole category shares one confirmation
 date, because a category is re-read in a single run, so categories expire in cliffs rather
 than drifting past the line one product at a time — that is the shape of the work, not a
 backlog. And the sampled re-fetch will keep reporting drift on pages that change daily;

--- a/docs/reference/gap-analysis.md
+++ b/docs/reference/gap-analysis.md
@@ -119,7 +119,7 @@ Worth stating plainly, because the code makes them look alike and they behave op
   reweights maturity from a blend to a single axis rather than declining to score. The product
   keeps counting toward the stage.
 
-That fallback is right for the case it was written for. 21 of the 26 null-capability products
+That fallback is right for the case it was written for. Most null-capability products
 are in `benchmark_eval_data`, where downloads plausibly *are* the quality signal — a corpus
 everyone evaluates against is, by that fact, a good corpus.
 
@@ -130,11 +130,11 @@ it counts as a category-leading fully-open product on one axis while a reader as
 **A correction, because this guide got the stakes wrong on first writing.** It claimed that
 `agent_tools_protocols`'s stage rested on that null, on the reasoning that one category-leading fully-open
 product is the entire `stage >= 4` threshold. The rule is real but the inference was not
-checked against the category: it has **seven** category-leading fully-open products, not one — MCP, `fastmcp`,
-`qdrant`, `mcp-python-sdk`, `mcp-typescript-sdk`, `docling`, `markitdown` — and six of them
+checked against the category: it has **several** category-leading fully-open products, not one — MCP, `fastmcp`,
+`qdrant`, `mcp-python-sdk`, `mcp-typescript-sdk`, `docling`, `markitdown` — and most of them
 reach 4.5 from a real adoption *and* a real capability score with no null in the arithmetic.
-Seven clears `_STAGE5_MIN_MATURE = 4`, so the category is **stage 5**, and deleting MCP
-entirely leaves six and changes nothing. The methodological defect is unaffected; the claim
+That comfortably clears `_STAGE5_MIN_MATURE = 4`, so the category is **stage 5**, and deleting
+MCP entirely changes nothing. The methodological defect is unaffected; the claim
 that a stage depended on it was wrong, and was caught by re-deriving it against
 `build/serialize.py` rather than reasoning from the threshold.
 
@@ -178,7 +178,7 @@ and crediting partially-open products to it would blur exactly the open-source-v
 line the map is built to expose. Open-weights models therefore never advance a stage. Counting
 also distinguishes resiliency from a single standout (see Stage 5).
 
-This is consequential but bounded: counting open-weights as fully open would move only three
+This is consequential but bounded: counting open-weights as fully open would move only a few
 categories, all in the model layer (`base_pretrained` 3→5, `finetuned_chat` 2→3,
 `edge_hardware` 3→4), and would leave every infrastructure and tooling verdict unchanged.
 
@@ -269,11 +269,11 @@ reported an openness gap instead, so nobody reading the map could see it.
 clear their cutoffs and the blend still misses 4.5, neither driver fires and the category carries
 only whatever `openness` applies — possibly nothing. The stage number already says the category
 has not reached the leading-product threshold; inventing an adoption or capability shortfall where
-the axis clears its cutoff would be a knowingly false label. Exactly one category is in this state:
-`benchmark_eval_data`, whose fully-open benchmarks are adoption 4 with a **null capability**, so
+the axis clears its cutoff would be a knowingly false label. `benchmark_eval_data` is the case:
+its fully-open benchmarks are adoption 4 with a **null capability**, so
 the blend is adoption alone and tops out at 4.0 — adoption is not short, capability is simply
-unmeasured. The fix is to score capability for evaluation sets — the axis is already applied to 4
-of that category's 27 products — which is filed separately. If unmeasured axes become common
+unmeasured. The fix is to score capability for evaluation sets — the axis is already applied to
+some of that category's products — which is filed separately. If unmeasured axes become common
 enough to name, add a gap for that state deliberately rather than reusing an inaccurate one.
 
 ### Declaring the disclosure gap

--- a/docs/reference/identity.md
+++ b/docs/reference/identity.md
@@ -50,7 +50,7 @@ version_in_identity: OpenAI markets GPT-4o as a distinct product, not a version 
 ```
 
 The presence of the field is the exemption and the value is the reason — the same shape a
-category's `deferred` block uses. Six products carry one today. Datasets and hardware are not
+category's `deferred` block uses. Datasets and hardware are not
 checked, because there the version genuinely is the identity: `oscar-2301` is a specific crawl,
 `raspberry-pi-5` is a specific board, and the next one is a different product rather than an
 update.
@@ -95,7 +95,7 @@ openness:
   governing_release: gemma-4
 ```
 
-It is **declared rather than derived**, and the reason is worth keeping: 6 of the 15 products
+It is **declared rather than derived**, and the reason is worth keeping: many of the products
 carrying one are closed or API-only, with no artifact to date. A derivation would cover some
 products and not others, and a reader could not tell which kind they were looking at.
 
@@ -222,7 +222,7 @@ exactly one, so its key stays `(artifact, relation)`.
 
 ## Organizations
 
-Organizations carry aliases for the same reason and under the same rule. Two exist, both
+Organizations carry aliases for the same reason and under the same rule. The ones that exist are
 consolidations rather than renames: `google-deepmind` into `google`, `alibaba` into
 `alibaba-cloud`. `org_slug` is emitted into the payload and joined in the registry, so a rename
 with no forwarding address breaks a join rather than a link.
@@ -287,9 +287,9 @@ So `org` recall is a **regression invariant**, not a floor:
 
 | Relation | Precision | Recall | Kind of check |
 |---|---|---|---|
-| `equivalence` | ≥ 1.00 | ≥ 0.90 | floor, floor (15 truth items today, so waived) |
+| `equivalence` | ≥ 1.00 | ≥ 0.90 | floor, floor (waived while under the minimum truth count) |
 | `membership_non_scoring` | ≥ 0.98 | ≥ 0.90 | floor, floor |
-| `artifact_identity` | ≥ 0.99 | ≥ 0.95 | floor, floor (0 truth pairs today, so waived) |
+| `artifact_identity` | ≥ 0.99 | ≥ 0.95 | floor, floor (waived while under the minimum truth count) |
 | `membership_scoring` | — | — | never automated, so never floored |
 | `org` | ≥ 0.97 | ≥ 0.99 | precision **floor**, recall **invariant** |
 
@@ -311,13 +311,14 @@ route's numbers are pending the handle review in issue #483, and a floor set bef
 would be a guess. What it carries instead is a **baseline ratchet**:
 `tests/fixtures/identity_coverage_baseline.json` pins today's `(orgs with a handle, orgs with
 artifacts)` per route, and any run exits 1 if a route's live ratio falls below its pinned ratio.
-Coverage can only go up. The pinned values as of this writing:
+Coverage can only go up. Read the pinned ratios from that file rather than from a copy here; the
+routes and their denominators are:
 
-| Route | Coverage | Denominator |
-|---|---|---|
-| `github` | 211/299 | orgs owning a `github` artifact |
-| `huggingface` | 2/61 | orgs owning a `huggingface_model` or `huggingface_dataset` artifact |
-| `homepage_domain` | 6/27 | orgs owning a `homepage` artifact |
+| Route | Denominator |
+|---|---|
+| `github` | orgs owning a `github` artifact |
+| `huggingface` | orgs owning a `huggingface_model` or `huggingface_dataset` artifact |
+| `homepage_domain` | orgs owning a `homepage` artifact |
 
 `uv run python -m build.identity_eval --write-coverage-baseline` re-pins the file from the corpus.
 That is a deliberate act in its own commit — raising the ratchet because coverage genuinely rose,
@@ -376,7 +377,7 @@ pattern is a literal prefix of another's and the two name different products.
 ## Where the graph lives
 
 The identity questions this guide describes in prose are also computed as a graph on the OSO
-platform, in the `currentai.identity` dataset. Seven models, all deployed:
+platform, in the `currentai.identity` dataset. These models, all deployed:
 
 | Table | What one row is |
 |---|---|
@@ -389,7 +390,7 @@ platform, in the `currentai.identity` dataset. Seven models, all deployed:
 | `digest` | a reviewable claim, ranked for the weekly sweep |
 
 The pool feeds `signal_hfhub.model_universe`, `signal_openrouter.models` and
-`signal_goodailist.repo_catalog` supply the undeclared candidates. All ten tables are
+`signal_goodailist.repo_catalog` supply the undeclared candidates. All of these tables are
 platform-owned: the repo keeps read-only mirrors under `warehouse/models/identity/` and
 `warehouse/models/signal_{hfhub,openrouter,goodailist}/`, each recorded as a dependency contract
 in `warehouse/dependencies.yaml` with a `mirror:` block pinning the model id, revision and file
@@ -410,7 +411,7 @@ keeps the tier that declared it and the eval reports the head/tail split per rel
 what gives `membership_non_scoring` a floor at all: `homepage` is the only artifact kind with no
 adoption route, no head product declares one, and the tail rows that do are what put
 `membership_non_scoring` over the minimum truth count its floor needs to mean anything. That
-relation's truth set is therefore small enough (27) that one edge decides whether it clears the
+relation's truth set is therefore small enough that one edge decides whether it clears the
 floor, so its failures need reading twice — a tail homepage edit is emitted from the last published
 `registry.tail_products` until the weekly publish lands, and the same edit staleness-fails the
 committed pass fixture. `build/identity_eval.py`'s module docstring carries both readings, and the

--- a/docs/reference/openness.md
+++ b/docs/reference/openness.md
@@ -29,12 +29,12 @@ Each `sources/scores/<slug>.yaml` carries two separate, analyst-assigned opennes
 Every non-null value needs a primary `sources:` entry. Both fields were originally assigned
 by hand against MOF/OSI, and that history is why `components`/`note` read as editorial prose.
 
-**A deterministic formula now exists for most of the map.** All 18 categories declare a
+**A deterministic formula now exists for most of the map.** Every category declares a
 `scoring_recipe` that names an ordered rule list over dimension values, and
 `build/check_rubric.py` replays it against each product's recorded `components` to check that
 the recorded score is the one the rules produce. Most recipes `extend` a shared ladder in
 [`sources/rubrics/`](../../sources/rubrics/) rather than restating one: `software.yaml` covers
-twelve categories directly plus the software half of `safeguards`, `model.yaml` the fine-tuned and guardrail models. A category holding more
+the software categories directly plus the software half of `safeguards`, `model.yaml` the fine-tuned and guardrail models. A category holding more
 than one kind of product maps `extends` per product type.
 
 Three caveats, because "a formula exists" is easy to over-read:
@@ -150,8 +150,8 @@ license families. The **caps** are what is universal.
 Before the scale, the same license family was scored two ways. `Llama-3.1-Community` was
 `3/open_weights` on `llama-guard` in `safeguards` and `2/restricted` on `llama-instruct` in
 `finetuned_chat`. `CC-BY-NC` capped `command-r` at 2 while `CC-BY-NC-SA` left `personahub` at
-5. Ten products carry a bounded commercial license; six were recorded 2 and four were recorded
-3.
+5. Of the ten products then carrying a bounded commercial license, six were recorded 2 and four
+were recorded 3.
 
 Applying the scale on 2026-08-01 moved seven scores: six from `2/restricted` to
 `3/open_weights` (`llama`, `codellama`, `llama-instruct`, `tulu`, `jamba-large`, `codegemma`)
@@ -216,9 +216,9 @@ corpus also answered that question 54 times under `self-host`, in a vocabulary o
 on the other. Whether a vendor lets you run the published thing yourself *is* whether the
 core is withheld, so these were never two facts.
 
-Twenty-three records carry both keys, and they never disagree — 11 `yes`/`ungated`, 10
-`primary`/`ungated`, 2 `only`/`ungated`, and no contradictions in either direction. That
-agreement is what licenses the merge. Until 2026-08-11 `self-host` was an undeclared key,
+Twenty-three records carried both keys at the time of the merge, and they never disagreed — 11
+`yes`/`ungated`, 10 `primary`/`ungated`, 2 `only`/`ungated`, and no contradictions in either
+direction. That agreement is what licensed the merge. Until 2026-08-11 `self-host` was an undeclared key,
 which meant it was dropped before the formula ran, and the 31 records that used it *instead*
 of `core-gated` left the dimension unanswered.
 
@@ -286,9 +286,9 @@ precedent, which is why the rule is now stated here and in `sources/rubrics/soft
 rather than left to be rediscovered.
 
 One caveat for anyone applying it: not every `core-gated: gated` in the corpus was recorded
-against this test. Twenty-two products reach the gated rung, and a number of them record their
-gate as a managed cloud "on top" of a complete OSI core — the shape this section says is
-*ungated* — with no withheld component named. Those predate the rule and have not been re-read.
+against this test. Some products reaching the gated rung record their gate as a managed cloud
+"on top" of a complete OSI core — the shape this section says is *ungated* — with no withheld
+component named. Those predate the rule and have not been re-read.
 A `gated` value is not evidence that somebody applied this rule; check what the record says is
 actually withheld.
 
@@ -309,7 +309,7 @@ recorded against the artifact they actually govern. `llamafirewall` is 5/open_so
 `openai-evals` was already resolved this way before the rule was written: it records
 `license: MIT`, `source: public(full framework + registry)` and
 `per-dataset-licenses: mixed(CC/CC0/Apache for bundled data)`, and scores 5 on the framework.
-Those two are the only bundles of this shape in the corpus today.
+Any further bundle of this shape resolves the same way.
 
 The rule does have an edge, and it is worth stating so nobody stretches it. It applies where the
 bundled artifact is *substitutable* — you can point LlamaFirewall at a different model and it
@@ -331,8 +331,8 @@ This is recorded as an `accessory_host` dimension in `sources/rubrics/hardware.y
 as an extra rung. The rung version — `{schematics: partial, toolchain: partial}` → 4 — would have
 reproduced the number the HAT then held and been non-monotonic: `ti-am67a` and
 `qualcomm-dragonwing-rb3-gen-2` both record `{partial, open}` and score 3, so it would have ranked
-strictly weaker evidence strictly higher. One product records `accessory-host` today; the next
-accessory records its host rather than needing another rung.
+strictly weaker evidence strictly higher. An accessory records its host rather than needing a
+rung of its own.
 
 The dimension earned itself on 2026-08-14, sooner than expected. `raspberry-pi-5` was corrected
 from 4 to 3 — it publishes a mechanical drawing and two STEP files and no schematic of the board,
@@ -407,7 +407,7 @@ Both are choices, not oversights, and neither moves the binary line.
 
 The **dataset** vocabulary has no middle. Its classes are `open`, `gated`, `restricted`
 and `closed`, and `open` is the only word above `gated`, so every corpus classed `open` sits
-in that bucket — 51 products today, including one at 3 and six at 4. A model at 4
+in that bucket, including ones scored below 5. A model at 4
 is `open_weights` and open-ish; a corpus at 4 is `open`. `the-pile` (license deferring to
 per-subset terms, Books3 withdrawn) and `stack-edu` (deferring to The Stack v2's gated terms)
 are counted as open on that basis. Closing it means giving the vocabulary a middle class and

--- a/docs/reference/product-copy.md
+++ b/docs/reference/product-copy.md
@@ -152,8 +152,8 @@ the field.
 
 ### The verification line — canonical form
 
-The corpus carries this idiom 227 ways ("Verified live June 2026", "verified live on HF
-June 2026", "Verified live 2026-06-22 via primary sources", …). Standardize on:
+The corpus carries this idiom in many spellings ("Verified live June 2026", "verified live on
+HF June 2026", "Verified live 2026-06-22 via primary sources", …). Standardize on:
 
 ```
 Verified <YYYY-MM-DD> via <source>.
@@ -286,7 +286,7 @@ as a stand-in for a count. If a number matters, it is an `adoption` score, not a
 A "latest version" clause fails the same test for the same reason: the next release makes
 it wrong, and nothing in the repo will notice. `v0.26.0 released 2026-07-25` and
 `Latest stable v1.2.1 ...; 1.3.0 release candidates in progress` are both promises the map
-cannot keep across several hundred products. The `github`/`pypi`/`huggingface_*` links
+cannot keep across the whole corpus. The `github`/`pypi`/`huggingface_*` links
 already point at the page showing the current release. Do not restate it.
 
 Three cases are **durable** and stay:

--- a/docs/reference/queries.md
+++ b/docs/reference/queries.md
@@ -25,7 +25,7 @@ down that read them are historical.
 
 ## Starting points
 
-**For notebook queries:** use `scores.repos_summary` (15K rows, pre-computed snapshot):
+**For notebook queries:** use `scores.repos_summary` (a pre-computed snapshot):
 ```sql
 SELECT * FROM currentai.scores.repos_summary WHERE country = 'France' ORDER BY stars DESC
 ```

--- a/docs/reference/sibling-invariants.md
+++ b/docs/reference/sibling-invariants.md
@@ -90,7 +90,7 @@ which SPELLING had been used rather than off the normalized status, on the reaso
 ground that scalar entries predate the feature and should not be disturbed. What that bought was a
 published category owing nothing: a scalar entry pointing at a file with only `name`,
 `display_name` and an empty roster produced zero errors and would have shipped visibly empty. The
-checks now run on the normalized value, and every one of the sixteen scalar entries already
+checks now run on the normalized value, and every scalar entry already
 satisfied them, which is the measurement that should have preceded the exemption.
 
 

--- a/docs/reference/where-scores-live.md
+++ b/docs/reference/where-scores-live.md
@@ -105,8 +105,8 @@ label, `stages` by their stage number, `long_tail_top` by its name, `product_lin
 `alias`, with no surrogate at all.
 
 A source's key carries `shows` and `accessed` because the URL alone does not identify the row.
-One source list can hold the same URL twice on the same axis — 69 pairs today — and every one
-of those pairs is a re-verification that recorded a different claim or a different date. They
+One source list can hold the same URL twice on the same axis, and every such pair is a
+re-verification that recorded a different claim or a different date. They
 are two observations of one page, and those two fields are what tell them apart. The
 consequence worth knowing: editing a source's `shows` or `accessed` moves that row's id,
 because it is a different observation and an id moves when its natural key does.
@@ -252,25 +252,26 @@ The **score** is curated in `sources/scores/*.yaml` as `adoption.level`, and mir
 What the warehouse does hold is a **measured band per product**, from whichever channel the
 product declares:
 
-| Table | Instrument | Products | Agrees with the repo |
-|---|---|---|---|
-| `currentai.signal_huggingface.product_adoption` | 30-day Hub downloads | 115 | **96%** (111/115) |
-| `currentai.signal_pypi.package_downloads` | monthly PyPI downloads | 106 | **91%** (97/106) |
-| `currentai.signal_github.product_adoption` | stars, a declared **fallback** | 120 | **50%** (60/120) |
+| Table | Instrument | Agrees with the repo |
+|---|---|---|
+| `currentai.signal_huggingface.product_adoption` | 30-day Hub downloads | nearly always |
+| `currentai.signal_pypi.package_downloads` | monthly PyPI downloads | nearly always |
+| `currentai.signal_github.product_adoption` | stars, a declared **fallback** | about half the time |
 
 Read those three rates together and they say something specific rather than alarming. Where a
 product publishes a download channel, the repo and the warehouse agree. Where adoption rests on
-stars, they part company — and in 56 of the 60 disagreements the repo bands **higher**, by one
-level 28 times, two levels 21 times, and three or more 7 times.
+stars, they part company — and in nearly every one of those disagreements the repo bands
+**higher**, usually by one level and sometimes by more. Count them yourself against the tables
+rather than quoting a figure from here; the signal crons move them weekly.
 
 That is the fallback behaving like a fallback: stars are a weaker proxy than downloads and land
 lower on their own scale, and `docs/reference/adoption.md` is explicit that a band is only comparable
-within its `signal_type`. So it is not 60 errors. It is 56 products whose adoption rests on the
-weakest instrument the map has, banded above what that instrument alone would support, with no
-gate over any of it. Worth a pass, not a correction sweep.
+within its `signal_type`. So the disagreements are not errors. They are products whose adoption
+rests on the weakest instrument the map has, banded above what that instrument alone would
+support, with no gate over any of it. Worth a pass, not a correction sweep.
 
-**The 50 products promoted on 2026-08-19 have no signal rows yet.** The signal crons are Sunday,
-so the earliest is 2026-08-23.
+**A newly promoted product has no signal rows until the next cron.** The signal crons are
+Sunday, so the batch promoted on 2026-08-19 was first measurable on 2026-08-23.
 
 ## Capability — mirrored, never recomputed
 

--- a/docs/workflows/discover-candidates.md
+++ b/docs/workflows/discover-candidates.md
@@ -245,8 +245,12 @@ token, or leave the field absent and say the fetch did not complete. Never recor
 and capability are earned later against evidence, under `add-product` or `promote-category`.
 Preliminary scoring here would be a number with no source behind it.
 
-**No bot PRs.** The sweep ends at populated registry files and a summary for a human to
-approve. Opening PRs per candidate is not part of this workflow.
+**Automation may open the PR; only a human merges it.** Under
+[ADR-004](../architecture/adr-004-machine-proposals-and-the-public-tail.md#decision), a sweep
+may end in a bot-opened pull request carrying the machine-generated review sheet and exactly
+one label — here, `tail-batch`. What automation never does is merge: the registry rows and the
+batch summary exist for a human to review and accept. Open one PR for the batch, not one per
+candidate.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- `docs/workflows/discover-candidates.md` no longer says "No bot PRs". It states the ADR-004 rule — automation may open the PR, only a human merges it — and links the ADR.
- Removes present-tense claims about the size of mutable sets across `docs/reference/*.md` and `docs/architecture/data-architecture.md`: product, organization, row and category counts that drift as the corpus grows.
- Keeps what the evergreen-docs rule says to keep: explicitly dated historical measurements ("Measured 2026-08-10, 49 of the 60…"), past-tense history, derived and gated counts behind their `count:` markers, and named product examples.
- Docs-only: 12 files, no code, no fixtures.

## How this was produced

Built and reviewed by the build-review loop (`ccerv1/agent-loops`), run `docs-current-truth-2026-09-06-a6`. A Claude builder worked in an isolated clone with no remotes; Codex reviewed the branch and returned **pass** with zero blocking items, after four earlier rounds returned `fail` on counts an earlier grep-based sweep could not see.

The reviewer independently re-ran the integrity tests rather than trusting the builder's claim: **15 passed**.

## Test plan

- [x] `uv run pytest tests/test_docs_integrity.py -q` — 15 passed
- [x] diff touches only `docs/`
- [x] spot-checked the remaining count-like strings by hand: every survivor is dated, past-tense, structural, or a PR number

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rk13b2TEwhhV8hvTLtQVz
