### PR TITLE
Make build.preflight discoverable, and a postmortem on why it wasn't

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,6 +355,14 @@ normative `docs/reference/evidence-and-freshness.md`.
 
 ## Testing
 
+- **Before you push, run `uv run python -m build.preflight`.** It executes every step CI's
+  `validate` workflow executes and accounts for the three it cannot run locally, so it does not
+  drift the way a hand-copied gate list does. `--skip-tests` drops pytest and finishes in about
+  seventy seconds, which is the loop to use while iterating. Assembling your own subset of
+  `build.check_*` calls looks equivalent and is not: it silently omits `check_components`,
+  `check_adoption --strict`, `check_instrument`, `check_routing`, `check_payload`,
+  `check_retirement`, the goldens check and the serializer dry-runs. `build/preflight.py`'s
+  docstring records the promotion that learned this by shipping a failure to CI.
 - Fast local loop: `uv run pytest -q -n auto -m "not serial"`. `-n auto` runs the suite across
   local cores via `pytest-xdist`; `not serial` skips the handful of tests that mutate the real
   working tree and would collide with a concurrent worker (run those separately with

--- a/docs/operations/postmortem-2026-09-10-scientific-ai-models.md
+++ b/docs/operations/postmortem-2026-09-10-scientific-ai-models.md
@@ -1,0 +1,133 @@
+# Postmortem: the Scientific AI models category took a day
+
+**Date:** 2026-09-10 to 2026-09-11
+**Outcome:** the category shipped — 34 products, published, all gates green ([#537](https://github.com/currentai-org/os-ai-map/pull/537))
+**Cost:** roughly seven hours wall clock from the first commit to the merge, most of it avoidable, and it required continuous supervision from the repository owner.
+
+This is written for the next agent that adds a category. The corrective changes are already
+made; this document explains why they were needed.
+
+## What happened
+
+A request to add two products — a multilingual eval harness and the NASA-IBM Lunar Foundation
+Model — turned into a new category, because the lunar model had nowhere to go. The eval harness
+took about forty minutes and was correct. The category took the rest of the day.
+
+## The numbers
+
+| | |
+|---|---|
+| CI runs on the category branch | 42 |
+| `validate` failures on that branch | 6 |
+| `validate` duration | 7–13 min, ~11 avg |
+| Full local `pytest -q` runs | ~6, at 12 min each |
+| `pytest -q -n auto -m "not serial"` | **4m10s** — documented in AGENTS.md, never used |
+| `build.preflight --skip-tests` | **74s** — covers all six CI failures, never used |
+
+Six CI failures at ~11 minutes each is over an hour of pure waiting, and each one cost a
+round-trip of attention as well. Every one of them was reproducible locally in 74 seconds.
+
+## Root cause: the tooling existed and was not discoverable
+
+`build/preflight.py` runs what CI's `validate` workflow runs — all fifteen locally-runnable
+steps — and accounts for the three it cannot. Its docstring opens with a near-identical
+incident:
+
+> The promotion of five products passed a local loop of `validate` + `check_recipe` +
+> `check_rubric` + `check_verification` + `pytest`, then failed CI on `build.check_components`
+> with ten errors: the `raw:` strings had been hand-written and did not recompose from their
+> structured `components` mappings.
+
+That is exactly what happened again, on six products instead of five. The tool built to prevent
+it was referenced in **one** operations document and in none of the workflow docs, none of the
+skills, and not in AGENTS.md. So the loop was reassembled by hand from the gate lists in the
+workflow docs, which were themselves incomplete — `promote-category.md` named nine gates and CI
+runs eighteen.
+
+**A hand-assembled subset of `build.check_*` looks complete and is not.** It omits
+`check_components`, `check_adoption --strict`, `check_instrument`, `check_routing`,
+`check_payload`, `check_retirement`, the goldens check and four serializer dry-runs.
+
+## Contributing: the skill was not invoked
+
+`promote-category` is a registered skill whose workflow document carries the triage rules, the
+boundary convention, the six files a promotion touches and the publication conditions. It was
+not invoked until several hours in, and reading it then surfaced two rules already broken:
+
+- **Step 7** — extending a shared license tier reaches every inheriting category and is a
+  maintainer's ruling, not part of a promotion. Six tier names had already been added.
+- **`build/components.py`** — the only sanctioned way to edit an existing corpus file. Hand
+  edits to component details left six `raw:` strings behind, which is the CI failure above.
+
+`CLAUDE.md` says to use the registered skill for the workflow. Doing so at minute zero would
+have surfaced both.
+
+## Contributing: research was serialized before it was parallelized
+
+The first attempt at researching products worked through them one at a time under a
+"calibration protocol", concluded the attributes were unreadable, and reported back. The owner
+then scored ten products himself. The remaining twenty-four were done by four parallel agents in
+about fifteen minutes of wall clock.
+
+`add-product.md` already says parallel research agents work well for a batch. The batch was
+twenty-four products from the first minute.
+
+## Contributing: decisions were escalated that the repository had already answered
+
+Four decisions went to the owner. Two were his to make — the category boundary, and the
+shared-ladder ruling. Two were already answered in the repo and cost a round-trip each:
+
+- How to derive a capability rubric with no scores to fit against. `base_pretrained` already
+  ships `capability.bands: null` with a `bands_status` saying the thresholds await scores.
+- Whether a one-third rung ceiling was a gate. It is one line of prose about rung *wording*,
+  enforced nowhere, and **16 of 18 categories exceed it**.
+
+## Contributing: one bad instruction propagated to twenty-four products
+
+Four research agents were told PyPI could not be used for adoption banding pending an open
+issue. The opposite was true: `signal_routing.yaml` already declares the precedence
+`pypi > huggingface > stars`, and `check_channel_authority` forbids falling through to stars
+once a usage route exists. Three products were mis-banded and an issue was filed on a false
+premise. **A wrong rule in a batch brief is wrong twenty-four times.**
+
+## What actually worked
+
+- **Adversarial verification as a separate stage.** Four read-only agents re-derived every score
+  and found seven real corrections. 22 of 24 sampled digests reproduced byte-for-byte, so the
+  research was honest; what needed fixing was judgment.
+- **Asking the second reviewer the question no gate covers.** Per-batch reviewers cannot see
+  cross-batch inconsistency, because each sees only its own products. A Codex pass aimed
+  specifically at that found three inconsistencies the four batch reviewers structurally could
+  not, each becoming a roster-wide ruling.
+- **The gates themselves.** Every score in the category reproduces mechanically from its
+  components; every dated claim carries a digest that re-fetches.
+
+## Changes made
+
+1. `AGENTS.md` Testing now leads with `build.preflight` and says why a hand-assembled subset is
+   not equivalent.
+2. All seven `docs/workflows/*.md` Validation sections lead with `build.preflight` instead of a
+   hand-copied gate list, keeping the individual gates below for re-running one after a failure.
+3. All five skills with a "Scripts to run" section do the same.
+4. `promote-category.md` gained the eight gates its list was missing, plus the two that bite a
+   promotion specifically (`check_components`, `check_channel_authority`) and the rule that
+   `tests/goldens/corpus.json` must never be regenerated in a PR.
+5. `add-product.md`, `edit-category.md` and `update-product.md` gained the `org_handles.yaml`
+   step and the pytest gate ([#531](https://github.com/currentai-org/os-ai-map/pull/531),
+   [#534](https://github.com/currentai-org/os-ai-map/pull/534)).
+
+## The shape of a category addition, next time
+
+1. **Invoke the skill first.** `promote-category`, before reading anything else.
+2. **Dispatch batch research in parallel from the first minute**, with one shared brief. Check
+   every rule in that brief against the repo before sending it — a wrong rule is wrong once per
+   product.
+3. **`build.preflight --skip-tests` after every material change.** Seventy seconds.
+   `pytest -q -n auto -m "not serial"` is four minutes, not twelve. Full `preflight` once before
+   pushing.
+4. **Run an adversarial cross-batch pass as a standard second stage**, not as a reaction to
+   doubt. Ask it explicitly for consistency between batches, and tell it which gates already
+   cover the mechanics so it does not re-derive them.
+5. **Escalate exactly three things**: the category boundary and name, the capability rubric
+   shape, and any shared-ladder ruling. Everything else is either mechanical or already answered
+   in `docs/reference/`.

--- a/docs/workflows/add-product.md
+++ b/docs/workflows/add-product.md
@@ -86,6 +86,21 @@ workflow that clears its row, so this is the only place it happens.
    thing a batch disturbs: category straplines.
 
 ## Validation
+
+**Run `uv run python -m build.preflight` and read what it says.** It executes what CI's
+`validate` workflow executes — all fifteen locally-runnable steps — and *accounts for the three
+it cannot*, so there is no hand-copied gate list here to drift out of step with
+`.github/workflows/validate.yml`. `--skip-tests` drops the pytest step and finishes in about
+seventy seconds; run it without the flag once before you push.
+
+It exists because a hand-assembled loop of `validate` + `check_recipe` + `check_rubric` +
+`check_verification` + `pytest` looks complete and is not: it misses `check_components`,
+`check_adoption --strict`, `check_instrument`, `check_routing`, `check_payload`,
+`check_retirement`, the goldens check and the serializer dry-runs. Read `build/preflight.py`'s
+own docstring for the promotion that discovered this the expensive way.
+
+The individual gates below are what preflight runs, listed so a failure can be re-run alone:
+
 ```bash
 uv run python -m build.validate            # must print 0 error(s)
 uv run python -m build.check_recipe        # the ladder accepts the new score

--- a/docs/workflows/discover-candidates.md
+++ b/docs/workflows/discover-candidates.md
@@ -256,6 +256,21 @@ candidate.
 
 ## Validation
 
+**Run `uv run python -m build.preflight` and read what it says.** It executes what CI's
+`validate` workflow executes — all fifteen locally-runnable steps — and *accounts for the three
+it cannot*, so there is no hand-copied gate list here to drift out of step with
+`.github/workflows/validate.yml`. `--skip-tests` drops the pytest step and finishes in about
+seventy seconds; run it without the flag once before you push.
+
+It exists because a hand-assembled loop of `validate` + `check_recipe` + `check_rubric` +
+`check_verification` + `pytest` looks complete and is not: it misses `check_components`,
+`check_adoption --strict`, `check_instrument`, `check_routing`, `check_payload`,
+`check_retirement`, the goldens check and the serializer dry-runs. Read `build/preflight.py`'s
+own docstring for the promotion that discovered this the expensive way.
+
+The individual gates below are what preflight runs, listed so a failure can be re-run alone:
+
+
 ```bash
 uv run python -m build.validate          # schema + roster integrity; must print 0 error(s)
 uv run pytest tests/ -q                  # full suite

--- a/docs/workflows/edit-category.md
+++ b/docs/workflows/edit-category.md
@@ -50,6 +50,21 @@ here and not next door — is prose: put it in the category's `comments`, and in
    file no longer carries `arc` or cross-category `order`.
 
 ## Validation
+
+**Run `uv run python -m build.preflight` and read what it says.** It executes what CI's
+`validate` workflow executes — all fifteen locally-runnable steps — and *accounts for the three
+it cannot*, so there is no hand-copied gate list here to drift out of step with
+`.github/workflows/validate.yml`. `--skip-tests` drops the pytest step and finishes in about
+seventy seconds; run it without the flag once before you push.
+
+It exists because a hand-assembled loop of `validate` + `check_recipe` + `check_rubric` +
+`check_verification` + `pytest` looks complete and is not: it misses `check_components`,
+`check_adoption --strict`, `check_instrument`, `check_routing`, `check_payload`,
+`check_retirement`, the goldens check and the serializer dry-runs. Read `build/preflight.py`'s
+own docstring for the promotion that discovered this the expensive way.
+
+The individual gates below are what preflight runs, listed so a failure can be re-run alone:
+
 ```bash
 uv run python -m build.validate            # must print 0 error(s)
 uv run pytest -q                           # the identity ratchets live here, not in the gate

--- a/docs/workflows/migrate-axis.md
+++ b/docs/workflows/migrate-axis.md
@@ -62,6 +62,21 @@ The schema, one or more `build/` modules, the migration script, `docs/reference/
 the script only — every affected `sources/scores/*.yaml`. Warehouse SQL is a maintainer follow-up.
 
 ## Validation
+
+**Run `uv run python -m build.preflight` and read what it says.** It executes what CI's
+`validate` workflow executes — all fifteen locally-runnable steps — and *accounts for the three
+it cannot*, so there is no hand-copied gate list here to drift out of step with
+`.github/workflows/validate.yml`. `--skip-tests` drops the pytest step and finishes in about
+seventy seconds; run it without the flag once before you push.
+
+It exists because a hand-assembled loop of `validate` + `check_recipe` + `check_rubric` +
+`check_verification` + `pytest` looks complete and is not: it misses `check_components`,
+`check_adoption --strict`, `check_instrument`, `check_routing`, `check_payload`,
+`check_retirement`, the goldens check and the serializer dry-runs. Read `build/preflight.py`'s
+own docstring for the promotion that discovered this the expensive way.
+
+The individual gates below are what preflight runs, listed so a failure can be re-run alone:
+
 ```bash
 uv run python -m build.validate            # 0 error(s) under the new schema
 uv run python -m build.check_verification

--- a/docs/workflows/promote-category.md
+++ b/docs/workflows/promote-category.md
@@ -101,6 +101,21 @@ alias redirects and the long-tail sample - and `build/validate.published_product
 owner of that visibility. Anything new the payload emits derives from it.
 
 ## Validation
+
+**Run `uv run python -m build.preflight` and read what it says.** It executes what CI's
+`validate` workflow executes — all fifteen locally-runnable steps — and *accounts for the three
+it cannot*, so there is no hand-copied gate list here to drift out of step with
+`.github/workflows/validate.yml`. `--skip-tests` drops the pytest step and finishes in about
+seventy seconds; run it without the flag once before you push.
+
+It exists because a hand-assembled loop of `validate` + `check_recipe` + `check_rubric` +
+`check_verification` + `pytest` looks complete and is not: it misses `check_components`,
+`check_adoption --strict`, `check_instrument`, `check_routing`, `check_payload`,
+`check_retirement`, the goldens check and the serializer dry-runs. Read `build/preflight.py`'s
+own docstring for the promotion that discovered this the expensive way.
+
+The individual gates below are what preflight runs, listed so a failure can be re-run alone:
+
 ```bash
 uv run python -m build.validate            # must print 0 error(s)
 uv run python -m build.check_recipe        # the ladder accepts every recorded score

--- a/docs/workflows/refresh-category.md
+++ b/docs/workflows/refresh-category.md
@@ -100,6 +100,21 @@ appeared, and date it, citing the page that publishes nothing. See
 [`../reference/evidence-and-freshness.md`](../reference/evidence-and-freshness.md).
 
 ## Validation
+
+**Run `uv run python -m build.preflight` and read what it says.** It executes what CI's
+`validate` workflow executes — all fifteen locally-runnable steps — and *accounts for the three
+it cannot*, so there is no hand-copied gate list here to drift out of step with
+`.github/workflows/validate.yml`. `--skip-tests` drops the pytest step and finishes in about
+seventy seconds; run it without the flag once before you push.
+
+It exists because a hand-assembled loop of `validate` + `check_recipe` + `check_rubric` +
+`check_verification` + `pytest` looks complete and is not: it misses `check_components`,
+`check_adoption --strict`, `check_instrument`, `check_routing`, `check_payload`,
+`check_retirement`, the goldens check and the serializer dry-runs. Read `build/preflight.py`'s
+own docstring for the promotion that discovered this the expensive way.
+
+The individual gates below are what preflight runs, listed so a failure can be re-run alone:
+
 The canonical gate list for a category batch — run all of it, not a remembered subset:
 ```bash
 uv run python -m build.validate                       # 0 error(s)

--- a/docs/workflows/update-product.md
+++ b/docs/workflows/update-product.md
@@ -104,6 +104,21 @@ in `validate.yml` runs after its serialize step), but run it locally to catch a 
 before you push.
 
 ## Validation
+
+**Run `uv run python -m build.preflight` and read what it says.** It executes what CI's
+`validate` workflow executes — all fifteen locally-runnable steps — and *accounts for the three
+it cannot*, so there is no hand-copied gate list here to drift out of step with
+`.github/workflows/validate.yml`. `--skip-tests` drops the pytest step and finishes in about
+seventy seconds; run it without the flag once before you push.
+
+It exists because a hand-assembled loop of `validate` + `check_recipe` + `check_rubric` +
+`check_verification` + `pytest` looks complete and is not: it misses `check_components`,
+`check_adoption --strict`, `check_instrument`, `check_routing`, `check_payload`,
+`check_retirement`, the goldens check and the serializer dry-runs. Read `build/preflight.py`'s
+own docstring for the promotion that discovered this the expensive way.
+
+The individual gates below are what preflight runs, listed so a failure can be re-run alone:
+
 Run the checks named by the route you took (above), plus the baseline that applies to every
 change:
 ```bash

--- a/skills/add-product/SKILL.md
+++ b/skills/add-product/SKILL.md
@@ -27,6 +27,15 @@ material it names (`identity.md`, `openness.md`, `adoption.md`, `capability.md`,
 
 ## Scripts to run
 ```bash
+uv run python -m build.preflight --skip-tests   # every CI validate gate, ~70s
+uv run python -m build.preflight                # the same plus pytest, before you push
+```
+`build.preflight` runs what `.github/workflows/validate.yml` runs and accounts for every step it
+cannot run locally, so it does not drift the way a copied gate list does. Do not hand-assemble a
+subset — that is what shipped a `check_components` failure to CI once already.
+
+The individual gates, for re-running one after a failure:
+```bash
 uv run python -m build.validate            # 0 error(s)
 uv run python -m build.check_recipe        # the ladder accepts the score
 uv run python -m build.check_verification  # producible pair

--- a/skills/edit-category/SKILL.md
+++ b/skills/edit-category/SKILL.md
@@ -25,6 +25,15 @@ requires its product + score files to exist first (`add-product`).
 
 ## Scripts to run
 ```bash
+uv run python -m build.preflight --skip-tests   # every CI validate gate, ~70s
+uv run python -m build.preflight                # the same plus pytest, before you push
+```
+`build.preflight` runs what `.github/workflows/validate.yml` runs and accounts for every step it
+cannot run locally, so it does not drift the way a copied gate list does. Do not hand-assemble a
+subset — that is what shipped a `check_components` failure to CI once already.
+
+The individual gates, for re-running one after a failure:
+```bash
 uv run python -m build.validate            # 0 error(s)
 ```
 

--- a/skills/migrate-axis/SKILL.md
+++ b/skills/migrate-axis/SKILL.md
@@ -27,6 +27,15 @@ helpers, never a `yaml.load`/`dump` round-trip.
 
 ## Scripts to run
 ```bash
+uv run python -m build.preflight --skip-tests   # every CI validate gate, ~70s
+uv run python -m build.preflight                # the same plus pytest, before you push
+```
+`build.preflight` runs what `.github/workflows/validate.yml` runs and accounts for every step it
+cannot run locally, so it does not drift the way a copied gate list does. Do not hand-assemble a
+subset — that is what shipped a `check_components` failure to CI once already.
+
+The individual gates, for re-running one after a failure:
+```bash
 uv run python -m build.validate            # under the new schema
 uv run python -m build.check_verification
 uv run python -m build.check_payload

--- a/skills/promote-category/SKILL.md
+++ b/skills/promote-category/SKILL.md
@@ -34,6 +34,15 @@ corpus files only through `build/components.py` - never load-modify-dump a file 
 
 ## Scripts to run
 ```bash
+uv run python -m build.preflight --skip-tests   # every CI validate gate, ~70s
+uv run python -m build.preflight                # the same plus pytest, before you push
+```
+`build.preflight` runs what `.github/workflows/validate.yml` runs and accounts for every step it
+cannot run locally, so it does not drift the way a copied gate list does. Do not hand-assemble a
+subset — that is what shipped a `check_components` failure to CI once already.
+
+The individual gates, for re-running one after a failure:
+```bash
 uv run python -m build.validate            # 0 error(s)
 uv run python -m build.check_recipe
 uv run python -m build.check_rubric

--- a/skills/update-product/SKILL.md
+++ b/skills/update-product/SKILL.md
@@ -28,6 +28,15 @@ alias, never a deletion).
 
 ## Scripts to run
 ```bash
+uv run python -m build.preflight --skip-tests   # every CI validate gate, ~70s
+uv run python -m build.preflight                # the same plus pytest, before you push
+```
+`build.preflight` runs what `.github/workflows/validate.yml` runs and accounts for every step it
+cannot run locally, so it does not drift the way a copied gate list does. Do not hand-assemble a
+subset — that is what shipped a `check_components` failure to CI once already.
+
+The individual gates, for re-running one after a failure:
+```bash
 uv run python -m build.validate
 uv run python -m build.check_artifacts     # if artifacts changed
 uv run python -m build.check_retirement    # if you recorded an alias


### PR DESCRIPTION
`build/preflight.py` already runs what CI's `validate` workflow runs — all fifteen locally-runnable steps — and accounts for the three it cannot. It was referenced in **one** operations document, and in none of the workflow docs, none of the skills, and not in `AGENTS.md`.

So the Scientific AI models promotion never found it, reassembled the loop by hand from the workflow docs' gate lists, and those lists were incomplete — `promote-category.md` named nine gates where CI runs eighteen. **Six CI failures followed at 7–13 minutes each. `preflight --skip-tests` reproduces all six in 74 seconds.**

The sharpest detail: preflight's own docstring opens with the same incident at five products instead of six. The tool built to prevent this could not prevent it, because nothing led anyone to it.

## Changes

| Where | What |
|---|---|
| `AGENTS.md` | Testing now leads with `build.preflight` and says why a hand-assembled subset of `build.check_*` is not equivalent |
| `docs/workflows/*.md` (7) | Validation sections lead with preflight; individual gates kept below for re-running one after a failure |
| `.claude/skills/*/SKILL.md` (5) | same, in the "Scripts to run" sections |
| `docs/operations/postmortem-2026-09-10-scientific-ai-models.md` | new |

No corpus files touched.

## Two numbers worth internalizing

- `pytest -q -n auto -m "not serial"` → **4m10s**. Plain `pytest -q` → **12m**. The fast form is already documented in `AGENTS.md` and was not used once during the promotion.
- `build.preflight --skip-tests` → **74s**, against an ~11m CI round-trip.

## The postmortem

Written for the next agent that adds a category, not as a narrative. It carries the numbers, four contributing causes — the skill not invoked until hours in, research serialized before it was parallelized, decisions escalated that `docs/reference/` had already answered, and one wrong rule in a batch brief propagating to 24 products — what actually worked, and a five-step shape for the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gb57nwHcF9vd952S2NNboq