### PR TITLE
ADR-004: a gate only a corpus-wide fixture edit could repair does not block a proposal

### DIFF
--- a/docs/architecture/adr-004-machine-proposals-and-the-public-tail.md
+++ b/docs/architecture/adr-004-machine-proposals-and-the-public-tail.md
@@ -26,10 +26,21 @@ budget; and if the observed tier is hidden, the map cannot show coverage at all.
 3. **Corpus-wide generated fixtures are regenerated only after canonical state changes on
    `main`, and never appear in proposal PRs.** `tests/goldens/corpus.json` joins
    `build/notebook_data.json` under `regenerate.yml` and `generated-files-guard`.
+   It follows that **a gate whose only repair is a corpus-wide fixture edit does not block a
+   proposal PR.** Such gates — identity membership fixtures and committed coverage baselines
+   among them — bind on `main`, where the fixtures are regenerated, not on the proposals that
+   cannot touch them. A proposal PR failing *only* those gates is complete; a reviewer records
+   the failure and merges on the sheet. This is not an exception granted per batch. Two rules
+   otherwise contradict each other, and a proposal caught between them stalls with its work
+   finished and unmergeable.
 4. **No tail field depends on an LLM judgment.** An agent may orchestrate serialization and
    PR creation without being epistemically involved in the result.
 
 ## Consequences
+
+A registry-only batch is no longer blocked by identity gates it is forbidden to repair.
+Those gates still protect the corpus from silent drift, but they do it where the drift can
+happen — on `main` — rather than on a proposal that adds only registry rows.
 
 Two independent product PRs merge back to back with no fixture repair. The intentional
 change gate moves from digest pins to the per-PR semantic diff. Review effort is spent on


### PR DESCRIPTION
## Summary

ADR-004 point 3 forbids corpus-wide generated fixtures from appearing in proposal PRs. It never said what happens when a proposal's gates fail *because* those fixtures are stale — leaving a proposal caught between two rules, where the gate demands a repair the ADR prohibits.

This states the corollary: such a gate binds on `main`, where the fixtures are regenerated, not on proposals that cannot reach them. A proposal failing *only* those gates is complete; the reviewer records the failure and merges on the sheet.

Written as a standing rule rather than a per-batch exception, so the same question isn't re-answered every week.

## Why now

The 2026-09-06 weekly tail batch hit it. That run produced 93 registry rows, `build.validate` at 0 errors, and a `check_corpus_diff` sheet showing zero stage or gap moves — then stalled. Two identity tests failed on stale tail-membership fixtures and a committed handle-coverage baseline, and every repair path required files the batch may not touch.

The reviewer was right to refuse: it would not widen the diff or lower a baseline unilaterally. But the outcome was finished, valid work left unmergeable on a contradiction in the policy rather than a problem with the batch.

## Test plan

Documentation only — no code, no gates changed. The claim to check is that the new paragraph describes the gates as they actually behave once this is adopted:

- [ ] A registry-only proposal that fails only fixture-dependent identity gates is merged on its review sheet.
- [ ] Those gates still fail loudly on `main`, where a fixture regeneration can answer them.
- [ ] `regenerate.yml` and `generated-files-guard` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)