### PR TITLE
Add an end_of_life field, and declare perspective-api ending

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,8 +146,10 @@ registry, plus the single `sources/taxonomy.yaml` manifest:
   business logic. Open artifacts are declared as typed top-level arrays of `{url: ...}`
   objects: `github`, `npm`, `pypi`, `crates`, `go`, `huggingface_model`,
   `huggingface_dataset`, `arxiv`. Only keys with entries are included; `product.schema.json`
-  is the authoritative list. Four further optional keys are not artifacts and are documented
-  in the schema: `aliases`, `lineage`, `version_in_identity`, `artifact_exceptions`. Optional
+  is the authoritative list. Five further optional keys are not artifacts and are documented
+  in the schema: `aliases`, `lineage`, `version_in_identity`, `artifact_exceptions`,
+  `end_of_life` (a declared sunset date for a product that still works; it moves no score and
+  no category stage -- docs/reference/identity.md). Optional
   `comments` is a free-text string for provenance and scoring notes (version, license, last
   release date).
 - **scores**: one file per product (same slug) with `openness`, `adoption`, `capability`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,10 +146,8 @@ registry, plus the single `sources/taxonomy.yaml` manifest:
   business logic. Open artifacts are declared as typed top-level arrays of `{url: ...}`
   objects: `github`, `npm`, `pypi`, `crates`, `go`, `huggingface_model`,
   `huggingface_dataset`, `arxiv`. Only keys with entries are included; `product.schema.json`
-  is the authoritative list. Five further optional keys are not artifacts and are documented
-  in the schema: `aliases`, `lineage`, `version_in_identity`, `artifact_exceptions`,
-  `end_of_life` (a declared sunset date for a product that still works; it moves no score and
-  no category stage -- docs/reference/identity.md). Optional
+  is the authoritative list. Four further optional keys are not artifacts and are documented
+  in the schema: `aliases`, `lineage`, `version_in_identity`, `artifact_exceptions`. Optional
   `comments` is a free-text string for provenance and scoring notes (version, license, last
   release date).
 - **scores**: one file per product (same slug) with `openness`, `adoption`, `capability`.

--- a/build/check_payload.py
+++ b/build/check_payload.py
@@ -88,6 +88,30 @@ def _require_dict(payload: dict, key: str) -> dict:
     return value
 
 
+def _check_end_of_life(slug: str, eol: object) -> None:
+    """Gate the shape of a declared end-of-life record.
+
+    The field says a product still works and stops on a stated day, and the payload is where a
+    reader meets that claim. A row carrying `end_of_life` that the app cannot read -- a bare
+    string where the object belongs, a date in some other notation, a source that is not a
+    link -- would render as nothing at all, which is the one outcome worse than never declaring
+    it: the map would look like it had checked and found no sunset. So an unreadable record
+    fails here rather than being skipped.
+    """
+    if not isinstance(eol, dict):
+        raise PayloadError(
+            f"{slug!r} has an end_of_life that is not an object (got {type(eol).__name__})"
+        )
+    date = eol.get("date")
+    if not is_iso_date(date):
+        raise PayloadError(f"{slug!r} has an end_of_life date that is not ISO 8601: {date!r}")
+    source = eol.get("source")
+    if not isinstance(source, str) or not source.startswith(("http://", "https://")):
+        raise PayloadError(
+            f"{slug!r} declares an end_of_life with no usable source URL: {source!r}"
+        )
+
+
 def check(payload: dict) -> None:
     if not isinstance(payload, dict):
         raise PayloadError(f"payload is not an object (got {type(payload).__name__})")
@@ -138,6 +162,8 @@ def check(payload: dict) -> None:
                 or fresh.get("basis") not in _FRESHNESS_BASES):
             raise PayloadError(f"{slug!r} has no usable freshness record")
         _check_freshness_caveats(slug, fresh)
+        if "end_of_life" in row:
+            _check_end_of_life(slug, row["end_of_life"])
 
     dates = {row["freshness"]["date"] for row in rows}
     if len(dates) <= 1:

--- a/build/serialize.py
+++ b/build/serialize.py
@@ -18,7 +18,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 PRODUCT_KEY_ORDER = ["slug", "product", "org_slug", "org", "type", "description",
                      "openness", "adoption", "capability", "overall_score", "tier",
-                     "maturity", "mature",
+                     "maturity", "mature", "end_of_life",
                      "freshness", "version_note", "lineage"]
 
 # --- Gap analysis (category-level stage + gaps) -----------------------------
