### PR TITLE
Re-pin the identity ratchet and fixture after #511, and fix a floor test that stopped testing the floor

### DIFF
--- a/build/identity_eval.py
+++ b/build/identity_eval.py
@@ -236,10 +236,14 @@ now bites is the point of counting the truth, not a reason to raise `MIN_TRUTH`.
 
 ## `membership_non_scoring` has no headroom, so read its failures twice
 
-Its truth set is the tail's homepage declarations and nothing else -- 27 today. One wrong or
-missing edge is a ~3.7% swing, which is already more than the 0.98 precision floor allows. Two
-things that are not regressions land as a failure on that row, and `FLOOR_NOTES` prints both
-next to it so a log alone is enough to tell them apart:
+Its truth set is the tail's homepage declarations and nothing else. **The floor's sensitivity
+scales with that set's size, so it weakens as the tail grows**: one wrong or missing edge is a
+1/n swing, which breached the 0.98 precision floor on its own while n was 27 and no longer does
+past 50 -- at n=51 a single bad edge scores 0.9804 and passes, and n=200 tolerates four. Read a
+green row on this relation as "no more than floor(n * 0.02) bad edges", not as "none". Raising
+the floor is a rubric change and belongs to a human. Two things that are not regressions land as
+a failure on that row, and `FLOOR_NOTES` prints both next to it so a log alone is enough to tell
+them apart:
 
 - **Publish lag.** Truth is the repo; the edges are the warehouse. A tail homepage row edited or
   deleted in `sources/registry/*.yaml` is still emitted from the last published

