### PR TITLE
Cover the whole window since 0.3.0 in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
   ([#537](https://github.com/currentai-org/os-ai-map/pull/537)).
 - `languagebench` (`fair-forward/evals-for-every-language`) to `evaluation_code`, with the
   `fair-forward` organization ([#531](https://github.com/currentai-org/os-ai-map/pull/531)).
+- An `end_of_life` field on the product schema, and `perspective-api` declared ending. The map had
+  two states for a product and neither was honest about a service with an announced shutdown date;
+  the date and its source serialize onto the product row, and `check_payload` gates the shape.
+  Nothing in the build compares the date to today, so an expired product is not yet treated
+  differently — the post-expiry policy is deferred
+  ([#524](https://github.com/currentai-org/os-ai-map/pull/524)).
+- A comparison-cycle check in `check_capability`. The arithmetic check read each `relative_to` edge
+  in isolation, so a cycle of edges could be individually valid and collectively unresolvable
+  ([#516](https://github.com/currentai-org/os-ai-map/pull/516)).
 
 ### Changed
 
@@ -51,6 +60,8 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
   runs each CI step locally and accounts for the three it cannot. It already existed and was
   undiscoverable, which is what `docs/operations/postmortem-2026-09-10-scientific-ai-models.md` was
   written about ([#539](https://github.com/currentai-org/os-ai-map/pull/539)).
+- `perplexica` renamed to Vane, and `composable-kernel` re-declared, on the identity rulings of
+  2026-09-08 ([#523](https://github.com/currentai-org/os-ai-map/pull/523)).
 
 ### Fixed
 
@@ -61,6 +72,11 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
 - `edit-category` and `update-product` name the pytest gate, which neither did — a category or
   product edit can break a pinned test without failing any `build.*` check
   ([#534](https://github.com/currentai-org/os-ai-map/pull/534)).
+- `reverify` addresses a source entry by position rather than by URL, so an axis citing one page
+  twice under different `establishes` lists — legal, and 55 (product, axis) pairs do it — can no
+  longer have a confirmation stamped onto the wrong citation. That defect is why the reverify
+  workflow had a single run in its history and it failed
+  ([#528](https://github.com/currentai-org/os-ai-map/pull/528)).
 
 ### Removed
 


### PR DESCRIPTION
#541 backfilled this session's PRs and stopped at #530, leaving the six days between the v0.3.0 release commit and this session unrecorded. This walks every first-parent merge after `e9752f3a` and adds the four that clear the file's bar.

| Heading | Added here |
|---|---|
| Added | the `end_of_life` field with `perspective-api` declared ending (#524); the comparison-cycle check in `check_capability` (#516) |
| Changed | `perplexica` renamed to Vane, `composable-kernel` re-declared (#523) |
| Fixed | `reverify` addressing a source entry by position (#528) |

**Deliberately out**, against the same bar — "routine maintenance stays out": the two freshness re-verifies (#526, #530), which re-dated evidence and re-classified nothing; the weekly candidate sweep (#511), whose 71 registry rows are inputs rather than products; the doc restructures (#503, #504, #507, #510, #515); and the internal test and ratchet re-pins (#505, #513, #520). #519 was already the Removed entry.

Both new categories were already recorded in #541 — `embeddings_retrieval` and `scientific_ai_models` are the only two the taxonomy gained since 0.3.0 (18 → 20 published), which I re-checked by diffing the taxonomy at the tag.

I also confirmed by diffing `sources/products`, `sources/categories` and `sources/organizations` between the release commit and this session that no product, category or organization was added or removed in that window beyond the three modified records named above.

## Verification

`build.preflight --skip-tests` — all 15 steps pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gb57nwHcF9vd952S2NNboq