### PR TITLE
Name the pytest gate in edit-category and update-product

### DIFF
--- a/docs/workflows/edit-category.md
+++ b/docs/workflows/edit-category.md
@@ -52,8 +52,18 @@ here and not next door — is prose: put it in the category's `comments`, and in
 ## Validation
 ```bash
 uv run python -m build.validate            # must print 0 error(s)
+uv run pytest -q                           # the identity ratchets live here, not in the gate
 ```
 Then serialize and render locally to preview; do not commit the generated notebook or payload.
+
+`validate` alone is not enough the moment a **seed roster** is involved. A registry row names
+its org directly, so it feeds org truth exactly as a head product's artifacts do, and seeding
+candidates from an org the corpus has not met raises a handle-coverage denominator with nothing
+to match it. That drops the ratio below its pinned baseline and fails
+`tests/test_identity_eval.py`, which `validate` does not run. Register the org's accounts in
+`sources/org_handles.yaml` in the same PR — see the note in
+[`add-product.md`](add-product.md#files-this-changes) for the shape and for
+`build.propose_org_handles`.
 
 ## Expected PR contents
 The category file, plus `taxonomy.yaml` if you created or regrouped a category, and an optional

--- a/docs/workflows/edit-category.md
+++ b/docs/workflows/edit-category.md
@@ -57,9 +57,10 @@ uv run pytest -q                           # the identity ratchets live here, no
 Then serialize and render locally to preview; do not commit the generated notebook or payload.
 
 `validate` alone is not enough the moment a **seed roster** is involved. A registry row names
-its org directly, so it feeds org truth exactly as a head product's artifacts do, and seeding
-candidates from an org the corpus has not met raises a handle-coverage denominator with nothing
-to match it. That drops the ratio below its pinned baseline and fails
+its org directly, so it feeds org truth exactly as a head product's artifacts do. Seeding a
+candidate from a new org, or adding the first artifact on a route its existing org has no handle
+for, raises a handle-coverage denominator with nothing to match it. That drops the ratio below
+its pinned baseline and fails
 `tests/test_identity_eval.py`, which `validate` does not run. Register the org's accounts in
 `sources/org_handles.yaml` in the same PR — see the note in
 [`add-product.md`](add-product.md#files-this-changes) for the shape and for

--- a/docs/workflows/update-product.md
+++ b/docs/workflows/update-product.md
@@ -121,9 +121,11 @@ The pytest line is not optional on the identity and membership routes. Handle co
 ratchet over orgs-with-a-handle / orgs-with-artifacts, per platform, so **adding an artifact of a
 kind its org has no handle for** — a first `huggingface_model` on a product whose org is
 GitHub-only, say — raises the denominator alone and fails
-`tests/test_identity_eval.py`. **Moving a product to a different org** can do it from the other
-side, by leaving the old org's last artifact of a kind behind. Neither shows up in `validate` or
-`check_artifacts`; both are fixed by a row in `sources/org_handles.yaml`, per
+`tests/test_identity_eval.py`. **Moving a product to a different org** changes which org must be
+covered on every route its artifacts use: the destination needs matching handles, and removing
+the source org's last artifact on a route can also lower the ratio when that org was covered.
+Neither shows up in `validate` or `check_artifacts`; add any missing destination handles in
+`sources/org_handles.yaml`, per
 [`add-product.md`](add-product.md#files-this-changes).
 
 ## Files this changes

--- a/docs/workflows/update-product.md
+++ b/docs/workflows/update-product.md
@@ -113,8 +113,18 @@ uv run python -m build.check_artifacts     # identity / artifacts changed
 uv run python -m build.check_retirement    # a retirement alias was recorded
 uv run python -m build.check_payload       # an end-of-life date was declared
 uv run python -m build.check_verification  # an axis was re-dated
+uv run pytest -q                           # org membership or artifacts changed
 ```
 Never commit `build/notebook_data.json` or `notebooks/` (bot-owned).
+
+The pytest line is not optional on the identity and membership routes. Handle coverage is a
+ratchet over orgs-with-a-handle / orgs-with-artifacts, per platform, so **adding an artifact of a
+kind its org has no handle for** — a first `huggingface_model` on a product whose org is
+GitHub-only, say — raises the denominator alone and fails
+`tests/test_identity_eval.py`. **Moving a product to a different org** can do it from the other
+side, by leaving the old org's last artifact of a kind behind. Neither shows up in `validate` or
+`check_artifacts`; both are fixed by a row in `sources/org_handles.yaml`, per
+[`add-product.md`](add-product.md#files-this-changes).
 
 ## Files this changes
 Whichever the route above names — never the generated `build/notebook_data.json` or `notebooks/`.


### PR DESCRIPTION
Fast follow to #531.

#531 failed CI because `add-product` named four gates and the check that caught it lives in the test suite, which none of the four runs. That doc is fixed. This does the same for the two remaining workflows that can trip the identity ratchets without saying so.

## Why these two

Handle coverage is a ratchet over orgs-with-a-handle / orgs-with-artifacts, per platform. Anything that moves a denominator without moving a numerator fails `tests/test_identity_eval.py`, and nothing in `build.validate` sees it.

- **`edit-category`** creates seed rosters. A registry row names its org directly (`identity_eval.py` reads tail declarations as org truth), so a new org or a first artifact on a route its existing org has no handle for can raise the denominator on its own.
- **`update-product`** reaches it from two sides. Adding a first artifact of a kind its org has no handle for raises the denominator alone. Moving a product between orgs changes which org must be covered on every route its artifacts use; either the destination can lack a handle or the source can leave the denominator when its last artifact on that route moves.

`refresh-category`, `promote-category`, `migrate-axis` and `discover-candidates` already run pytest. These were the last two that did not.

Both new notes point at `add-product.md`'s explanation rather than restating it, so the fix has one home.

## Test plan

```
uv run python -m build.validate   # 0 error(s), 2 pre-existing warnings
uv run pytest -q                  # 1888 passed, 1 skipped
```

Docs only — no corpus files touched, so no review sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gb57nwHcF9vd952S2NNboq
