### PR TITLE
The org recall failure told readers to look for a bug that isn't there

### DIFF
--- a/build/identity_eval.py
+++ b/build/identity_eval.py
@@ -155,7 +155,11 @@ recall read 1.000 and mean nothing:
   computed over exactly the pairs a declared handle could bridge, so recoverability is defined
   by the same route the graph emits on. That makes it a REGRESSION INVARIANT, not a coverage
   target: a miss is the resolver failing to use evidence it already has, which is a bug rather
-  than a curation gap. `RECALL_INVARIANTS` pins it at >= 0.99 for `org`, it still exits 1 on
+  than a curation gap. **One caveat the invariant does not currently model:** part of `org`'s
+  truth is tail-derived, and truth is the repo while the edges are the warehouse -- so a registry
+  batch depresses this recall the moment it merges and until the weekly publish lands, with no
+  resolver defect involved. Until that is modelled, read a failure here against `n_emitted`:
+  unchanged while `n_truth` grew means lag, not regression. `RECALL_INVARIANTS` pins it at >= 0.99 for `org`, it still exits 1 on
   failure under `--floors`, and the table labels that row `recall invariant` rather than
   `recall floor` so nobody reads a 1.000 as coverage.
 - **coverage = have we given it enough evidence.** That is `org_handle_coverage`, per route:
@@ -353,6 +357,18 @@ MIN_TRUTH = 20
 # alone cannot supply: which failures are not regressions. See the module docstring's
 # "membership_non_scoring has no headroom" section for the arithmetic.
 FLOOR_NOTES: dict[str, str] = {
+    "org": (
+        "part of this relation's truth is TAIL-derived, so a publish lag depresses its recall the\n"
+        "  same way it depresses membership_non_scoring -- despite the failure line calling a miss a\n"
+        "  resolver bug. Truth is the repo; the edges are the warehouse. A registry batch adds org\n"
+        "  pairs the moment it merges, and none of them can be recovered until the weekly publish\n"
+        "  lands, so recall drops to (n-k)/n with k the new tail pairs. Worked example: merging 67\n"
+        "  registry rows on 2026-09-07 took org recall from 1.000 (446/446) to 0.980 (446/455) with\n"
+        "  n_emitted UNCHANGED at 3089 -- the warehouse side had not moved at all.\n"
+        "  So before reading this as a resolver defect: compare n_emitted against the previous run.\n"
+        "  Unchanged n_emitted with grown n_truth is a lag, and it clears itself at the next publish.\n"
+        "  A genuine miss shows n_emitted moving while recovery does not."
+    ),
     "membership_non_scoring": (
         "this relation's entire truth set is the tail's homepage declarations, so one wrong or\n"
         "  missing edge is a 1/n swing -- sensitive while n is small, weaker as the tail grows\n"


### PR DESCRIPTION
## Summary

`org` had **no `FLOOR_NOTES` entry at all**, so its only failure message was `the resolver missed a pair a declared handle already bridges` — and the module docstring reinforced it, calling a miss *"a bug rather than a curation gap."* For the commonest cause of this failure, that reading is wrong and sends the reader hunting a resolver defect that does not exist.

Part of `org`'s truth is tail-derived. Truth is the repo; the edges are the warehouse. A registry batch adds org pairs the moment it merges, and none can be recovered until the weekly publish lands — so recall drops to `(n-k)/n` with no resolver defect involved. Exactly the publish-lag case `membership_non_scoring` already documents, in a relation whose message denies it.

## Isolated, not inferred

Same warehouse, two repo states:

| repo state | org recall | truth | n_tail | n_emitted |
|---|---|---|---|---|
| pre-#511 (`9df82a12`) | **1.000** | 446/446 | 5 | 3089 |
| post-#511 (`7b4bb5b9`) | **0.980** | 446/455 | 14 | 3089 |

`n_emitted` identical, truth up 9, recovery up 0. `#511` added 9 tail-derived org pairs the warehouse has not published. Lag, not regression.

## What this adds

The note, plus the test a reader can actually apply: **unchanged `n_emitted` against grown `n_truth` is a lag** and clears at the next publish; **a genuine miss shows `n_emitted` moving while recovery does not.** The docstring now names the caveat instead of asserting the opposite.

## Not changed — flagged for a human

The `>= 0.99` invariant, and what counts as org truth. Making this lag-proof means either scoping truth to what has been published, or exempting unpublished tail pairs. Either is a rubric change.

Worth deciding, because an "invariant" a routine merge can trip is not one — and the same mechanism has `membership_non_scoring` recall at `0.529` right now. Both clear at the next weekly publish, so nothing is broken; the gates are just uninformative for the rest of this week.

## Test plan

- [x] `uv run pytest tests/test_identity_eval.py` — 137 passed
- [x] Live run confirms the note prints under the real failure (`--from-warehouse --floors`)
- [x] Lag hypothesis isolated against the pre-#511 tree on the same warehouse
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)