--- a/build/identity_eval.py
+++ b/build/identity_eval.py
@@ -354,8 +354,11 @@ MIN_TRUTH = 20
 # "membership_non_scoring has no headroom" section for the arithmetic.
 FLOOR_NOTES: dict[str, str] = {
     "membership_non_scoring": (
-        "this relation's entire truth set is the tail's homepage declarations (27 today), so a\n"
-        "  SINGLE wrong or missing edge is a ~3.7% swing -- there is no headroom by construction.\n"
+        "this relation's entire truth set is the tail's homepage declarations, so one wrong or\n"
+        "  missing edge is a 1/n swing -- sensitive while n is small, weaker as the tail grows\n"
+        "  (one bad edge breached the 0.98 precision floor at n=27 and no longer does past 50).\n"
+        "  A publish lag trips RECALL, and trips it hard: a batch adding k homepage\n"
+        "  declarations holds recall at (n-k)/n until the weekly publish lands.\n"
         "  Two non-regressions look like this failure. (1) A tail homepage row edited in the repo\n"
         "  is still emitted by the warehouse until the weekly registry publish lands, so a red\n"
         "  scheduled run soon after such an edit means republish, not regression -- check\n"

--- a/tests/fixtures/identity_coverage_baseline.json
+++ b/tests/fixtures/identity_coverage_baseline.json
@@ -1,14 +1,14 @@
 {
   "github": [
     211,
-    299
+    328
   ],
   "huggingface": [
     51,
-    62
+    81
   ],
   "homepage_domain": [
-    6,
-    27
+    7,
+    50
   ]
 }

--- a/tests/fixtures/identity_edges_pass.json
+++ b/tests/fixtures/identity_edges_pass.json
@@ -62,6 +62,42 @@
     },
     {
       "artifact_kind": "github",
+      "artifact_id": "landing-ai/ade-cli",
+      "product_tier": "tail",
+      "product_slug": "ade-cli",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "docs.landing.ai/ade/ade-overview",
+      "product_tier": "tail",
+      "product_slug": "ade-cli",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "microsoft/agent-governance-toolkit",
+      "product_tier": "tail",
+      "product_slug": "agent-governance-toolkit",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
       "artifact_id": "Panniantong/Agent-Reach",
       "product_tier": "tail",
       "product_slug": "agent-reach",
@@ -98,6 +134,54 @@
     },
     {
       "artifact_kind": "github",
+      "artifact_id": "splx-ai/agentic-radar",
+      "product_tier": "tail",
+      "product_slug": "agentic-radar",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "splx.ai",
+      "product_tier": "tail",
+      "product_slug": "agentic-radar",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "msoedov/agentic_security",
+      "product_tier": "tail",
+      "product_slug": "agentic-security",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "agentic-security.vercel.app",
+      "product_tier": "tail",
+      "product_slug": "agentic-security",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
       "artifact_id": "agentsmd/agents.md",
       "product_tier": "tail",
       "product_slug": "agents-md",
@@ -113,6 +197,54 @@
       "artifact_id": "agents.md",
       "product_tier": "tail",
       "product_slug": "agents-md",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "Tencent/AI-Infra-Guard",
+      "product_tier": "tail",
+      "product_slug": "ai-infra-guard",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "tencent.github.io/AI-Infra-Guard",
+      "product_tier": "tail",
+      "product_slug": "ai-infra-guard",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "huggingface/aisheets",
+      "product_tier": "tail",
+      "product_slug": "aisheets",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "huggingface.co/spaces/aisheets/sheets",
+      "product_tier": "tail",
+      "product_slug": "aisheets",
       "confidence": 0.95,
       "method": [
         "declared"
@@ -146,6 +278,30 @@
     },
     {
       "artifact_kind": "github",
+      "artifact_id": "RightNow-AI/autokernel",
+      "product_tier": "tail",
+      "product_slug": "autokernel",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "rightnowai.co/forge",
+      "product_tier": "tail",
+      "product_slug": "autokernel",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
       "artifact_id": "awslabs/mcp",
       "product_tier": "tail",
       "product_slug": "aws-mcp-servers",
@@ -167,6 +323,90 @@
       ],
       "penalties": [],
       "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "google-bert/bert-base-cased",
+      "product_tier": "tail",
+      "product_slug": "bert-base-cased",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "google-bert/bert-base-multilingual-cased",
+      "product_tier": "tail",
+      "product_slug": "bert-base-multilingual-cased",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "google-bert/bert-base-multilingual-uncased",
+      "product_tier": "tail",
+      "product_slug": "bert-base-multilingual-uncased",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "google-bert/bert-base-uncased",
+      "product_tier": "tail",
+      "product_slug": "bert-base-uncased",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "neuralmind/bert-large-portuguese-cased",
+      "product_tier": "tail",
+      "product_slug": "bert-large-portuguese-cased",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "emilyalsentzer/Bio_ClinicalBERT",
+      "product_tier": "tail",
+      "product_slug": "bio-clinicalbert",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "microsoft/BiomedNLP-BiomedBERT-base-uncased-abstract",
+      "product_tier": "tail",
+      "product_slug": "biomednlp-biomedbert-base-uncased-abstract",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
     },
     {
       "artifact_kind": "github",
@@ -218,6 +458,30 @@
     },
     {
       "artifact_kind": "github",
+      "artifact_id": "kenryu42/cc-safety-net",
+      "product_tier": "tail",
+      "product_slug": "cc-safety-net",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "ccsafetynet.com",
+      "product_tier": "tail",
+      "product_slug": "cc-safety-net",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
       "artifact_id": "zilliztech/claude-context",
       "product_tier": "tail",
       "product_slug": "claude-context",
@@ -251,6 +515,54 @@
       ],
       "penalties": [],
       "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "bespokelabsai/curator",
+      "product_tier": "tail",
+      "product_slug": "curator",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "docs.bespokelabs.ai/bespoke-curator",
+      "product_tier": "tail",
+      "product_slug": "curator",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "microsoft/deberta-v3-base",
+      "product_tier": "tail",
+      "product_slug": "deberta-v3-base",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "microsoft/deberta-v3-large",
+      "product_tier": "tail",
+      "product_slug": "deberta-v3-large",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
     },
     {
       "artifact_kind": "github",
@@ -311,6 +623,66 @@
       ],
       "penalties": [],
       "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "distilbert/distilbert-base-uncased",
+      "product_tier": "tail",
+      "product_slug": "distilbert-base-uncased",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "distilbert/distilroberta-base",
+      "product_tier": "tail",
+      "product_slug": "distilroberta-base",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "dphn/dolphin-2.9.1-yi-1.5-34b",
+      "product_tier": "tail",
+      "product_slug": "dolphin-2-9-1-yi-1-5-34b",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "ConardLi/easy-dataset",
+      "product_tier": "tail",
+      "product_slug": "easy-dataset",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "docs.easy-dataset.com",
+      "product_tier": "tail",
+      "product_slug": "easy-dataset",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
     },
     {
       "artifact_kind": "github",
@@ -374,6 +746,42 @@
     },
     {
       "artifact_kind": "github",
+      "artifact_id": "flagos-ai/FlagGems",
+      "product_tier": "tail",
+      "product_slug": "flaggems",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "cyberark/FuzzyAI",
+      "product_tier": "tail",
+      "product_slug": "fuzzyai",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "marcelroed/gigatoken",
+      "product_tier": "tail",
+      "product_slug": "gigatoken",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
       "artifact_id": "idosal/git-mcp",
       "product_tier": "tail",
       "product_slug": "git-mcp",
@@ -397,6 +805,30 @@
       "scoring_bearing": false
     },
     {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "hivetrace/gliner-guard-omni",
+      "product_tier": "tail",
+      "product_slug": "gliner-guard-omni",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "fastino/GLiNER2-Guardrails-PII-Multi",
+      "product_tier": "tail",
+      "product_slug": "gliner2-guardrails-pii-multi",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
       "artifact_kind": "github",
       "artifact_id": "Coding-Solo/godot-mcp",
       "product_tier": "tail",
@@ -407,6 +839,54 @@
       ],
       "penalties": [],
       "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "openai-community/gpt2",
