### PR TITLE
Rename Perplexica to Vane, and re-declare composable-kernel against the live monorepo

### DIFF
--- a/sources/products/composable-kernel.yaml
+++ b/sources/products/composable-kernel.yaml
@@ -4,7 +4,18 @@ type: software
 description: Composable Kernel provides a programming model and template library for performance-critical machine
   learning kernels, decomposing GEMM, convolution and attention operations into tile-level pieces that recombine
   and fuse. It targets AMD GPUs through ROCm and carries a code generator and dispatcher for instance selection.
-  AMD develops it as part of the ROCm stack.
+  AMD develops it as part of the ROCm stack; development has moved into the consolidated ROCm/rocm-libraries
+  monorepo, and the standalone ROCm/composable_kernel repository is kept as a read-only mirror.
 github:
+- url: https://github.com/ROCm/rocm-libraries
 - url: https://github.com/ROCm/composable_kernel
-comments: Verified 2026-08-18 via the GitHub API and the LICENSE body.
+comments: 'The live repository is ROCm/rocm-libraries, declared first here per #447. The standalone
+  ROCm/composable_kernel repository now describes itself as "[DEPRECATED] Moved to ROCm/rocm-libraries repo"
+  with its develop branch a read-only mirror, so its activity and stars freeze while the product carries on
+  being developed in the monorepo. The monorepo declaration is not product-scoped - rocm-libraries is a super
+  repo holding many AMD libraries, of which this product is one directory - so anything read from it measures
+  the monorepo unless it is scoped to the composable_kernel path first, and the adoption band was deliberately
+  held rather than derived from it; the reason sits on the adoption axis in sources/scores/composable-kernel.yaml.
+  The mirror stays declared alongside it because it is still a real home of this code and the frozen observation
+  baseline carries readings against it; dropping it would leave those observations pointing at an artifact the
+  product no longer declares. Verified 2026-09-08 via the GitHub API.'

--- a/sources/products/perplexica.yaml
+++ b/sources/products/perplexica.yaml
@@ -1,12 +1,15 @@
 name: perplexica
-display_name: Perplexica
+display_name: Vane
 type: software
+aliases:
+- vane
 description: Answer engine that returns answers with citations, pairing a bundled SearXNG metasearch layer
   with local or cloud models so queries stay on the machine the operator runs. It works with Ollama, OpenAI,
   Anthropic, Gemini, Groq or any OpenAI-compatible endpoint, and offers web, academic, discussion, image and
   video search modes plus file-upload retrieval.
 github:
 - url: https://github.com/ItzCrazyKns/Vane
-comments: The project was renamed from Perplexica to Vane in 2026 and the old repository URL redirects. The
-  slug here still reads Perplexica; the rename is an identity question, not an evidence one. Verified 2026-08-13
-  via the ItzCrazyKns/Vane repository.
+comments: The project renamed itself from Perplexica to Vane during 2026, to put distance between it and
+  Perplexity AI, and the old repository URL redirects. The slug stays perplexica because a slug is immutable
+  once links are built on it; the new name resolves through the vane alias, and every source on the record
+  already reads the Vane repository. Verified 2026-08-13 via the ItzCrazyKns/Vane repository.

--- a/sources/scores/composable-kernel.yaml
+++ b/sources/scores/composable-kernel.yaml
@@ -50,9 +50,15 @@ adoption:
   reach: <1K stars
   signal_type: stars_fallback
   confidence: low
-  note: 543 GitHub stars, which lands in the <1K stars band of the stars scale, level 1. Vendored into ROCm libraries
-    and built from source rather than distributed as a package, so the stars scale is the only instrument; at 543
-    stars it bands at 1, the floor.
+  note: '543 GitHub stars, which lands in the <1K stars band of the stars scale, level 1. Vendored into ROCm
+    libraries and built from source rather than distributed as a package, so the stars scale is the only instrument;
+    at 543 stars it bands at 1, the floor. That figure comes from the standalone ROCm/composable_kernel repository,
+    now a read-only mirror, and the band is deliberately held there rather than taken from the declared
+    ROCm/rocm-libraries artifact. Two reasons, either sufficient. The monorepo is a super repo carrying many
+    AMD libraries, so its star count measures the monorepo and not this product, which is the measurement-population
+    rule. And #441 settled that a star count carries no count of use, so trading one star figure for another
+    would move the level without adding evidence for it. The band stays at the floor until an instrument scoped
+    to the composable_kernel directory exists.'
   last_verified: '2026-08-18'
   sources:
   - url: https://api.github.com/repos/ROCm/composable_kernel


### PR DESCRIPTION
Two of the three identity rulings from the 2026-09-08 decision session. The third is held back and
the reason is worth reading.

## #303 — Perplexica is now Vane

The slug stays `perplexica`, because a slug is immutable once links are built on it. `display_name`
becomes Vane and the new name resolves through an `aliases` entry.

One correction to the ruling as written: it says to add an entry to `sources/slug_aliases.yaml`.
That file was **retired on 2026-08-08** — a duplicate key silently kept only the last value, and
several of its top-level keys were not alias maps at all. Aliases are a field on the product record
now. The intent was right, the mechanism had moved.

## #447 — composable-kernel declares the live monorepo

`ROCm/composable_kernel` now describes itself as `[DEPRECATED] Moved to ROCm/rocm-libraries`, with
its develop branch a read-only mirror, so its stars and activity freeze while the product carries
on being developed elsewhere. The record now declares `ROCm/rocm-libraries` first.

The deprecated repository stays declared alongside it, because the frozen observation baseline
carries readings against it and dropping it would leave those observations pointing at an artifact
the product no longer declares.

**The adoption band is deliberately held at its recorded level**, and the record says why in two
independent ways. The monorepo is a super repo holding many AMD libraries, so its star count
measures the monorepo rather than this product — the measurement-population rule. And #441 settled
that a star count carries no count of use, so trading one star figure for another would move the
level without adding evidence for it.

## Why #262 is not here

The ruling was "retire `perspective-api` now, no alias target" — taken on the understanding that it
was cheaper than adding an `end_of_life` field. Building it showed otherwise. Retirement with no
alias target has no mechanism in this repo, and the implementation that survives the existing gates
came to a new `build/withdrawals.py`, a schema, a `sources/withdrawals.yaml`, a test module, changes
to `validate`, `assets`, `check_retirement` and `declaration_version`, and a CI trigger — roughly
540 new lines, plus deleting a 96-line score record and an organization.

That is a subsystem, not a data edit, and the premise the ruling rested on was wrong. It is going
back for a second look rather than landing on a stale assumption. The work is preserved on #522.

## Verification

- `uv run python -m build.validate` → 0 errors, 2 warnings (pre-existing `model_families` pattern
  overlaps, unrelated)
- `uv run pytest -k "identity or alias or adoption or rubric"` → 435 passed
