### PR TITLE
Stop the repository describing a frozen table as though it were live

### DIFF
--- a/docs/architecture/data-architecture.md
+++ b/docs/architecture/data-architecture.md
@@ -410,7 +410,7 @@ The following do not belong in `catalog` long term:
 - repo-derived bridges presented as external inventory;
 - frozen historical tables without an explicit historical label.
 
-`currentai.catalog.stack_map` must be classified and migrated. Its curated identity and membership fields belong in `registry`; any compatibility output required by `scores.stack_contributors` should become an explicitly named compatibility view with a documented deprecation plan.
+ADR-003 settled `currentai.catalog.stack_map`, which this section previously said must still be classified and migrated. It was externalized: removed from this repo's inventory, its producer archived, and the deployed table left frozen under platform ownership at its last publish. Its only reader, `scores.stack_contributors`, was externalized with it, so the compatibility view this section once called for has nothing left to serve. The curated identity and membership fields it carried live in `registry`. Nothing in this repo migrates it now, and a doc that asks someone to is asking them to redo ADR-003.
 
 ### 4.3 `currentai.observations`
 

--- a/docs/reference/queries.md
+++ b/docs/reference/queries.md
@@ -23,27 +23,40 @@ down that read them are historical.
 
 `oso.*` tables are public and can be queried with any valid key.
 
-## Starting points
+## Worked examples (externalized datasets)
 
-**For notebook queries:** use `scores.repos_summary` (a pre-computed snapshot):
+Every example below reads a dataset ADR-003 externalized. They still run. What they return
+stopped advancing at that table's last publish, so a result set that looks current is not,
+and nothing in the query itself says so. Each example carries the warning as a SQL comment,
+which is the only part of this page that survives a copy into your client.
+
+For a table this repo still maintains, start at `registry`, `observations` or `evaluation`.
+
+**Repo-level snapshot,** `scores.repos_summary`:
 ```sql
+-- FROZEN (ADR-003): scores.repos_summary has no producer in this repo and stopped
+-- advancing at its last publish. Results are historical.
 SELECT * FROM currentai.scores.repos_summary WHERE country = 'France' ORDER BY stars DESC
 ```
 
-**For project-level data:** use `scores.project_summary`:
+**Project-level data,** `scores.project_summary`:
 ```sql
+-- FROZEN (ADR-003): historical, no longer refreshed.
 SELECT * FROM currentai.scores.project_summary ORDER BY total_stars DESC LIMIT 20
 ```
 
-**For time-series:** use `metrics.daily` (long format):
+**Time-series,** `metrics.daily` (long format). The series ends at the freeze date, so do not
+read its last point as today:
 ```sql
+-- FROZEN (ADR-003): the series stops at the last publish, it does not run to today.
 SELECT day, value FROM currentai.metrics.daily
 WHERE repo = 'pytorch/pytorch' AND metric = 'stars'
 ORDER BY day
 ```
 
-**For raw events:** use `events.github_events`:
+**Raw events,** `events.github_events`:
 ```sql
+-- FROZEN (ADR-003): no events after the last publish, so counts are a closed window.
 SELECT event_type, COUNT(*) FROM currentai.events.github_events
 WHERE repo = 'pytorch/pytorch' GROUP BY event_type
 ```
@@ -58,7 +71,13 @@ WHERE repo = 'pytorch/pytorch' GROUP BY event_type
 
 ## Join patterns
 