+      "product_tier": "tail",
+      "product_slug": "gpt2",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "openai-community/gpt2-large",
+      "product_tier": "tail",
+      "product_slug": "gpt2-large",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "InternScience/GraphGen",
+      "product_tier": "tail",
+      "product_slug": "graphgen",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "chenzihong.gitbook.io/graphgen-cookbook",
+      "product_tier": "tail",
+      "product_slug": "graphgen",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
     },
     {
       "artifact_kind": "github",
@@ -425,6 +905,42 @@
       "artifact_id": "plugins.hex-rays.com/mrexodia/ida-pro-mcp",
       "product_tier": "tail",
       "product_slug": "ida-pro-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "intel/intel-extension-for-pytorch",
+      "product_tier": "tail",
+      "product_slug": "intel-extension-for-pytorch",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "ELS-RD/kernl",
+      "product_tier": "tail",
+      "product_slug": "kernl",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "kernl.ai",
+      "product_tier": "tail",
+      "product_slug": "kernl",
       "confidence": 0.95,
       "method": [
         "declared"
@@ -494,6 +1010,18 @@
     },
     {
       "artifact_kind": "github",
+      "artifact_id": "MarkPDFdown/markpdfdown",
+      "product_tier": "tail",
+      "product_slug": "markpdfdown",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
       "artifact_id": "googleapis/mcp-toolbox",
       "product_tier": "tail",
       "product_slug": "mcp-toolbox-for-databases",
@@ -509,6 +1037,78 @@
       "artifact_id": "mcp-toolbox.dev",
       "product_tier": "tail",
       "product_slug": "mcp-toolbox-for-databases",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "microsoft/mdeberta-v3-base",
+      "product_tier": "tail",
+      "product_slug": "mdeberta-v3-base",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "answerdotai/ModernBERT-base",
+      "product_tier": "tail",
+      "product_slug": "modernbert-base",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "answerdotai/ModernBERT-large",
+      "product_tier": "tail",
+      "product_slug": "modernbert-large",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "guardion/ModernGuard-1",
+      "product_tier": "tail",
+      "product_slug": "modernguard-1",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "Nasiko-Labs/nasiko",
+      "product_tier": "tail",
+      "product_slug": "nasiko",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "nasiko.com",
+      "product_tier": "tail",
+      "product_slug": "nasiko",
       "confidence": 0.95,
       "method": [
         "declared"
@@ -541,6 +1141,30 @@
       "scoring_bearing": false
     },
     {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "hfmlsoc/ncii-guard-v02",
+      "product_tier": "tail",
+      "product_slug": "ncii-guard-v02",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "nunchux-ai/nunchaku",
+      "product_tier": "tail",
+      "product_slug": "nunchaku",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
       "artifact_kind": "github",
       "artifact_id": "adithya-s-k/omniparse",
       "product_tier": "tail",
@@ -557,6 +1181,30 @@
       "artifact_id": "omniparse.cognitivelab.in",
       "product_tier": "tail",
       "product_slug": "omniparse",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "siliconflow/onediff",
+      "product_tier": "tail",
+      "product_slug": "onediff",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "github.com/siliconflow/onediff/wiki",
+      "product_tier": "tail",
+      "product_slug": "onediff",
       "confidence": 0.95,
       "method": [
         "declared"
@@ -625,6 +1273,150 @@
       "scoring_bearing": true
     },
     {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "apple/OpenELM-1_1B-Instruct",
+      "product_tier": "tail",
+      "product_slug": "openelm-1-1b-instruct",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "facebook/opt-125m",
+      "product_tier": "tail",
+      "product_slug": "opt-125m",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "axa-group/Parsr",
+      "product_tier": "tail",
+      "product_slug": "parsr",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "oomol-lab/pdf-craft",
+      "product_tier": "tail",
+      "product_slug": "pdf-craft",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "pdf.oomol.com",
+      "product_tier": "tail",
+      "product_slug": "pdf-craft",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "Intel/polite-guard",
+      "product_tier": "tail",
+      "product_slug": "polite-guard",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "ibm-research/PowerMoE-3b",
+      "product_tier": "tail",
+      "product_slug": "powermoe-3b",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "utkusen/promptmap",
+      "product_tier": "tail",
+      "product_slug": "promptmap",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "pymupdf/PyMuPDF",
+      "product_tier": "tail",
+      "product_slug": "pymupdf",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "pymupdf.readthedocs.io",
+      "product_tier": "tail",
+      "product_slug": "pymupdf",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "pytorch/xla",
+      "product_tier": "tail",
+      "product_slug": "pytorch-xla",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "pytorch.org/xla",
+      "product_tier": "tail",
+      "product_slug": "pytorch-xla",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
       "artifact_kind": "github",
       "artifact_id": "repowise-dev/repowise",
       "product_tier": "tail",
@@ -647,6 +1439,30 @@
       ],
       "penalties": [],
       "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "FacebookAI/roberta-base",
+      "product_tier": "tail",
+      "product_slug": "roberta-base",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "FacebookAI/roberta-large",
+      "product_tier": "tail",
+      "product_slug": "roberta-large",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
     },
     {
       "artifact_kind": "github",
@@ -674,6 +1490,66 @@
     },
     {
       "artifact_kind": "github",
+      "artifact_id": "NVIDIA/SkillSpector",
+      "product_tier": "tail",
+      "product_slug": "skillspector",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "docs.nvidia.com/skills/scanning-agent-skills",
+      "product_tier": "tail",
+      "product_slug": "skillspector",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "snorkel-team/snorkel",
+      "product_tier": "tail",
+      "product_slug": "snorkel",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "snorkel.org",
+      "product_tier": "tail",
+      "product_slug": "snorkel",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "CompVis/stable-diffusion-safety-checker",
+      "product_tier": "tail",
+      "product_slug": "stable-diffusion-safety-checker",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
       "artifact_id": "steel-dev/steel-browser",
       "product_tier": "tail",
       "product_slug": "steel-browser",
@@ -698,9 +1574,129 @@
     },
     {
       "artifact_kind": "github",
+      "artifact_id": "superagent-ai/superagent",
+      "product_tier": "tail",
+      "product_slug": "superagent",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "superagent.sh",
+      "product_tier": "tail",
+      "product_slug": "superagent",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "meta-llama/synthetic-data-kit",
+      "product_tier": "tail",
+      "product_slug": "synthetic-data-kit",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "pypi.org/project/synthetic-data-kit",
+      "product_tier": "tail",
+      "product_slug": "synthetic-data-kit",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "google-t5/t5-base",
+      "product_tier": "tail",
+      "product_slug": "t5-base",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "google-t5/t5-small",
+      "product_tier": "tail",
+      "product_slug": "t5-small",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
       "artifact_id": "grab/cursor-talk-to-figma-mcp",
       "product_tier": "tail",
       "product_slug": "talk-to-figma-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "CatchTheTornado/text-extract-api",
+      "product_tier": "tail",
+      "product_slug": "text-extract-api",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "demo.doctractor.com",
+      "product_tier": "tail",
+      "product_slug": "text-extract-api",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "KoalaAI/Text-Moderation",
+      "product_tier": "tail",
+      "product_slug": "text-moderation",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "llvm/torch-mlir",
+      "product_tier": "tail",
+      "product_slug": "torch-mlir",
       "confidence": 0.95,
       "method": [
         "declared"
@@ -737,6 +1733,78 @@
       "artifact_id": "coplaydev.github.io/unity-mcp",
       "product_tier": "tail",
       "product_slug": "unity-mcp",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "Unstructured-IO/unstructured",
+      "product_tier": "tail",
+      "product_slug": "unstructured",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "unstructured.io",
+      "product_tier": "tail",
+      "product_slug": "unstructured",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "valqore/valqore",
+      "product_tier": "tail",
+      "product_slug": "valqore",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "valqore.io",
+      "product_tier": "tail",
+      "product_slug": "valqore",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "github",
+      "artifact_id": "0xMassi/webclaw",
+      "product_tier": "tail",
+      "product_slug": "webclaw",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "homepage",
+      "artifact_id": "webclaw.io",
+      "product_tier": "tail",
+      "product_slug": "webclaw",
       "confidence": 0.95,
       "method": [
         "declared"
@@ -791,6 +1859,30 @@
       ],
       "penalties": [],
       "scoring_bearing": false
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "FacebookAI/xlm-roberta-base",
+      "product_tier": "tail",
+      "product_slug": "xlm-roberta-base",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
+    },
+    {
+      "artifact_kind": "huggingface_model",
+      "artifact_id": "FacebookAI/xlm-roberta-large",
+      "product_tier": "tail",
+      "product_slug": "xlm-roberta-large",
+      "confidence": 0.95,
+      "method": [
+        "declared"
+      ],
+      "penalties": [],
+      "scoring_bearing": true
     },
     {
       "artifact_kind": "github",

--- a/tests/test_identity_eval.py
+++ b/tests/test_identity_eval.py
@@ -774,12 +774,26 @@ def test_main_write_fixture_rewrites_and_scores_nothing(tmp_path, capsys):
 
 
 def test_a_stale_fixture_tail_row_fails_the_floor_with_the_publish_lag_note(tmp_path, capsys):
-    """The failure mode the note exists for: one wrong row out of 27 breaks the 0.98 precision
-    floor, and the message has to say that a red run can mean "republish" or "regenerate the
-    fixture" rather than "the graph regressed"."""
+    """The failure mode the note exists for: enough wrong rows to breach the 0.98 precision
+    floor, with a message saying a red run can mean "republish" or "regenerate the fixture"
+    rather than "the graph regressed".
+
+    The number of corrupted rows is DERIVED, not fixed at one. The floor's sensitivity scales
+    with the truth set: one bad row breached 0.98 while the tail held 27 homepage declarations,
+    and stopped breaching it past 50. Hard-coding one row made this test start passing for the
+    wrong reason the moment the corpus grew — it reported "the floor catches a stale row" when
+    the floor had quietly stopped doing so.
+    """
     rows = tail_membership_rows(REAL_TRUTH.route_kinds)
     stale = [dict(row) for row in rows]
-    next(row for row in stale if row["artifact_kind"] == "homepage")["artifact_id"] = "gone.example.com"
+    homepage = [row for row in stale if row["artifact_kind"] == "homepage"]
+    floor = FLOORS["membership_non_scoring"][0]
+    # Fewest corruptions that put precision strictly below the floor, at whatever size the
+    # truth set is today.
+    n = len(homepage)
+    needed = next(k for k in range(1, n + 1) if (n - k) / n < floor)
+    for row in homepage[:needed]:
+        row["artifact_id"] = "gone.example.com"
     path = tmp_path / "edges.json"
     path.write_text(json.dumps({"membership": stale}))
     assert main(["--edges", str(path), "--floors"]) == 1


### PR DESCRIPTION
## Summary

The `main`-side half of the rule ADR-004 gained in #510. #511 merged with `identity-eval` and `validate` red because both failures were pinned baselines a proposal PR may not touch — this is where they get repaired.

Two commits, deliberately separate:

1. **`2f8e5a8` re-pins the handle-coverage ratchet.** #511 added 67 registry rows, so every route's denominator grew while the numerators held or rose: github `211/299 → 211/328`, hf `51/62 → 51/81`, homepage `6/27 → 7/50`. Coverage did not regress; the pins went stale. Its own commit because `--write-coverage-baseline` requires that — a failing run must never rewrite the file for itself, or the ratchet ratchets nothing.

2. **`dec1676` regenerates the pass fixture** (156 rows re-derived from `sources/registry/*.yaml`) **and repairs a floor test.**

## The finding worth reading

The `membership_non_scoring` floor test corrupted exactly one row, on the documented reasoning that *"one wrong row out of 27 breaks the 0.98 precision floor."*

The truth set is **51** today. One bad row scores `50/51 = 0.9804` and **clears** the floor. So the test had begun passing while asserting something no longer true, and it would have kept passing as the gate got weaker:

| Truth set size | Bad edges needed to breach 0.98 |
|---|---|
| 27 | 1 |
| 51 | 2 |
| 100 | 3 |
| 200 | 5 |

Read a green row on this relation as "no more than `floor(n * 0.02)` bad edges", not as "none".

The test now **derives** the number of rows to corrupt from the live set size and the floor, so it cannot quietly stop exercising the floor again. The module comment that baked in the n=27 arithmetic states the relationship instead of a number that expires.

**Not changed: the 0.98 floor itself.** Raising it is a rubric change and belongs to a human — flagged, not done.

## Test plan

- [x] `uv run pytest tests/test_identity_eval.py` — 137 passed (was 3 failing before the regeneration, 1 before the test fix)
- [x] `uv run python -m build.validate` — 0 error(s), 2 pre-existing `model_families` pattern-overlap warnings
- [x] Both regenerations used the documented recipes (`--write-coverage-baseline`, `--write-fixture`), not hand edits
- [ ] CI green on this PR, which is what confirms `main` is clean again after #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)