@@ -320,6 +320,20 @@ def _row(slug: str, prod: dict, org_slug: str, org_name: str, score: dict,
     row["mature"] = (
         m is not None and m >= _MATURE_MIN and openness["bucket"] == "open"
     )
+    # A declared end-of-life date: the product still works and stops on that day. Emitted as
+    # the date and the announcement link, so a consumer can say the product is ending and point
+    # at who said so; the `shows` quote stays in sources/ because the payload is not the audit
+    # trail. It is deliberately inert in every number above it -- the openness, adoption and
+    # capability blocks, `overall_score`, `tier`, `mature` and the category stage all read the
+    # same as they did before the field was declared. A date that moved a score would move a
+    # category's stage with no evidence change and no curator acting; where a sunset has really
+    # moved usage, that belongs in the adoption LEVEL with a source. Nothing here compares the
+    # date to today either: the payload carries what was declared, and whether that day has
+    # passed is the reader's arithmetic, not a value that silently changes overnight.
+    # See docs/reference/identity.md.
+    eol = prod.get("end_of_life")
+    if eol:
+        row["end_of_life"] = {"date": eol["date"], "source": eol["source"]}
     # Bridge: the source field is now `comments` (a string), but the payload key
     # the notebook consumes is still `version_note`. Same value, renamed at rest.
     if prod.get("comments"):

--- a/docs/reference/identity.md
+++ b/docs/reference/identity.md
@@ -124,13 +124,15 @@ that stops in three months, and for that case the argument is:
 - The reader is better served by the fact than by an arithmetic gesture. "This category's leading
   open option stops in December" is a sentence the map can print. A silently lowered stage is not.
 
-**Nothing happens when the date passes.** No automatic retirement, no change in the payload, no
-gate that turns red overnight; an ending product does not become a different kind of record by
-being left alone. The date passing is a curation trigger. On or after it, a curator re-reads the
-source and either keeps the record with a past date, which is honest and still linkable, or
-retires the slug through the alias mechanism if something has actually replaced it. If a sweep is
-ever wanted for dates that have gone by, it belongs with the verification queue, alongside the
-other work that a curator picks up, and not in a build gate.
+**Nothing happens when the date passes.** Nothing in the build compares `end_of_life.date` to
+today's date. `build/serialize.py` copies the declared date onto the product row, the gates read
+it as a declared fact, and no arithmetic anywhere consults the calendar, so a record whose date
+has gone by serializes, validates and scores exactly as it did the day before. What a curator
+should then do with such a record -- keep it with a past date, retire the slug through the alias
+mechanism, or something else -- is deliberately not settled here. It is a curation policy, it
+needs a decision from a maintainer rather than a default set by the change that added the field,
+and it belongs on its own issue. Until that issue is settled, a past date is a fact on the record
+and nothing more; do not read this section as permission to leave one there indefinitely.
 
 ### What a consumer sees
 

--- a/docs/reference/identity.md
+++ b/docs/reference/identity.md
@@ -73,6 +73,75 @@ is the other, and its target sits beside a still-live `github-copilot`.
 The rule: an alias is a promise to anyone holding an old link. Where no such link could exist,
 make no promise, and leave the slug free to be reused.
 
+## A product that is ending
+
+Between live and retired there is a third state: the product still works, still has users, and
+stops on a date somebody has announced. Retirement does not fit it. Retirement here is
+implemented as aliasing a dead slug onto the product that replaced it, and a withdrawal has no
+successor to point at, so the mechanism has nothing to attach to. Dropping the record instead is
+not available either: the gates require a product in exactly one category roster and exactly one
+org roster, and a single-product organization goes with it.
+
+So the product keeps its record and declares the date:
+
+```yaml
+end_of_life:
+  date: '2026-12-31'
+  source: https://perspectiveapi.com/
+  shows: "'Perspective API is sunsetting and service is officially ending after 2026',
+    with 'The service will remain active until December 31, 2026'"
+  accessed: '2026-08-13'
+```
+
+`date` is the day service stops, not the day it was announced, because the reader's question is
+how long they have. `source` and `shows` are required for the same reason a score's citation is:
+an end-of-life date is the least checkable claim on the record, and a page saying support ends is
+a different date from a page saying the service is switched off.
+
+### What it changes, and what it does not
+
+**Identity is untouched.** The slug stays live, the product stays in exactly one category roster
+and one org roster, its organization stays resolvable, and its score files stay where they are.
+That is the whole difference from retirement, and it is what makes declaring one cheap.
+
+**No number moves.** Openness, adoption and capability read the same. So do the derived
+`overall_score`, `tier` and `mature`, and so does the category's stage and its gaps: an
+end-of-life product counts toward its category exactly as it did the day before the field was
+added.
+
+That is a deliberate rule and not an artifact of the first case. `perspective-api` is
+`openness.class: closed` and the stage computation is strict open-only, so it was inert either
+way — recomputing `safeguards` with the row removed returns the same Stage 3 and the same
+`adoption` gap. The rule has to hold for the case that is not inert, a fully open product at 4.5
+that stops in three months, and for that case the argument is:
+
+- A stage is a **count of what exists now**. Excluding an ending product would drop a category a
+  rung on a calendar tick, with no evidence change and nobody deciding anything. Promotion in
+  this repo is a human act; demotion is not allowed to be cheaper than promotion.
+- Where a sunset has genuinely moved usage, that belongs in the **adoption level**, written by a
+  curator with a source a reader can audit. A penalty applied by the schema would double-count
+  with an honest re-score and would be invisible in the numbers it changed.
+- The reader is better served by the fact than by an arithmetic gesture. "This category's leading
+  open option stops in December" is a sentence the map can print. A silently lowered stage is not.
+
+**Nothing happens when the date passes.** No automatic retirement, no change in the payload, no
+gate that turns red overnight; an ending product does not become a different kind of record by
+being left alone. The date passing is a curation trigger. On or after it, a curator re-reads the
+source and either keeps the record with a past date, which is honest and still linkable, or
+retires the slug through the alias mechanism if something has actually replaced it. If a sweep is
+ever wanted for dates that have gone by, it belongs with the verification queue, alongside the
+other work that a curator picks up, and not in a build gate.
+
+### What a consumer sees
+
+`build/serialize.py` emits `date` and `source` onto the product row in the payload, so a consumer
+can say the product is ending and link the announcement. The `shows` quote stays in `sources/`:
+the payload carries the claim, the repo carries the audit trail. `build/check_payload.py` fails
+on a row whose `end_of_life` it cannot read, because a malformed record renders as nothing and
+would leave the map looking as though it had checked and found no sunset. Rendering it is the
+front end's side of the contract, and until `aipotluck.org` reads the key, the fact reaches a
+reader only through the prose fields.
+
 ## When one slug covers several releases
 
 Collapsing releases into a tier means one score describes several things. The combine rules:
@@ -423,7 +492,7 @@ eval prints them next to the failing row.
 - `docs/reference/openness.md` — the ladders, and the multi-SKU rule the rubric applies
 - `docs/reference/product-copy.md` — the prose fields, and why a curation rationale is not a
   description
-- `docs/schemas/product.schema.json` — `aliases` and `version_in_identity`
+- `docs/schemas/product.schema.json` — `aliases`, `version_in_identity` and `end_of_life`
 - `docs/reference/adoption.md` — the instruments a declared artifact routes to, and the
   precedence order `select_route` applies
 - `sources/resolution_ledger.yaml` — where a rejected or reassigned identity is recorded, so

--- a/docs/schemas/product.schema.json
+++ b/docs/schemas/product.schema.json
@@ -49,6 +49,38 @@
       "type": "string",
       "description": "The other hand-authored prose field, and a footnote rather than a second description: how we know what the entry says. In practice the verification line, plus the occasional note about a judgment call or an evidence gap. Also published copy \u2014 build/serialize.py renames it to `version_note` in the payload and the front end renders it under `description` in smaller type \u2014 so a fact stated in both fields is read twice. The test for which field a sentence belongs in, the canonical `Verified <YYYY-MM-DD> via <source>.` form, and why the license must not be restated here are all in docs/reference/product-copy.md. Its verification line is editorial provenance for the PROSE and is not a score's `last_verified`: writing one earns nothing on any axis, and the two mechanisms are kept apart deliberately (docs/reference/evidence-and-freshness.md). 464 of 472 products carry one on 2026-08-08."
     },