+The `entities`, `metrics` and `scores` joins below all read externalized tables. They are
+kept because the join shapes are still the right ones, not because the data is current.
+
 ```sql
+-- FROZEN (ADR-003): every entities/metrics/scores table in this block is frozen at its
+-- last publish. The join shapes hold; the rows do not advance.
+
 -- Repo → project
 SELECT r.repo, r.project_slug, p.display_name, p.location
 FROM currentai.entities.repos r
@@ -74,7 +93,8 @@ SELECT m.model_id, m.url, m.benchmark_avg
 FROM currentai.entities.models m
 WHERE m.project_slug = 'pytorch'
 
--- Monthly dev counts by category (from metrics.daily)
+-- Monthly dev counts by category (from metrics.daily). The last month is the freeze
+-- month, not the current one.
 SELECT r.category, DATE_TRUNC('month', m.day) AS month,
   MAX(CASE WHEN m.metric = 'contributors' THEN CAST(m.value AS INTEGER) END) AS devs
 FROM currentai.metrics.daily m
@@ -93,7 +113,7 @@ GROUP BY pc.collection_name, c.display_name
 
 ## Join and dedupe caveats
 
-- `scores.repos_summary` and `entities.repos` are already deduped by `LOWER(repo)`. No `ROW_NUMBER()` needed.
+- `scores.repos_summary` and `entities.repos` (both frozen) are already deduped by `LOWER(repo)`. No `ROW_NUMBER()` needed.
 - `signal_goodailist.repo_catalog` is the GoodAI roster. It replaces the retired
   `catalog.goodailist_repos` static model; deduplicate by `LOWER(repo)` when querying it
   directly.
@@ -103,7 +123,7 @@ GROUP BY pc.collection_name, c.display_name
 ## Gap semantics
 
 - Coverage/ingestion gaps (missing orgs/repos) are tracked in GitHub issues.
-- `scores.ossd_coverage` = per-org oss-directory match rates.
+- `scores.ossd_coverage` = per-org oss-directory match rates, frozen at its last publish.
 
 ## Pointers
 

--- a/docs/reference/where-scores-live.md
+++ b/docs/reference/where-scores-live.md
@@ -290,7 +290,7 @@ Four things carry columns named like ours and answer a different question.
 |---|---|---|
 | `currentai.stack_map.product_scores` | The **v1 hand-scored upload**: `adoption_level`, `capability_score`, `capability_value`, `combined_score` per product | **Frozen.** 282 products, 11 categories, newest `last_verified` 2026-05-29, keyed on `product_name` rather than slug. **No deployed model reads it.** |
 | `currentai.catalog.stack_map` | The repo→warehouse taxonomy bridge, carrying `adoption`, `capability`, `maturity` per product | **Externalized and frozen (ADR-003).** Out of the Gap Map's data system; removed from this repo's inventory and its producer archived, frozen under platform ownership at its last publish. Its former reader `scores.stack_contributors` was externalized with it. Not a repo-maintained table. |
-| `currentai.catalog.osai_gap_map` | The **external** OSAI gap map: `ease_of_adoption`, `maturity`, `overall_score` | A different organisation's taxonomy and scale. Not our products, not our axes. |
+| `currentai.catalog.osai_gap_map` | The **external** OSAI gap map: `ease_of_adoption`, `maturity`, `overall_score` | **Externalized and frozen (ADR-003).** A different organisation's taxonomy and scale — not our products, not our axes — and no longer repo-maintained, so it is frozen at its last publish as well as being the wrong scale to compare against. |
 | `currentai.ai_demand_curve.*` | `capability_score`, `adoption_level` against **OpenRouter/LMArena models** | Keyed to model names from a leaderboard, not to gap-map product slugs. |
 
 `currentai.stack_map.category_scores` and `.gap` are the same v1 freeze at category grain.

--- a/docs/sweeps/2026-09-07-tail-batch.md
+++ b/docs/sweeps/2026-09-07-tail-batch.md
@@ -42,7 +42,8 @@ See **Revisions** at the end for all four revisions in one table.
   row here is promoted later through `add-product`, not `promote-category`.
 - **Categories that emit rows:** five. `edge_hardware` was swept and emits nothing — see
   **`edge_hardware`: swept, nothing emitted**.
-- **Not reached:** the warehouse discovery pool (`currentai.entities.repos`). No `OSO_API_KEY` in
+- **Not reached:** the warehouse discovery pool (`currentai.entities.repos`, externalized under
+  ADR-003 and frozen at its last publish). No `OSO_API_KEY` in
   this environment, so the pool was unreachable — reported as a gap, not filled with a guess. It is
   an enrichment and consolidation step, never a rejection step, so its absence does not invalidate
   the dedup below; it does mean multi-signal consolidation rested on self-dedup alone.

--- a/docs/workflows/discover-candidates.md
+++ b/docs/workflows/discover-candidates.md
@@ -43,7 +43,9 @@ head products use `promote-category`; to re-verify what is already published use
   and code that assumed the scalar form is what broke `build_stack_map`. `category_statuses()`
   and `arc_categories()` own that normalization.
 - A time window, so the sweep is reproducible and the next one knows where to start.
-- Warehouse access for the discovery pool (`currentai.entities.repos`), if available. This is
+- Warehouse access for the discovery pool (`currentai.entities.repos`, frozen), if available.
+  ADR-003 externalized the table and it stopped advancing at its last publish, so it will not
+  surface a repository created since then; treat a miss as a stale pool, not an empty world. This is
   the long-tail *discovery* set, not the accepted Gap Map: a repository appearing there may be
   exactly what this workflow should emit. Use it to consolidate multiple signals into one
   entity, recover a canonical repository identity, and enrich a candidate — **presence in the

--- a/tests/test_externalized_table_docs.py
+++ b/tests/test_externalized_table_docs.py
@@ -1,0 +1,147 @@
+"""An externalized table must not be described anywhere as if it were still current.
+
+ADR-003 moved 28 tables out of this repository's scope. They were left live on the OSO
+platform and frozen at their last publish: they still answer a query, they just stop
+advancing. That is the dangerous shape. A deleted table announces itself; a frozen one
+returns rows and looks fine, and the reader only finds out that the numbers stopped moving
+if the docs say so.
+
+So every mention of a still-externalized table in the hand-maintained docs has to carry a
+word that marks it as historical. The list of tables is read from
+`warehouse/audits/externalization.json` through `build.assets.still_externalized()`, not
+kept here: adding a table to the receipt puts it under this rule immediately, with no test
+edit, and reclaiming one (`reclaims`, disposition `reclaimed-as-dependency`) takes it back
+out, because a reclaimed table is live in the governed graph again and describing it as
+current is correct.
+
+Granularity: **the unit of the rule is the unit of copying.**
+
+A mention inside a fenced code block is satisfied by a marker anywhere in that fence at or
+above the mention's own line. A fence is what a reader selects and pastes, so a comment in
+the fence travels with the query into their SQL client, which is where the warning has to
+arrive. Requiring the marker on the mention's own physical line -- the rule the first draft
+of this test used -- cannot be satisfied inside SQL without wedging a comment between
+`FROM` and the table name, and a warning that mangles the query gets deleted.
+
+A mention in prose is satisfied only by a marker on the same line. Prose is read, not
+copied, and the eye lands on the line, so the line is the unit. Deliberately NOT a
+nearest-heading or n-lines-of-context rule: a preamble fifteen lines up is invisible to
+someone who arrived at the section from the table of contents, and a rule that a distant
+paragraph can satisfy is a rule any distant paragraph can fool.
+
+A marker below the mention inside its fence does not count. A warning printed after the
+thing it warns about is not a warning.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from build.assets import still_externalized
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Words that mark a mention as historical rather than a recommendation. The last three are
+# the receipt's own vocabulary for what ADR-003 did.
+MARKERS = (
+    "archived",
+    "superseded",
+    "frozen",
+    "deprecated",
+    "retired",
+    "do not",
+    "externaliz",
+    "no producer",
+    "out of scope",
+)
+
+# The hand-maintained documentation surface, matching tests/test_docs_integrity.py plus the
+# warehouse's own prose. Generated files and the gitignored session workspace are excluded.
+DOC_GLOBS = ("docs/**/*.md", "warehouse/**/*.md", "skills/**/SKILL.md")
+DOC_FILES = ("README.md", "CONTRIBUTING.md", "AGENTS.md", "CLAUDE.md")
+
+
+def doc_files() -> list[Path]:
+    found = {p for pattern in DOC_GLOBS for p in ROOT.glob(pattern) if p.is_file()}
+    found |= {ROOT / name for name in DOC_FILES if (ROOT / name).exists()}
+    return sorted(found)
+
+
+def externalized_tables() -> list[str]:
+    """Fully-qualified tables currently outside the repo's graph, from the receipt."""
+    return sorted({e["table"] for e in still_externalized() if e.get("table")})
+
+
+def has_marker(text: str) -> bool:
+    lowered = text.lower()
+    return any(marker in lowered for marker in MARKERS)
+
+
+def unmarked_mentions(text: str, table: str) -> list[tuple[int, str]]:
+    """Lines mentioning `table` with no marker in their copy unit.
+
+    Inside a fenced block the unit is the fence, from its opening line down to the mention.
+    Outside one it is the single line.
+    """
+    offenders: list[tuple[int, str]] = []
+    in_fence = False
+    fence_marked = False
+    for number, line in enumerate(text.splitlines(), 1):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            fence_marked = has_marker(line) if in_fence else False
+            continue
+        marked = has_marker(line)
+        if in_fence:
+            fence_marked = fence_marked or marked
+        if table in line and not (fence_marked if in_fence else marked):
+            offenders.append((number, line.strip()))
+    return offenders
+
+
+@pytest.mark.parametrize("table", externalized_tables())
+def test_no_doc_presents_an_externalized_table_as_current(table: str) -> None:
+    offenders: list[str] = []
+    for path in doc_files():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if table not in text:
+            continue
+        for number, line in unmarked_mentions(text, table):
+            offenders.append(f"{path.relative_to(ROOT)}:{number}: {line[:120]}")
+    assert not offenders, (
+        f"{table} was externalized under ADR-003 and is frozen at its last publish, but these "
+        f"lines present it as current. A reader would copy them and get data that stopped "
+        f"advancing.\nMark the mention with one of {list(MARKERS)} -- on the same line in prose, "
+        f"or anywhere at or above it inside the code fence:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_table_list_comes_from_the_receipt_and_tracks_reclaims() -> None:
+    """Guard on the guard: an empty or hand-copied list would make the check vacuous."""
+    tables = externalized_tables()
+    assert tables, "the externalization receipt lists no un-reclaimed tables; delete this test"
+    receipt_ids = {e["id"] for e in still_externalized()}
+    assert {t.split(".", 1)[1] for t in tables} == receipt_ids
+    # A reclaimed table is live again and is deliberately out of scope for the rule.
+    from build.assets import externalized, reclaimed_tables
+
+    for reclaimed in reclaimed_tables():
+        assert reclaimed not in tables, f"{reclaimed} was reclaimed; the rule should not cover it"
+    assert len(tables) == len(externalized()) - len(reclaimed_tables())
+
+
+def test_the_check_rejects_an_unmarked_mention_and_accepts_a_marked_one() -> None:
+    """Prove the marker logic can fail, in both copy units."""
+    table = externalized_tables()[0]
+    prose = f"Query `{table}` for the current roster.\n"
+    assert unmarked_mentions(prose, table), "an unmarked prose mention must be caught"
+    assert not unmarked_mentions(f"`{table}` is frozen; do not read it as current.\n", table)
+
+    fenced = f"```sql\n-- FROZEN: stopped advancing at externalization.\nSELECT * FROM {table}\n```\n"
+    assert not unmarked_mentions(fenced, table), "a marker in the fence must satisfy the rule"
+    assert unmarked_mentions(f"```sql\nSELECT * FROM {table}\n```\n", table)
+    # A marker after the mention does not warn anyone.
+    trailing = f"```sql\nSELECT * FROM {table}\n-- that table is frozen\n```\n"
+    assert unmarked_mentions(trailing, table), "a marker below the mention must not count"


### PR DESCRIPTION
# archived-table-doc-guard — pass

**Goal.** Stop the repository describing a frozen table as though it were live. Closed PR #341 carried a test

## Success criteria
- [ ] a test exists that fails when a doc presents an externalized table as current, and its list of tables is derived from `warehouse/audits/externalization.json` rather than hand-maintained, so a table added to the receipt is covered without editing the test
- [ ] the test passes, which means every mention it finds has either been marked or been fixed
- [ ] `docs/reference/queries.md` no longer hands a reader a copy-paste query against a frozen table without telling them the data does not advance
- [ ] `docs/architecture/data-architecture.md` no longer instructs anyone to classify and migrate `currentai.catalog.stack_map`, which ADR-003 already did
- [ ] `uv run python -m build.validate` reports 0 errors
- [ ] `uv run pytest -q` passes
- [ ] no change under `sources/` or `warehouse/models/`; docs and tests only

## Outcome
`pass` after 1 round(s). Branch `loop/archived-table-doc-guard-2026-09-08-a1`.

## Final verdict
```json
{
 "verdict": "pass",
 "blocking": [],
 "non_blocking": [],
 "settled_now": [
  "No P0 blockers found; the documentation fixes communicate actual staleness.",
  "Receipt additions should gate immediately; no grace mechanism is needed.",
  "Fence-level warnings are acceptable at P0, but do not fail closed when readers copy partial fences.",
  "This guard would not generally catch #509 or #517: deleted producers and contradictory governed-asset banners require other checks.",
  "Validation relies on the builder\u2019s reported passing runs; independent reruns were blocked by the read-only environment."
 ],
 "escalation": null
}
```

## Settled ground this run added (9)
- ADR-003 and the externalization receipt as the authority for what is frozen.
- That #341 is closed and correctly so; only its test is being kept.
- Docs and tests only. `sources/` and `warehouse/models/` are out of scope.
- That a frozen table's query examples should stay rather than be deleted — they still execute, and
- No P0 blockers found; the documentation fixes communicate actual staleness.
- Receipt additions should gate immediately; no grace mechanism is needed.
- Fence-level warnings are acceptable at P0, but do not fail closed when readers copy partial fences.
- This guard would not generally catch #509 or #517: deleted producers and contradictory governed-asset banners require other checks.
- Validation relies on the builder’s reported passing runs; independent reruns were blocked by the read-only environment.

Later runs of this job inherit `/workspace/GitHub/personal/agent-loops/jobs/settled/archived-table-doc-guard.json`; prune it there.

_Opened by build-review-loop; builder notes in the first comment._
