### PR TITLE
Reject comparison cycles in check_capability (#442)

### DIFF
--- a/build/check_capability.py
+++ b/build/check_capability.py
@@ -19,7 +19,7 @@ noticed when the product it referred to moved.
 `relative_to` and `relation` record it. This module then asks the three questions that a
 recorded comparison makes answerable and a sentence never did.
 
-## The three checks
+## The checks
 
 **Consistency.** If a product records `relative_to: megatron-lm, relation: one_below`, then its
 score must be exactly one below Megatron-LM's. This is the direct analogue of the
@@ -31,6 +31,12 @@ arithmetic over two integers is the whole rule.
 category. A cross-category comparison is not obviously wrong, but it is never what the notes
 are doing, and allowing it silently would let the anchor graph sprawl into a ranking of the
 whole map.
+
+**No cycles.** The arithmetic check reads each edge alone, so a reciprocal pair — X `one_below`
+Y written alongside Y `one_above` X — satisfies both equations while being circular: each
+score's justification is the other's. A ring of any length is the same defect, the reciprocal
+pair its shortest case, so `check` walks the `relative_to` graph and rejects a cycle before the
+graph grows enough to hide one.
 
 **Transitive freshness.** A confirmation of a derived band cannot be more recent than the
 confirmation of the band it derives from. If Megatron-LM's capability was last confirmed in
@@ -184,7 +190,54 @@ def check(scores: dict, owner: dict) -> list[str]:
                 f"{slug}:capability: claims last_verified {claimed}, but {target} was last "
                 f"confirmed {anchor_date}. The comparison was not re-derived"
             )
+
+    for cycle in comparison_cycles(scores):
+        ring = " -> ".join(cycle + [cycle[0]])
+        problems.append(
+            f"{cycle[0]}:capability: comparison cycle {ring}. Each band in the ring is placed "
+            f"against another in it, so none rests on a judgment made outside it"
+        )
     return problems