+    "end_of_life": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "date",
+        "source",
+        "shows"
+      ],
+      "description": "The date this product stops working, declared for a product that is still live. It exists because the schema otherwise offers two states and neither is honest about a service in its final months: scored normally, which recommends something that stops in December with the sunset visible only to a reader of the prose, or retired, which is implemented as aliasing a dead slug onto the product that replaced it and so assumes a successor a withdrawal does not have. Perspective API is the first case (#262). WHAT IT CHANGES: nothing that is computed. The product keeps its slug, stays in exactly one category roster and one org roster, keeps its scores, and counts toward its category's stage and gaps exactly as it did before - which is what makes declaring one cheap, and is the whole difference from retirement. build/serialize.py emits `date` and `source` into the payload row so the front end can render the fact; build/check_payload.py gates the shape. Where a sunset has actually moved usage, that belongs in the adoption LEVEL with a source a reader can audit, not in a penalty this field applies behind the scenes: a date that quietly deducted maturity would double-count with an honest re-score, and would move a category's stage on a calendar tick with no evidence change and no human act. Nothing fires when the date passes either - it is a curation trigger, not a transition. docs/reference/identity.md carries the rule and what a curator does on the day.",
+      "properties": {
+        "date": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "description": "The last day the product works, as the announcement states it, ISO 8601. The day service stops rather than the day it was announced: a reader asks how long they have. Quoted in YAML, because an unquoted date parses to a `datetime.date` and fails this string type - the same reason every `accessed` and `last_verified` in sources/ is quoted. Pattern-checked rather than `format: date`, since jsonschema's draft-07 validator ignores `format` unless a format checker is passed and build/validate.py passes none, so a `format` here would assert a check nobody runs."
+        },
+        "source": {
+          "type": "string",
+          "pattern": "^https?://",
+          "description": "The page that announces the end, http(s) only. Required, on the same principle as a score's citation: an end-of-life date is a claim about a product's future and the least checkable thing on the record, so it ships with the document it came from or not at all. Emitted into the payload beside the date, so the front end can link the reader at the announcement instead of asking them to take the map's word for it."
+        },
+        "shows": {
+          "type": "string",
+          "minLength": 1,
+          "description": "What the source actually says, quoted from the page that was read - the same job `shows` does on a score's sources[] entry. It is what lets somebody check the date without trusting the curator, and it is the field that catches the common error: a page saying support ends and a page saying the service is switched off are different dates, and a paraphrase loses the difference. Stays in the repo; the payload carries the date and the link, not the quote."
+        },
+        "accessed": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "description": "When the source was read, ISO 8601. Optional, and editorial provenance for THIS fact only: it is not a score's `last_verified` and earns nothing on any axis (docs/reference/evidence-and-freshness.md). Worth writing, because a sunset notice is a page that gets edited - dates move and get withdrawn."
+        }
+      }
+    },
     "github": {
       "type": "array",
       "items": {

--- a/docs/workflows/update-product.md
+++ b/docs/workflows/update-product.md
@@ -17,6 +17,7 @@ flowchart TD
     B -->|Description or comments only| D["Refresh product prose"]
     B -->|Score evidence or a score value| E["Re-verify the affected axes"]
     B -->|Which category or org it belongs to| F["Update the rosters"]
+    B -->|Announced an end date, still works| S["Declare an end-of-life date"]
     B -->|Retired / superseded by another product| R["Record a retirement alias"]
     E --> G{"One product or systemic?"}
     G -->|This one product| H["Product-scoped verification"]
@@ -64,6 +65,28 @@ A score change is evidence work, and it earns a date. Do **not** just edit the n
 Move the slug between `sources/categories/*.yaml` and/or `sources/organizations/*.yaml`. A slug
 appears in exactly one of each. See [`edit-category.md`](edit-category.md) for the category side.
 
+### Declare an end-of-life date — the product is ending but still works
+A product with an announced end date is neither a normal record nor a retirement: it still works
+and still has users, and retirement here means aliasing the slug onto a successor a withdrawal
+does not have. Add `end_of_life` to `sources/products/<slug>.yaml` with the day service stops,
+the page that announces it, and a quote from that page:
+```yaml
+end_of_life:
+  date: '2026-12-31'
+  source: https://perspectiveapi.com/
+  shows: "'The service will remain active until December 31, 2026'"
+  accessed: '2026-08-13'
+```
+Nothing else changes. The product stays on its category and org rosters and keeps its scores, and
+the date moves no score and no category stage — if the sunset has actually moved usage, that is
+the axis route below, written as an adoption level with a source. Nothing fires when the date
+passes either; re-read the source then and decide whether to keep the record or retire the slug.
+The rule is [`../reference/identity.md`](../reference/identity.md). Validate:
+```bash
+uv run python -m build.validate
+uv run python -m build.serialize --date ci-dry-run && uv run python -m build.check_payload
+```
+
 ### Record a retirement alias — the product was superseded
 A slug is retired only by being recorded as an **alias** on the product that replaced it, never
 deleted — `check_retirement` fails a slug that leaves the payload without a redirect. Add the
@@ -87,6 +110,7 @@ uv run python -m build.validate            # always — 0 error(s)
 # then, per route:
 uv run python -m build.check_artifacts     # identity / artifacts changed
 uv run python -m build.check_retirement    # a retirement alias was recorded
+uv run python -m build.check_payload       # an end-of-life date was declared
 uv run python -m build.check_verification  # an axis was re-dated
 ```
 Never commit `build/notebook_data.json` or `notebooks/` (bot-owned).

--- a/docs/workflows/update-product.md
+++ b/docs/workflows/update-product.md
@@ -80,7 +80,8 @@ end_of_life:
 Nothing else changes. The product stays on its category and org rosters and keeps its scores, and
 the date moves no score and no category stage — if the sunset has actually moved usage, that is
 the axis route below, written as an adoption level with a source. Nothing fires when the date
-passes either; re-read the source then and decide whether to keep the record or retire the slug.
+passes either — no gate compares the date to today — and what a curator should do with a record
+whose date has gone by is deliberately left open, not settled by this field.
 The rule is [`../reference/identity.md`](../reference/identity.md). Validate:
 ```bash
 uv run python -m build.validate

--- a/sources/products/perspective-api.yaml
+++ b/sources/products/perspective-api.yaml
@@ -7,3 +7,9 @@ description: Jigsaw's free hosted API for scoring the toxicity of text and relat
 comments: The service runs until 31 December 2026; new usage and quota requests closed in February 2026 and
   no migration support is offered. The reason given is that AI capabilities have evolved and demand for a standalone
   tool in this area has fallen. Verified 2026-08-13 via the Perspective API site.
+end_of_life:
+  date: '2026-12-31'
+  source: https://perspectiveapi.com/
+  shows: '''Important Notice - Perspective API is sunsetting and service is officially ending after 2026'',
+    with ''The service will remain active until December 31, 2026'' and no migration support offered.'
+  accessed: '2026-08-13'

--- a/tests/test_check_payload.py
+++ b/tests/test_check_payload.py
@@ -155,3 +155,38 @@ def test_fails_when_org_slug_is_missing_entirely():
     p = _ok(); del p["categories"]["c"]["products"][0]["org_slug"]
     with pytest.raises(PayloadError, match="missing organization"):
         check(p)
+
+
+def _ending():
+    p = _ok()
+    p["categories"]["c"]["products"][0]["end_of_life"] = {
+        "date": "2026-12-31", "source": "https://example.com/sunset"}
+    return p
+
+
+def test_passes_a_well_formed_end_of_life_row():
+    check(_ending())
+
+
+def test_fails_an_end_of_life_that_is_not_an_object():
+    """A bare date is the shortcut a curator reaches for, and the app cannot render it."""
+    p = _ending(); p["categories"]["c"]["products"][0]["end_of_life"] = "2026-12-31"
+    with pytest.raises(PayloadError, match="not an object"):
+        check(p)
+
+
+def test_fails_an_end_of_life_date_in_another_notation():
+    p = _ending(); p["categories"]["c"]["products"][0]["end_of_life"]["date"] = "31/12/2026"
+    with pytest.raises(PayloadError, match="ISO 8601"):
+        check(p)
+
+
+def test_fails_an_end_of_life_with_no_usable_source():
+    """The claim reaches the reader; the link that backs it has to reach them too."""
+    p = _ending(); p["categories"]["c"]["products"][0]["end_of_life"]["source"] = "perspectiveapi.com"
+    with pytest.raises(PayloadError, match="no usable source"):
+        check(p)
+
+
+def test_a_row_with_no_end_of_life_is_unaffected():
+    check(_ok())

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -681,3 +681,66 @@ def test_a_built_payload_never_carries_an_undescribed_gap():
     for cid in payload["order"]:
         for gap in payload["categories"][cid]["gaps"]:
             assert gap in described, f"category {cid} carries undescribed gap {gap!r}"
+
+
+def _ending_sources():
+    s = _sources()
+    s["products"]["llama-4"]["end_of_life"] = {
+        "date": "2026-12-31",
+        "source": "https://example.com/sunset",
+        "shows": "the service will remain active until December 31, 2026",
+        "accessed": "2026-08-13",
+    }
+    return s
+
+
+def test_end_of_life_reaches_the_payload_with_its_source():
+    """The reader meets this fact in the payload, not in the YAML.
+
+    The date alone would be an unciteable claim on the one field that most needs a citation, so
+    the announcement link ships with it. The `shows` quote does not: the payload carries the
+    claim, sources/ carries the audit trail.
+    """
+    row = build_payload(_ending_sources(), frozen_long_tail={}, generated="2026-06-10"
+                        )["categories"]["base_pretrained"]["products"][0]
+    assert row["end_of_life"] == {"date": "2026-12-31",
+                                  "source": "https://example.com/sunset"}
+    assert "shows" not in row["end_of_life"]
+
+
+def test_a_product_with_no_end_of_life_carries_no_key():
+    row = build_payload(_sources(), frozen_long_tail={}, generated="2026-06-10"
+                        )["categories"]["base_pretrained"]["products"][0]
+    assert "end_of_life" not in row
+
+
+def test_ending_moves_no_score_and_no_stage():
+    """The rule the field is worth having: declaring one changes nothing that is computed.
+
+    A stage is a count of what exists now, so dropping an ending product out of it would move a
+    category on a calendar tick with no evidence change and no curator acting. Where a sunset has
+    really moved usage, that is an adoption level a reader can audit. Asserted on the whole row
+    rather than on the score alone, so a future penalty applied to `tier` or `mature` fails here
+    too.
+    """
+    plain = build_payload(_sources(), frozen_long_tail={}, generated="2026-06-10")
+    ending = build_payload(_ending_sources(), frozen_long_tail={}, generated="2026-06-10")
+    before = plain["categories"]["base_pretrained"]
+    after = ending["categories"]["base_pretrained"]
+    assert after["stage"] == before["stage"] and after["gaps"] == before["gaps"]
+    assert {k: v for k, v in after["products"][0].items() if k != "end_of_life"} \
+        == before["products"][0]
+
+
+def test_ending_is_declared_rather_than_derived_from_today():
+    """A date already past serializes the same as one in the future.
+
+    Nothing compares the date to the clock, so the payload cannot change overnight for a product
+    nobody touched, and no stage can move on the day a service stops.
+    """
+    s = _ending_sources()
+    s["products"]["llama-4"]["end_of_life"]["date"] = "2019-01-01"
+    row = build_payload(s, frozen_long_tail={}, generated="2026-06-10"
+                        )["categories"]["base_pretrained"]["products"][0]
+    assert row["end_of_life"]["date"] == "2019-01-01"
+    assert row["mature"] is False and row["maturity"] == 4.0

--- a/tests/test_signal_routing.py
+++ b/tests/test_signal_routing.py
@@ -31,6 +31,10 @@ ROOT = Path(__file__).resolve().parents[1]
 # `artifact_exceptions` is the subtle one: it is an annotation ABOUT artifacts (why
 # `pymilvus`'s downloads stand in for the Milvus server, why distilabel's PyPI metadata names
 # a dead org), not an artifact itself.
+#
+# `end_of_life` is a declared date and its citation. Nothing about it is countable, and that is
+# the point: the day a service stops is announced on a page, never emitted by a registry, so
+# there is no source to route it to and no signal it could ever become.
 METADATA_KEYS = {
     "name",
     "display_name",
@@ -41,6 +45,7 @@ METADATA_KEYS = {
     "lineage",
     "version_in_identity",
     "artifact_exceptions",
+    "end_of_life",
 }
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -859,3 +859,51 @@ def test_load_sources_tolerates_a_tree_with_no_model_families_or_org_handles_fil
     real = load_sources(ROOT)
     assert real["model_families"]["families"], "the real corpus must not load as empty"
     assert real["org_handles"]["handles"], "the real corpus must not load as empty"
+
+
+def _ending(slug="llama"):
+    """The fixture with one product declared end-of-life, live and stopping on a date."""
+    d = _fixture()
+    d["products"][slug]["end_of_life"] = {
+        "date": "2026-12-31",
+        "source": "https://example.com/sunset",
+        "shows": "the service will remain active until December 31, 2026",
+        "accessed": "2026-08-13",
+    }
+    return d
+
+
+def test_an_ending_product_still_satisfies_the_roster_and_organization_gates():
+    """The point of the field, stated as a test.
+
+    Retiring a product means deleting it, and the gates refuse that: a product must appear in
+    exactly one category roster and exactly one org roster, and every org roster slug must
+    resolve to a product file — with a single-product org, retirement takes the organization
+    too. `end_of_life` is the state that keeps all of it, so the ending product stays rostered,
+    stays owned, and stays scored. If this ever fails, the field has become a second retirement
+    mechanism rather than an alternative to one.
+    """
+    assert validate_sources(_ending()) == []
+
+
+def test_end_of_life_needs_a_source_for_its_date():
+    """A date nobody can check is the one thing this field must not be able to say."""
+    d = _ending()
+    del d["products"]["llama"]["end_of_life"]["source"]
+    assert any("schema" in e and "source" in e for e in validate_sources(d))
+
+
+def test_end_of_life_rejects_a_bare_date():
+    """`end_of_life: 2026-12-31` reads naturally and carries no citation, so it is refused.
+
+    It is also what a curator writes first, and YAML parses an unquoted date to a
+    `datetime.date` rather than a string, so both spellings of the shortcut fail here.
+    """
+    for value in ("2026-12-31", __import__("datetime").date(2026, 12, 31)):
+        d = _ending()
+        d["products"]["llama"]["end_of_life"] = value
+        assert [e for e in validate_sources(d) if "schema" in e]
+
+
+def test_a_product_with_no_end_of_life_is_unaffected():
+    assert not [e for e in validate_sources(_fixture()) if "end_of_life" in e]


### PR DESCRIPTION
# end-of-life-field — pass

**Goal.** Give the schema a way to say a product is live but ending, and use it on `perspective-api`. Closes

## Success criteria
- [ ] `docs/schemas/product.schema.json` accepts an optional `end_of_life` date. The schema sets `additionalProperties: false`, so this is a deliberate addition rather than a free-form key
- [ ] `sources/products/perspective-api.yaml` declares it, with the date the service stops and a source for that date
- [ ] `uv run python -m build.validate` reports 0 errors with the field present
- [ ] the record a reader sees says the product is ending — in the serialized payload, not only in the YAML, since the payload is what the front end renders
- [ ] `docs/reference/identity.md` states what the field means and what it does and does not change, so the next product that ends is handled the same way
- [ ] `uv run pytest -q` passes, with a test that an `end_of_life` product still satisfies the roster and organization gates
- [ ] `sources/`, `docs/` and `build/` only; nothing under `warehouse/`

## Outcome
`pass` after 2 round(s). Branch `loop/end-of-life-field-2026-09-08-a1`.

## Final verdict
```json
{
 "verdict": "pass",
 "blocking": [],
 "non_blocking": [],
 "settled_now": [
  "Both round-one blockers are resolved: AGENTS.md is absent from the full diff, and post-expiry curation policy is explicitly deferred.",
  "The data-side change satisfies the agreed scope. Rendering end_of_life.date and its source in aipotluck.org remains held.",
  "Full-suite verification remains builder-reported: 1881 passed, 1 skipped."
 ],
 "escalation": null
}
```

## Settled ground this run added (11)
- That the field is the chosen shape. The withdrawals subsystem is preserved on #522 and is not
- That the product, its score record and the Jigsaw organization all stay. Keeping them is the
- That leaving it scored until December was considered and rejected, because it defers the same
- `sources/`, `docs/` and `build/` only.
- The sourced object and serialized date/source satisfy the data-side requirement; generated payload files should remain uncommitted.
- Declaring the field leaves scores, counts, stages, and gaps unchanged, including for fully open products.
- The aipotluck.org counterpart must render end_of_life.date and its source; that consumer work remains held.
- Independent validation returned 0 errors and 2 warnings. Test execution was blocked by the read-only environment; the full-suite result remains builder-reported.
- Both round-one blockers are resolved: AGENTS.md is absent from the full diff, and post-expiry curation policy is explicitly deferred.
- The data-side change satisfies the agreed scope. Rendering end_of_life.date and its source in aipotluck.org remains held.
- Full-suite verification remains builder-reported: 1881 passed, 1 skipped.

Later runs of this job inherit `/workspace/GitHub/personal/agent-loops/jobs/settled/end-of-life-field.json`; prune it there.

_Opened by build-review-loop; builder notes in the first comment._
