### PR TITLE
Score capability for five benchmark_eval_data products, and write the rubric they were banded against

### DIFF
--- a/sources/categories/benchmark_eval_data.yaml
+++ b/sources/categories/benchmark_eval_data.yaml
@@ -91,6 +91,78 @@ scoring_recipe:
         rung that tests a tier, and the recorded 4 stands rather than being replaced by a
         number nobody derived. Extending the dataset ladder with a use-bounded tier is the fix
         and it is a rubric change.
+  capability:
+    basis: feature_matrix
+    question: Does this benchmark still separate frontier models?
+    dimensions:
+      headroom:
+        question: How much room is left between the best reported score and the ceiling?
+        evidence: A published frontier figure on this benchmark, or a successor's measured
+          comparison against it.
+      contamination_control:
+        question: Does the design defend its headroom, by holding answers back or by replacing
+          items over time?
+        evidence: A held-out or private split, a documented rotation or version cadence, or a
+          canary string on the published artifact.
+      checkable_scoring:
+        question: Is an answer graded against ground truth or executed tests rather than by a
+          judge model?
+        evidence: The scoring procedure as the project documents it.
+      distinct_dimension:
+        question: Does it measure something no cheaper instrument already covers?
+        evidence: What the project states it tests, read against the other benchmarks on this
+          roster.
+    anchor:
+      primary: the benchmark's own reported frontier ceiling
+      machine_signal: none - requires research. `semanticscholar` routes adoption here and
+        corroborates capability without settling it.
+    bands: null
+    bands_status: >-
+      Hand-authored against the rungs below, on embeddings_retrieval's precedent. The four
+      dimensions do not combine by counting: GAIA is a 5 on one domain and MT-Bench a 4 with
+      judge scoring and no contamination control, so an attribute count reproduces neither.
+      Headroom leads and the other three say whether it will last. The layer-2 scorer must not
+      write this axis.
+    note: >-
+      Written on 2026-09-11 under issue #319, which ruled that a benchmark's difficulty and
+      contamination resistance IS a capability and that the category could not hold both
+      positions at once - four products banded on exactly that, and 28 abstaining at the time
+      of the ruling on the grounds that a dataset is not capable. The rungs below are read off
+      the four bands that already existed rather than invented beside them.
+
+      5 - still separates frontier models AND the design defends that: answers held out or
+      the item set replaced over time, and an answer is checkable without a judge. livebench
+      (monthly rotation, judge-free, top models under 70%), gaia (300 answers private, one
+      checkable answer, 15% against 92% for humans) and humanitys-last-exam (private holdout)
+      hold this rung.
+      4 - a real discriminator on a dimension nothing cheaper reaches, with one structural
+      weakness: judge-based scoring, a small item set, or partial saturation. mt-bench is the
+      anchor - 80 multi-turn questions and an LLM judge, still the instrument for a dimension
+      multiple choice cannot reach.
+      3 - harder than the classic it replaced and still separating, but static and published
+      in full, so its headroom is being spent rather than defended.
+      2 - plateaued. Frontier scores cluster near the ceiling, its own successors say so, and
+      it survives as a reporting convention rather than as a discriminator.
+      1 - saturated, or shown not to measure what it claims: frontier accuracy is at the
+      ceiling, or published work shows the score moves on rewrites that preserve the problem.
+
+      Three rules settle the calls the rungs alone leave open, and each one came out of
+      reading the four existing bands rather than out of scoring a product.
+      (a) Saturation is a fact about the benchmark, not a caveat about it. Recording "now
+      largely saturated" in prose while abstaining on the axis is the inconsistency #319
+      names; a saturated benchmark is a 1 or a 2 and the note says why.
+      (b) Openness does not enter the band. gaia and humanitys-last-exam are gated
+      specifically to hold answers back, and that is what earns them the top rung on this
+      axis. The openness axis records the cost separately.
+      (c) Gating is not contamination control on its own. livecodebench is gated over an
+      unstated license and math under a DMCA takedown; neither withholds answers to defend a
+      score.
+
+      Distribution after the first five bands (issue #319 calibration slice): 9 of 32 scored,
+      4/2/1/1/1 across levels 5/4/3/2/1. The top rung is 44 percent of what is scored, which
+      is not yet a distribution to judge - the 23 still unscored are mostly the saturated
+      classics this rubric puts on levels 1 to 3, so re-count once they land rather than
+      rewording against a slice.
 products:
 - humaneval
 - gsm8k

--- a/sources/categories/benchmark_eval_data.yaml
+++ b/sources/categories/benchmark_eval_data.yaml
@@ -104,6 +104,42 @@ scoring_recipe:
           items over time?
         evidence: A held-out or private split, a documented rotation or version cadence, or a
           canary string on the published artifact.
+        instrument:
+          name: Hugging Face training-dataset tag count
+          url_pattern: https://huggingface.co/api/models?filter=dataset:<owner>/<name>&limit=1000&full=false
+          read: The length of the returned array, which is how many models on the Hub declare
+            this corpus as a training dataset.
+          measured_on: '2026-09-11'
+          readings:
+            livebench: 0
+            terminal-bench: 0
+            gaia: 5
+            humanitys-last-exam: 11
+            mt-bench: 1
+            swe-bench-verified: 13
+            humaneval: 29
+            mmlu-pro: 30
+            mmlu: 327
+            gsm8k: 834
+          note: >-
+            A countable, re-derivable input to this dimension, added 2026-09-11 after the #319
+            calibration slice. Read the API, never the rendered dataset page: the two disagree
+            (834 against 1,109 for openai/gsm8k), and the page is browser-rendered, so its
+            number cannot be re-fetched to a stable digest. Cite the API figure and record the
+            discrepancy where it matters.
+
+            THE SIGNAL IS ASYMMETRIC, and that is the whole of how to use it. A high count is
+            strong evidence that a benchmark has been trained on. A low count establishes
+            nothing at all, because a corpus can reach a pretraining mix without any model ever
+            tagging it here. `humaneval` is the proof: 29 models declare it, and it is
+            known-saturated on every other reading. So this instrument may move a band DOWN and
+            may never move one UP, and it never overrides a read of the primary sources. It is
+            the same rule as a transient fetch not being evidence of absence.
+
+            It is also one input to one of four dimensions rather than a rung on its own.
+            `mt-bench` sits at 1 with a capability of 4: it is marked down for LLM-as-judge
+            scoring and an 80-question set, which is a fact about its design and not about
+            contamination. A count cannot place a band by itself.
       checkable_scoring:
         question: Is an answer graded against ground truth or executed tests rather than by a
           judge model?

--- a/sources/scores/gsm8k.yaml
+++ b/sources/scores/gsm8k.yaml
@@ -58,7 +58,8 @@ capability:
     "the performance of all models declines when only the numerical values in the question are altered"
     and that adding a single clause which does not change the answer costs up to 65%. A score that moves
     on a rewrite preserving the problem is not a reading of mathematical reasoning, so GSM8K separates frontier
-    models on neither difficulty nor reliability.
+    models on neither difficulty nor reliability. 834 models on the Hub declare GSM8K as a training dataset,
+    the highest count in this category by a wide margin, so the contamination is measured rather than inferred.
   last_verified: '2026-09-11'
   sources:
   - url: https://arxiv.org/abs/2110.14168
@@ -78,3 +79,10 @@ capability:
     accessed: '2026-09-11'
     http_status: 200
     content_sha256: 36c38851da6b9418590772ede85907bf0a0f54dd0435c1ac7530129f32d49f52
+  - url: https://huggingface.co/api/models?filter=dataset:openai/gsm8k&limit=1000&full=false
+    shows: 'an array of 834 model entries: 834 models on the Hub declare openai/gsm8k as a training dataset.
+      The rendered dataset page reports a larger figure, 1,109; the API count is the one recorded here because
+      it is the one that re-derives'
+    accessed: '2026-09-11'
+    http_status: 200
+    content_sha256: ce2d96b20b98b117b61a544c7e35f110e8a7618ee0b1e94f52f7638569419523

--- a/sources/scores/gsm8k.yaml
+++ b/sources/scores/gsm8k.yaml
@@ -47,17 +47,34 @@ adoption:
     http_status: 200
     content_sha256: df6c80e76df63b397706df7aeaeec618f8d1ff17795d6465f4199e9865a1e310
 capability:
-  score: null
-  basis: n/a
-  value: null
+  score: 1
+  basis: feature_matrix
+  basis_detail: GSM-Symbolic's perturbation study of GSM8K, read against the original paper's task definition
+  value: 8.5K grade-school word problems with the answers published alongside them; frontier accuracy is
+    at the ceiling, and every model tested drops when only the numbers in a question are changed, by up
+    to 65% when one irrelevant clause is added
   confidence: high
-  note: A dataset is not 'capable', so this axis is left unscored. GSM8K is now largely saturated by frontier
-    models, but that is a quality caveat rather than a capability score.
-  last_verified: '2026-08-13'
+  note: Bottom rung, and on the second half of that rung rather than the first. GSM-Symbolic reports that
+    "the performance of all models declines when only the numerical values in the question are altered"
+    and that adding a single clause which does not change the answer costs up to 65%. A score that moves
+    on a rewrite preserving the problem is not a reading of mathematical reasoning, so GSM8K separates frontier
+    models on neither difficulty nor reliability.
+  last_verified: '2026-09-11'
   sources:
-  - url: https://huggingface.co/datasets/openai/gsm8k
-    shows: a static corpus of grade-school word problems with question and answer columns; no performance,
-      throughput or feature claim on the page for the capability axis to read
-    accessed: '2026-08-13'
+  - url: https://arxiv.org/abs/2110.14168
+    shows: '"we introduce GSM8K, a dataset of 8.5K high quality linguistically diverse grade school math
+      word problems"; at publication "even the largest transformer models fail to achieve high test performance,
+      despite the conceptual simplicity of this problem distribution"'
+    accessed: '2026-09-11'
     http_status: 200
-    content_sha256: 581c3fab47c8883297cb96a2b8123aef25d563c6c72459875b10cbee3a2bea27
+    content_sha256: ea9c1057f32796ff8181e23c8d06881d1afbfbbafca95b1b25a62491856e6e54
+  - url: https://arxiv.org/abs/2410.05229
+    shows: '"While the performance of LLMs on GSM8K has significantly improved in recent years, it remains
+      unclear whether their mathematical reasoning capabilities have genuinely advanced, raising questions
+      about the reliability of the reported metrics"; "the performance of all models declines when only
+      the numerical values in the question are altered in the GSM-Symbolic benchmark"; "Adding a single
+      clause that seems relevant to the question causes significant performance drops (up to 65%) across
+      all state-of-the-art models"'
+    accessed: '2026-09-11'
+    http_status: 200
+    content_sha256: 36c38851da6b9418590772ede85907bf0a0f54dd0435c1ac7530129f32d49f52

--- a/sources/scores/mmlu-pro.yaml
+++ b/sources/scores/mmlu-pro.yaml
@@ -51,16 +51,26 @@ adoption:
     http_status: 200
     content_sha256: 33c1a868f84bdcce00ac909e3537b100e2358ae1988fe34325b79a4d6bcb0214
 capability:
-  score: null
-  basis: n/a
-  value: null
+  score: 3
+  basis: feature_matrix
+  basis_detail: 'the MMLU-Pro paper''s measured comparison against MMLU: the accuracy drop, the option count
+    and the prompt-sensitivity figures'
+  value: reasoning-focused questions across the MMLU subject range with ten answer options instead of four
+    and the trivial and noisy items removed; a measured 16% to 33% accuracy drop against MMLU, and prompt
+    sensitivity down from 4-5% to 2% across 24 prompt styles
   confidence: high
-  note: A dataset is not 'capable', so this axis is left unscored; openness and adoption carry this category.
-  last_verified: '2026-08-13'
+  note: 'Harder and measurably more discriminating than the MMLU it was built to replace, and the claim
+    is a measurement rather than an assertion. It stays off the top two rungs because it is a static public
+    multiple-choice set: questions and answers ship together, nothing rotates and nothing is held back,
+    so the headroom it bought is being spent rather than protected.'
+  last_verified: '2026-09-11'
   sources:
-  - url: https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro
-    shows: a static 10-option multiple-choice question corpus; no performance, throughput or feature
-      claim on the page for the capability axis to read
-    accessed: '2026-08-13'
+  - url: https://arxiv.org/abs/2406.01574
+    shows: '"MMLU-Pro, an enhanced dataset designed to extend the mostly knowledge-driven MMLU benchmark
+      by integrating more challenging, reasoning-focused questions and expanding the choice set from four
+      to ten options"; "MMLU-Pro not only raises the challenge, causing a significant drop in accuracy by
+      16% to 33% compared to MMLU but also demonstrates greater stability under varying prompts"; "the sensitivity
+      of model scores to prompt variations decreased from 4-5% in MMLU to just 2% in MMLU-Pro"'
+    accessed: '2026-09-11'
     http_status: 200
-    content_sha256: 1f030cb66fe26a245458fdc2e3a5f86fcf1bc00487c96e8e6ed43f4ce76e8686
+    content_sha256: 5d7cc32bd5dc2562317f2fa0bcfa6bb9806b0994eb94eb389a93b36346d32118

--- a/sources/scores/mmlu-pro.yaml
+++ b/sources/scores/mmlu-pro.yaml
@@ -62,7 +62,9 @@ capability:
   note: 'Harder and measurably more discriminating than the MMLU it was built to replace, and the claim
     is a measurement rather than an assertion. It stays off the top two rungs because it is a static public
     multiple-choice set: questions and answers ship together, nothing rotates and nothing is held back,
-    so the headroom it bought is being spent rather than protected.'
+    so the headroom it bought is being spent rather than protected. Thirty models on the Hub declare it
+    as a training dataset, against 327 for MMLU, so the corpus it replaced has been trained on an order
+    of magnitude more often.'
   last_verified: '2026-09-11'
   sources:
   - url: https://arxiv.org/abs/2406.01574
@@ -74,3 +76,9 @@ capability:
     accessed: '2026-09-11'
     http_status: 200
     content_sha256: 5d7cc32bd5dc2562317f2fa0bcfa6bb9806b0994eb94eb389a93b36346d32118
+  - url: https://huggingface.co/api/models?filter=dataset:TIGER-Lab/MMLU-Pro&limit=1000&full=false
+    shows: 'an array of 30 model entries: 30 models on the Hub declare TIGER-Lab/MMLU-Pro as a training
+      dataset'
+    accessed: '2026-09-11'
+    http_status: 200
+    content_sha256: 0b7f37ed46be4c48dd1de58763773518c4ae2a56958a15d19f6381b6b381d127

--- a/sources/scores/mmlu.yaml
+++ b/sources/scores/mmlu.yaml
@@ -50,18 +50,33 @@ adoption:
     http_status: 200
     content_sha256: 41596bee97cd66a4a0b9b1e19790663274f63b5b368ce20c38474bad29cc13f4
 capability:
-  score: null
-  basis: n/a
-  value: null
+  score: 2
+  basis: feature_matrix
+  basis_detail: 'the plateau its own successor benchmark measured: MMLU-Pro''s reported accuracy drop and
+    prompt-sensitivity comparison against MMLU'
+  value: 57 subjects of four-option multiple choice, questions and answers published together; frontier
+    accuracy has plateaued, and asking the same subject range in a harder form drops accuracy by 16% to
+    33%
   confidence: high
-  note: A dataset is not capability-scored, so this axis is left unscored. MMLU is saturated and contaminated
-    - top models land between 88% and 94%, and MMLU-Pro has largely superseded it for differentiation -
-    but that is a quality caveat rather than an openness or capability deduction.
-  last_verified: '2026-08-13'
+  note: Plateaued. The MMLU-Pro paper, written to replace it, records that "as models continue to improve,
+    their performance on these benchmarks has begun to plateau, making it increasingly difficult to discern
+    differences in model capabilities", and measures how much harder the same subject range has to be asked
+    before scores separate again. MMLU survives as a reporting convention rather than as a way to tell frontier
+    models apart, which is the level-2 rung rather than an abstention.
+  last_verified: '2026-09-11'
   sources:
-  - url: https://huggingface.co/datasets/cais/mmlu
-    shows: a static multiple-choice question corpus across 57 subjects; no performance, throughput or
-      feature claim on the page for the capability axis to read
-    accessed: '2026-08-13'
+  - url: https://arxiv.org/abs/2009.03300
+    shows: '"The test covers 57 tasks including elementary mathematics, US history, computer science, law,
+      and more"; the design is a static multitask multiple-choice test, and at publication "most recent
+      models have near random-chance accuracy"'
+    accessed: '2026-09-11'
     http_status: 200
-    content_sha256: 4233dafe2e394cdd10d4b90cd96c646b455a5c9565c1f423ec02f76188e2df0b
+    content_sha256: ffb542b1cf065c035f978c04346b0fd159498856223020214a0193499c7f6460
+  - url: https://arxiv.org/abs/2406.01574
+    shows: '"as models continue to improve, their performance on these benchmarks has begun to plateau,
+      making it increasingly difficult to discern differences in model capabilities"; MMLU-Pro measures
+      "a significant drop in accuracy by 16% to 33% compared to MMLU" and is offered as "a more discriminative
+      benchmark to better track progress in the field"'
+    accessed: '2026-09-11'
+    http_status: 200
+    content_sha256: 5d7cc32bd5dc2562317f2fa0bcfa6bb9806b0994eb94eb389a93b36346d32118

--- a/sources/scores/mmlu.yaml
+++ b/sources/scores/mmlu.yaml
@@ -62,7 +62,9 @@ capability:
     their performance on these benchmarks has begun to plateau, making it increasingly difficult to discern
     differences in model capabilities", and measures how much harder the same subject range has to be asked
     before scores separate again. MMLU survives as a reporting convention rather than as a way to tell frontier
-    models apart, which is the level-2 rung rather than an abstention.
+    models apart, which is the level-2 rung rather than an abstention. 327 models on the Hub declare MMLU
+    as a training dataset, against 30 for MMLU-Pro, which corroborates the plateau with a count rather than
+    with prose.
   last_verified: '2026-09-11'
   sources:
   - url: https://arxiv.org/abs/2009.03300
@@ -80,3 +82,8 @@ capability:
     accessed: '2026-09-11'
     http_status: 200
     content_sha256: 5d7cc32bd5dc2562317f2fa0bcfa6bb9806b0994eb94eb389a93b36346d32118
+  - url: https://huggingface.co/api/models?filter=dataset:cais/mmlu&limit=1000&full=false
+    shows: 'an array of 327 model entries: 327 models on the Hub declare cais/mmlu as a training dataset'
+    accessed: '2026-09-11'
+    http_status: 200
+    content_sha256: 25a1baca271a2803e8b889e7f4a4ce890568ce5eff632abe280acd4385134c6f

--- a/sources/scores/swe-bench-verified.yaml
+++ b/sources/scores/swe-bench-verified.yaml
@@ -104,6 +104,8 @@ capability:
     graded by that repository's own tests - which is why frontier labs report against it. It sits a rung
     below the contamination-resistant benchmarks because the set has been frozen since August 2024 and the
     gold patch and tests ship with every instance, so its headroom is being spent rather than protected.
+    Thirteen models on the Hub declare it as a training dataset, an order of magnitude below the saturated
+    classics in this category and consistent with a benchmark still doing work.
   last_verified: '2026-09-11'
   sources:
   - url: https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified/raw/main/README.md
@@ -131,3 +133,9 @@ capability:
     accessed: '2026-09-11'
     http_status: 200
     content_sha256: 06841624d7b5130dfe3cc6714642e9a8fd2a608c95c66ae0180e409f12b73aaa
+  - url: https://huggingface.co/api/models?filter=dataset:princeton-nlp/SWE-bench_Verified&limit=1000&full=false
+    shows: 'an array of 13 model entries: 13 models on the Hub declare princeton-nlp/SWE-bench_Verified
+      as a training dataset'
+    accessed: '2026-09-11'
+    http_status: 200
+    content_sha256: 1acf7dbcbfa6c6db83e4035a2009e515c3a467ad86e492a9da1b15b36b6e5e59

--- a/sources/scores/swe-bench-verified.yaml
+++ b/sources/scores/swe-bench-verified.yaml
@@ -92,18 +92,42 @@ adoption:
     http_status: 200
     content_sha256: e7239207ea1aa7e72552da32855ef449cabd79f850fb7b0060878d17a89c9254
 capability:
-  score: null
-  basis: n/a
-  value: null
+  score: 4
+  basis: feature_matrix
+  basis_detail: the dataset card's description of the 500-instance human-validated set and its unit-test
+    grading, read against the SWE-bench paper's task definition
+  value: 500 human-validated instances drawn from real GitHub issues across 12 Python repositories; graded
+    by running the pull request's FAIL_TO_PASS and PASS_TO_PASS unit tests, with no judge; a static set
+    whose gold patches and tests are published in full
   confidence: high
-  note: A dataset is not 'capable', so this axis is left unscored. SWE-bench Verified is notably contamination-resistant
-    and discriminating for coding agents, since it runs against real repository state and executable tests,
-    but that quality is noted here rather than turned into a number.
-  last_verified: '2026-08-13'
+  note: A real discriminator on a dimension nothing cheaper reaches - resolve an issue in a working repository,
+    graded by that repository's own tests - which is why frontier labs report against it. It sits a rung
+    below the contamination-resistant benchmarks because the set has been frozen since August 2024 and the
+    gold patch and tests ship with every instance, so its headroom is being spent rather than protected.
+  last_verified: '2026-09-11'
   sources:
-  - url: https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified
-    shows: a static 500-instance corpus of repo state, issue text, gold patch and tests; no performance,
-      throughput or feature claim on the page for the capability axis to read
-    accessed: '2026-08-13'
+  - url: https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified/raw/main/README.md
+    shows: '"SWE-bench Verified is a subset of 500 samples from the SWE-bench test set, which have been
+      human-validated for quality"; "Evaluation is performed by unit test verification using post-PR behavior
+      as the reference solution"; the split metadata records num_examples: 500 and the schema carries `patch`
+      (the gold patch), `test_patch`, FAIL_TO_PASS and PASS_TO_PASS'
+    accessed: '2026-09-11'
     http_status: 200
-    content_sha256: 21a9ae799b810fb5b73f025632c12b0858475dabbdc756309dad62af5af1d184
+    content_sha256: 6edb58b1b2c44ce858426c4ebc90077827713b75cebc243661e4433c81fd57f5
+  - url: https://arxiv.org/abs/2310.06770
+    shows: '"Resolving issues in SWE-bench frequently requires understanding and coordinating changes across
+      multiple functions, classes, and even files simultaneously, calling for models to interact with execution
+      environments, process extremely long contexts and perform complex reasoning that goes far beyond traditional
+      code generation tasks"; the problems are drawn from real GitHub issues and their pull requests across
+      12 popular Python repositories'
+    accessed: '2026-09-11'
+    http_status: 200
+    content_sha256: cd170cab3a56f891ee94070d5748d923685f2a84a91201d6336a221436fd0f9f
+  - url: https://raw.githubusercontent.com/SWE-bench/SWE-bench/main/README.md
+    shows: the news entry dated Aug. 13, 2024 reads "Introducing *SWE-bench Verified*! ... A subset of 500
+      problems that real software engineers have confirmed are solvable", and the harness is containerized
+      and run as `swebench eval verified`; the most recent entry is Sep. 1, 2026 on SWE-bench Multimodal,
+      with no newer Verified release
+    accessed: '2026-09-11'
+    http_status: 200
+    content_sha256: 06841624d7b5130dfe3cc6714642e9a8fd2a608c95c66ae0180e409f12b73aaa

--- a/sources/scores/terminal-bench.yaml
+++ b/sources/scores/terminal-bench.yaml
@@ -103,7 +103,9 @@ capability:
     how LiveBench holds the same rung. It differs from LiveBench in where the protection comes from: the
     tasks and their reference solutions are published in full, so turnover is the only thing holding contamination
     off. The band is read off the versioned dataset names, not off the live leaderboard, which renders its
-    rows in the browser.'
+    rows in the browser. No model on the Hub declares the 2.0 corpus as a training dataset, which is consistent
+    with the band; a count of zero corroborates and cannot establish it, since a benchmark can reach a pretraining
+    corpus untagged.'
   last_verified: '2026-09-11'
   sources:
   - url: https://arxiv.org/abs/2601.11868
@@ -123,3 +125,9 @@ capability:
     accessed: '2026-09-11'
     http_status: 200
     content_sha256: c4b77ef934ae210f3c712e7bab30f460ff35e125aa83affc30c9e7dd6317cdf1
+  - url: https://huggingface.co/api/models?filter=dataset:harborframework/terminal-bench-2.0&limit=1000&full=false
+    shows: 'an empty array: no model on the Hub declares harborframework/terminal-bench-2.0 as a training
+      dataset'
+    accessed: '2026-09-11'
+    http_status: 200
+    content_sha256: 4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945

--- a/sources/scores/terminal-bench.yaml
+++ b/sources/scores/terminal-bench.yaml
@@ -90,16 +90,36 @@ adoption:
     http_status: 200
     content_sha256: 9b6d7b707119de3a7fcd84f2db430559d65ed295a09923b01b099eb27b49155f
 capability:
-  score: null
-  basis: n/a
-  value: null
-  confidence: high
-  note: A dataset is not 'capable', so this axis is left unscored, mirroring the category pattern (gsm8k).
-  last_verified: '2026-09-01'
+  score: 5
+  basis: feature_matrix
+  basis_detail: the Terminal-Bench 2.0 paper's reported frontier ceiling, read against the project's own
+    dataset versioning
+  value: 89 tasks in Terminal-Bench 2.0, each with its own environment, a human-written solution and its
+    own test suite; graded by running those tests, with no judge; the task set is versioned and replaced
+    rather than frozen, from Core v0.1.1 to the 2.0 suite the project now points new users at
+  confidence: medium
+  note: 'Top rung. Frontier agents were reported below 65% on Terminal-Bench 2.0, an answer is graded by
+    the task''s own tests rather than by a judge, and the suite is replaced version by version, which is
+    how LiveBench holds the same rung. It differs from LiveBench in where the protection comes from: the
+    tasks and their reference solutions are published in full, so turnover is the only thing holding contamination
+    off. The band is read off the versioned dataset names, not off the live leaderboard, which renders its
+    rows in the browser.'
+  last_verified: '2026-09-11'
   sources:
-  - url: https://raw.githubusercontent.com/harbor-framework/terminal-bench/main/README.md
-    shows: a task collection and how to run it; no performance, throughput or feature claim for the capability
-      axis to read
-    accessed: '2026-09-01'
+  - url: https://arxiv.org/abs/2601.11868
+    shows: '"Terminal-Bench 2.0: a carefully curated hard benchmark composed of 89 tasks in computer terminal
+      environments inspired by problems from real workflows"; "Each task features a unique environment,
+      human-written solution, and comprehensive tests for verification"; "We show that frontier models and
+      agents score less than 65% on the benchmark"'
+    accessed: '2026-09-11'
     http_status: 200
-    content_sha256: 19cd7542ab806fc5732503f2fe2d6ee7e342de549ab1acfba184060f1290b03b
+    content_sha256: 48056dd2c223c4510d39bd6d06fd8079f7c8e7575276c30430e0186483623d36
+  - url: https://raw.githubusercontent.com/laude-institute/terminal-bench/main/README.md
+    shows: each task ships "an instruction in English", "a test script to verify if the language model /
+      agent completed the task successfully" and "a reference (\"oracle\") solution that solves the task";
+      the leaderboard is pinned to a named dataset version, `--dataset-name terminal-bench-core --dataset-version
+      0.1.1`, and the standing announcement points new users at "harbor, our new framework that can be used
+      to run Terminal-Bench 2.0"
+    accessed: '2026-09-11'
+    http_status: 200
+    content_sha256: c4b77ef934ae210f3c712e7bab30f460ff35e125aa83affc30c9e7dd6317cdf1


### PR DESCRIPTION
Calibration slice for issue #319. Five products scored, not the full 28, so the rubric application can be checked before the remaining 23 land in one tranche.

## The rubric, written down

`benchmark_eval_data` had no capability recipe. The category now declares one in its `scoring_recipe`, with `bands: null` and hand-authored rungs on `embeddings_retrieval`'s precedent, because the four dimensions do not combine by counting - GAIA is a 5 on a single domain and MT-Bench a 4 with judge scoring and no contamination control, so an attribute count reproduces neither.

The question is the one the issue names: does this benchmark still separate frontier models? Headroom leads, and contamination control, checkable scoring and distinctness say whether it will last.

- **5** - still separates frontier models and the design holds that: answers held out or the item set replaced over time, and an answer checkable without a judge.
- **4** - a real discriminator on a dimension nothing cheaper reaches, with one structural weakness: a judge, a small item set, or partial saturation.
- **3** - harder than the classic it replaced and still separating, but static and published in full.
- **2** - plateaued; a reporting convention rather than a discriminator.
- **1** - saturated, or shown not to measure what it claims.

The rungs reproduce all four existing bands: livebench, gaia and humanitys-last-exam at 5, mt-bench at 4. Three rules are recorded with them - saturation is a fact about the benchmark rather than a caveat about it, openness does not enter the band, and gating is not contamination control on its own (livecodebench is gated over an unstated license, math under a DMCA takedown).

## The five

**terminal-bench - 5**, basis `feature_matrix`.
Read the Terminal-Bench 2.0 paper (arXiv 2601.11868) and the repository README. The paper reports 89 tasks, each with its own environment, a human-written solution and comprehensive tests, and says frontier models and agents score under 65%. The README shows the per-task test script and oracle solution, the leaderboard pinned to a named dataset version, and the standing pointer at Terminal-Bench 2.0. Real headroom, graded by the task's own tests with no judge, and the suite is replaced version by version rather than frozen, which is how LiveBench holds this rung. The live leaderboard at tbench.ai was deliberately not cited: it renders its rows in the browser and its digest changed between two fetches minutes apart.

**swe-bench-verified - 4**, basis `feature_matrix`.
Read the HF dataset card (500 human-validated instances, "Evaluation is performed by unit test verification using post-PR behavior as the reference solution"), the SWE-bench paper, and the SWE-bench repository README. A real discriminator on a dimension nothing cheaper reaches, which is why frontier labs report against it. One rung below the top because the set has been frozen since August 2024 and the gold patch and tests ship with every instance, so its headroom is being spent rather than protected.

**mmlu-pro - 3**, basis `feature_matrix`.
Read the MMLU-Pro paper. Ten options instead of four, reasoning-focused items, noisy questions removed, a measured 16-33% accuracy drop against MMLU and prompt sensitivity down from 4-5% to 2%. Measurably more discriminating than what it replaced, and the claim is a measurement. It stays off the top two rungs because questions and answers ship together, nothing rotates and nothing is held back.

**mmlu - 2**, basis `feature_matrix`.
Read the original MMLU paper for the design and the MMLU-Pro paper for the plateau: "as models continue to improve, their performance on these benchmarks has begun to plateau, making it increasingly difficult to discern differences in model capabilities." The issue's own worked example. It survives as a reporting convention, which is the level-2 rung rather than an abstention.

**gsm8k - 1**, basis `feature_matrix`.
Read the GSM8K paper and GSM-Symbolic (arXiv 2410.05229), which reports that "the performance of all models declines when only the numerical values in the question are altered" and that one irrelevant added clause costs up to 65%. A score that moves on a rewrite preserving the problem is not a reading of mathematical reasoning, so GSM8K separates frontier models on neither difficulty nor reliability.

## The contamination instrument (added on review)

The Hugging Face API reports how many models declare a corpus as a training dataset, which is a countable, re-derivable input to the contamination-resistance dimension this recipe leads with:

```
https://huggingface.co/api/models?filter=dataset:<owner>/<name>&limit=1000&full=false
```

Readings across the category, taken 2026-09-11 and reproduced independently before recording:

| product | count | capability |
|---|---:|---:|
| livebench | 0 | 5 |
| terminal-bench | 0 | 5 |
| gaia | 5 | 5 |
| humanitys-last-exam | 11 | 5 |
| mt-bench | 1 | 4 |
| swe-bench-verified | 13 | 4 |
| humaneval | 29 | null |
| mmlu-pro | 30 | 3 |
| mmlu | 327 | 2 |
| gsm8k | 834 | 1 |

It reproduces all four pre-existing anchors and rank-orders the five new scores. It is declared under `contamination_control` in the recipe and added as corroborating evidence on each of the five records. **No score changed** — they stay 5/4/3/2/1.

**The signal is asymmetric, and that is the load-bearing part.** A high count is strong evidence that a benchmark has been trained on. A low count establishes nothing, because a corpus can reach a pretraining mix without any model tagging it on the Hub. `humaneval` is the proof: 29 models declare it and it is known-saturated on every other reading. So the instrument may move a band **down** and may never move one **up**, and it never overrides a read of the primary sources. Same rule as a transient fetch not being evidence of absence.

It is also one input to one of four dimensions rather than a rung of its own. `mt-bench` sits at 1 with a capability of 4, marked down for LLM-as-judge scoring and an 80-question set — facts about its design, not about contamination.

**The API, never the rendered page.** The two disagree: 834 against 1,109 for `openai/gsm8k`. The API figure is recorded because it is the one that re-fetches to a stable digest; the page is browser-rendered, the same class of source already avoided for tbench.ai. The discrepancy is written into the gsm8k record's `shows`.

## Published numbers move, and the issue predicted otherwise

The issue says the category stays at Stage 3 and nothing on the published map moves. It was already at **Stage 4**, and this change takes it to **Stage 3**.

`gsm8k` was the only fully-open product clearing the 4.5 maturity bar, and it cleared it on adoption 5 with a null capability. At the category's 0.6/0.4 weights it now blends to 3.4.

| | before | after |
|---|---|---|
| stage | 4, Competitive Open Ecosystem | 3, Viable Alternatives |
| gaps | `resiliency` | none |
| best fully-open | gsm8k, 5.0 | humaneval, 4.0 |

The `adoption` gap the issue expects does not fire either: the best fully-open product is now an adoption-only record at 4.0, which clears the adoption cutoff, so no driver gap fires. That may change once the remaining 23 land and the adoption-only records get capability scores of their own.

`notebook_data.json` and the notebooks are left to the regenerate bot.

## Open questions for review

- **`basis`.** All five use `feature_matrix`, matching the four anchors. An argument exists for `benchmark` here, since the reading behind the band is a published frontier figure on the product itself. Consistency with the anchors won; say if it should be the other way.
- **No peer edges.** Nothing records `relative_to`/`relation`. The rungs place the bands, and adding edges into a rubric under review seemed premature.
- **Rung distribution.** 9 of 32 scored, 4/2/1/1/1 across 5/4/3/2/1. The top rung is 44% of what is scored, which is not yet a distribution to judge - the 23 still unscored are mostly the saturated classics this rubric puts on 1 to 3.

## Gates

```
build.validate            0 error(s), 2 warnings (pre-existing model_families patterns)
build.check_verification  all four gates OK
build.check_capability    OK (12 weak roots pre-existing, report-only, none in this category)
build.check_recipe        0 failure(s)
build.check_rubric        benchmark_eval_data 30/30 reproduced, 2 deferred
build.check_freshness     all 20 categories within 45d
build.check_refetch --strict, each of the five: [OK] no fabricated digests
pytest -q                 1888 passed, 1 skipped (re-run after the instrument commit)
```

Every capability source on all five products, the training-tag counts included, re-fetched and reproduced its digest exactly. The drifts `check_refetch` reports on these products are on pre-existing openness and adoption sources (Hugging Face pages), not on anything added here.

Closes nothing yet - #319 stays open for the remaining 23.

