### PR TITLE
chore(freshness): rolling re-verification 2026-09-10

### DIFF
--- a/sources/scores/amazon-bedrock-custom-models-fine-tuning.yaml
+++ b/sources/scores/amazon-bedrock-custom-models-fine-tuning.yaml
@@ -15,7 +15,7 @@ openness:
   confidence: high
   note: Proprietary managed customization service inside AWS Bedrock, no source, runs only on AWS against
     Bedrock-hosted foundation models.
-  last_verified: '2026-09-09'
+  last_verified: '2026-09-10'
   raw: source:closed;training-code:closed;runs-on:AWS-Bedrock-only;license:Proprietary(managed AWS service,
     token+storage billed)
   sources:
@@ -25,7 +25,7 @@ openness:
       engine referenced anywhere on the page. A billing note states training is charged by tokens processed
       "and model storage charged per month per model," a metered AWS commercial arrangement rather than
       any code license -- consistent with the recorded source:closed and license:Proprietary components.
-    accessed: '2026-09-09'
+    accessed: '2026-09-10'
     http_status: 200
     content_sha256: d28a9ace3f45102bd7662c308714aad4c83ed189053eb47ada74fe4e1f1261dc
     establishes:


### PR DESCRIPTION
Deterministic re-verification of the oldest products. Openness dates were stamped only where every recorded dimension's digested source came back byte-identical.

```
atropos                          stamped=[] drifted=4 transient=0 skipped=0
megatron-lm                      stamped=[] drifted=6 transient=0 skipped=0
openai-fine-tuning-api           stamped=[] drifted=1 transient=2 skipped=0
swift                            stamped=[] drifted=6 transient=0 skipped=0
trl                              stamped=[] drifted=10 transient=0 skipped=0
amazon-bedrock-custom-models-fine-tuning stamped=['openness'] drifted=0 transient=0 skipped=0
anyscale-fine-tuning             stamped=[] drifted=1 transient=0 skipped=0
apple-core-ml-runtime            stamped=[] drifted=3 transient=0 skipped=0
aws-neuron                       stamped=[] drifted=2 transient=0 skipped=0
axolotl                          stamped=[] drifted=2 transient=0 skipped=0
azure-openai-fine-tuning         stamped=[] drifted=4 transient=0 skipped=0
cerebras-inference               stamped=[] drifted=1 transient=0 skipped=0
ds4                              stamped=[] drifted=2 transient=0 skipped=0
fireworks-fine-tuning            stamped=[] drifted=2 transient=0 skipped=0
fireworks-inference              stamped=[] drifted=2 transient=0 skipped=0
google-cloud-tpu-inference       stamped=[] drifted=2 transient=0 skipped=0
groq-inference                   stamped=[] drifted=2 transient=0 skipped=0
lamini                           stamped=[] drifted=1 transient=0 skipped=0
litgpt                           stamped=[] drifted=2 transient=0 skipped=0
llama-cpp                        stamped=[] drifted=2 transient=0 skipped=0
llama-factory                    stamped=[] drifted=5 transient=0 skipped=0
llamafile                        stamped=[] drifted=2 transient=0 skipped=0
lmdeploy                         stamped=[] drifted=3 transient=0 skipped=0
localai                          stamped=[] drifted=2 transient=0 skipped=0
max                              stamped=[] drifted=2 transient=0 skipped=0
```

Drifted and transient axes need the agent leg (refresh-category, scoped to these products).