+
+
+def comparison_cycles(scores: dict) -> list[list[str]]:
+    """Every directed cycle in the `relative_to` graph, each as a list of slugs.
+
+    `check` verifies each edge's arithmetic in isolation, so a reciprocal pair -- X `one_below`
+    Y written alongside Y `one_above` X -- satisfies both equations while being circular: each
+    score's justification is the other's, and neither rests on a read made outside the pair. A
+    cycle of any length is the same defect; the reciprocal pair is only its shortest case.
+
+    `relative_to` is single-valued, so the graph is functional -- every node has at most one
+    successor -- and a walk forward from any node runs into either a dead end or a cycle. Edges
+    `check` already rejects (a self-reference, a target off the map) are left out, so the only
+    thing reported here is a genuine ring. Each ring is returned once, rotated to start at its
+    smallest slug so it reads identically however it was entered.
+    """
+    successor: dict[str, str] = {}
+    for slug, doc in scores.items():
+        target = (doc.get("capability") or {}).get("relative_to")
+        if target and target != slug and target in scores:
+            successor[slug] = target
+
+    cycles: list[list[str]] = []
+    resolved: set[str] = set()
+    for start in sorted(successor):
+        if start in resolved:
+            continue
+        path: list[str] = []
+        seen: dict[str, int] = {}
+        node = start
+        while node in successor and node not in seen and node not in resolved:
+            seen[node] = len(path)
+            path.append(node)
+            node = successor[node]
+        if node in seen:  # the walk closed back onto itself: the tail before it is not part
+            cycle = path[seen[node]:]
+            pivot = cycle.index(min(cycle))
+            cycles.append(cycle[pivot:] + cycle[:pivot])
+        resolved.update(path)
+    return sorted(cycles, key=lambda ring: ring[0])
 
 
 def _attestation_problems(

--- a/docs/reference/capability.md
+++ b/docs/reference/capability.md
@@ -82,7 +82,7 @@ capability:
 Recording the comparison converts an unfalsifiable claim into a falsifiable one — the same
 move `establishes` made for openness. It does **not** make capability derivable from evidence,
 and it does not verify that the comparison is right; it makes the comparison checkable.
-`build/check_capability.py` then asks the three questions a recorded comparison makes
+`build/check_capability.py` then asks the questions a recorded comparison makes
 answerable and a sentence never did:
 
 1. **Consistency.** If a product records `relative_to: megatron-lm, relation: one_below`, its
@@ -97,6 +97,12 @@ answerable and a sentence never did:
    invariant applied to a different dependency: a date is only as good as the least recently
    confirmed thing underneath it. Unless the edge carries an attestation of its own — see
    below.
+4. **No cycles.** Consistency reads each edge alone, so a reciprocal pair — `X one_below Y`
+   written alongside `Y one_above X` — satisfies the arithmetic on both while being circular:
+   each score's justification is the other's, and neither rests on a read made outside the
+   pair. A ring of any length is the same defect, the reciprocal pair its shortest case, so the
+   gate walks the `relative_to` graph and rejects a cycle before the graph grows enough to hide
+   one.
 
 The gate ratchets like the others — it covers the products that record a comparison and does
 not block the ones that do not.

--- a/tests/test_check_capability.py
+++ b/tests/test_check_capability.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import pytest
 
-from build.check_capability import candidates, check, stale_attestations
+from build.check_capability import candidates, check, comparison_cycles, stale_attestations
 
 CATS = {"a": "cat", "b": "cat", "c": "cat", "far": "other"}
 
@@ -281,6 +281,51 @@ def test_a_missing_target_is_caught():
 def test_a_self_reference_is_caught():
     data = scores(a={"score": 4, "basis": "feature_matrix", "relative_to": "a", "relation": "at"})
     assert "points at itself" in check(data, CATS)[0]
+
+
+# --- the comparison graph must be acyclic (#442) ---------------------------------------------
+#
+# The arithmetic check reads each edge alone, so a reciprocal pair passes it while being
+# circular. A ring of any length is the same defect; these pin that check walks the graph.
+
+
+def test_a_reciprocal_pair_is_a_cycle_even_when_the_arithmetic_holds():
+    """X one_below Y and Y one_above X satisfy both equations, so only the cycle check sees it."""
+    data = scores(
+        a={"score": 4, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below"},
+        b={"score": 5, "basis": "feature_matrix", "relative_to": "a", "relation": "one_above"},
+    )
+    problems = check(data, CATS)
+    assert len(problems) == 1
+    assert "comparison cycle a -> b -> a" in problems[0]
+
+
+def test_comparison_cycles_finds_a_longer_ring_once_rotated_to_its_smallest_slug():
+    data = scores(
+        b={"score": 3, "basis": "feature_matrix", "relative_to": "c", "relation": "at"},
+        c={"score": 3, "basis": "feature_matrix", "relative_to": "a", "relation": "at"},
+        a={"score": 3, "basis": "feature_matrix", "relative_to": "b", "relation": "at"},
+    )
+    assert comparison_cycles(data) == [["a", "b", "c"]]
+
+
+def test_an_acyclic_anchor_chain_is_not_a_cycle():
+    """a -> b -> c with c an unanchored root is the normal shape and must stay clean."""
+    data = scores(
+        a={"score": 3, "basis": "feature_matrix", "relative_to": "b", "relation": "one_below"},
+        b={"score": 4, "basis": "feature_matrix", "relative_to": "c", "relation": "one_below"},
+        c={"score": 5, "basis": "feature_matrix"},
+    )
+    assert comparison_cycles(data) == []
+    assert check(data, CATS) == []
+
+
+def test_a_self_reference_is_not_double_reported_as_a_cycle():
+    """The self edge is check()'s to reject; it is excluded from the graph, not counted twice."""
+    data = scores(a={"score": 4, "basis": "feature_matrix", "relative_to": "a", "relation": "at"})
+    problems = check(data, CATS)
+    assert len(problems) == 1
+    assert "points at itself" in problems[0]
 
 
 def test_half_a_comparison_is_caught_here_too():

--- a/tests/test_check_capability.py
+++ b/tests/test_check_capability.py
@@ -320,6 +320,32 @@ def test_an_acyclic_anchor_chain_is_not_a_cycle():
     assert check(data, CATS) == []
 
 
+def test_a_tail_feeding_a_ring_is_not_reported_as_part_of_it():
+    """The slice that drops the tail only runs at a positive offset, which needs care to reach.
+
+    `d -> a -> b -> a` does not exercise it: the walk is entered in sorted order, so it starts
+    at `a`, already inside the ring, and the offset is zero. `a -> c -> b -> c` does — the walk
+    enters at the tail `a`, finds `c` at index 1, and must drop `a` before rotating the ring to
+    its smallest slug. Breaking the slice leaves every other test in this file passing.
+    """
+    data = scores(
+        a={"score": 3, "basis": "feature_matrix", "relative_to": "c", "relation": "at"},
+        c={"score": 3, "basis": "feature_matrix", "relative_to": "b", "relation": "at"},
+        b={"score": 3, "basis": "feature_matrix", "relative_to": "c", "relation": "at"},
+    )
+    assert comparison_cycles(data) == [["b", "c"]]
+
+
+def test_two_disjoint_rings_are_both_reported():
+    data = scores(
+        a={"score": 3, "basis": "feature_matrix", "relative_to": "b", "relation": "at"},
+        b={"score": 3, "basis": "feature_matrix", "relative_to": "a", "relation": "at"},
+        x={"score": 3, "basis": "feature_matrix", "relative_to": "y", "relation": "at"},
+        y={"score": 3, "basis": "feature_matrix", "relative_to": "x", "relation": "at"},
+    )
+    assert comparison_cycles(data) == [["a", "b"], ["x", "y"]]
+
+
 def test_a_self_reference_is_not_double_reported_as_a_cycle():
     """The self edge is check()'s to reject; it is excluded from the graph, not counted twice."""
     data = scores(a={"score": 4, "basis": "feature_matrix", "relative_to": "a", "relation": "at"})


### PR DESCRIPTION
## What

Adds a cycle check to `build/check_capability.py`. Closes #442.

The arithmetic check reads each comparison edge alone, so a reciprocal pair — `X one_below Y`
written alongside `Y one_above X` — satisfies both equations while being circular: each score's
justification is the other's, and neither rests on a read made outside the pair. A ring of any
length is the same defect; the reciprocal pair is its shortest case.

`relative_to` is single-valued, so the graph is functional and a forward walk from any node lands
on either a dead end or a cycle. `comparison_cycles` finds each ring once, rotated to start at its
smallest slug, and `check` fails the gate on it. The live corpus is clean, so the gate stays green.

## Why now

#439's comparison blocks are landing and the graph is about to grow. The defect is already one
edit away: `onetrainer` records at `ai-toolkit`, and #431's score note argues the inverse from the
`ai-toolkit` side. During the attestation pass in #440 the reciprocal edge was deliberately not
written for exactly this reason. A gate is better than remembering.

## Verification

- `uv run python -m build.validate` → `0 error(s)` (2 pre-existing, unrelated `model_families`
  warnings)
- `uv run pytest tests/test_check_capability.py -q` → 42 passed
- No score data changed. Gate, tests and reference doc only.

## Review

Reviewed twice. An ad-hoc Codex pass confirmed the traversal is correct on a functional graph —
the tail is excluded from a reported ring, and the `resolved` set cannot hide a genuine cycle
whatever order the walks are entered in — and confirmed the two exclusions are safe, since
`check` already rejects a self-reference and an off-map target before the arithmetic runs.

It also found a coverage gap, since fixed in `ecb5e253`. Every cycle test entered the graph
already inside the ring, so `path[seen[node]:]` only ever ran at offset zero; replacing that slice
with `path` left all forty tests passing. The case that reaches it is `a -> c -> b -> c`, which
enters at the tail. The obvious `d -> a -> b -> a` does not, because starts are taken in sorted
order and the walk begins inside the ring.
