### PR TITLE
Move agenta's category, repoint twelve arXiv citations, and gate the citation form

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -107,6 +107,15 @@ jobs:
       # one teaches everybody to ignore it.
       - name: Routing table structure
         run: uv run python -m build.check_routing
+
+      # An arXiv abstract page carries the abstract and the submission history, so a source that
+      # cites /abs for a table or a figure records a claim the cited page cannot support (#263).
+      # Fails on a citation whose own `shows` places the claim in the body; the numeric /abs
+      # citations that may simply be quoting the abstract are reported by --candidates and do
+      # not fail. See docs/reference/evidence-and-freshness.md.
+      - name: Citations gate (an arXiv /abs cited for a claim only the body carries)
+        run: uv run python -m build.check_citations
+
       # How stale is every axis, per category. Informational on purpose: no --max-age-days, so
       # it prints and cannot fail. The gate at 45 days (temporary) is `.github/workflows/freshness.yml`,
       # weekly, and it is the one gate here that must not run per PR — it fails on the passage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,8 @@ Gates              check_*, one module per question. Four families:
                      scoring    check_rubric, check_recipe, check_capability, check_adoption,
                                 check_instrument, check_components,
                                 check_channel_authority
-                     evidence   check_verification, check_freshness, check_refetch
+                     evidence   check_verification, check_freshness, check_refetch,
+                                check_citations
                      payload    check_payload, check_retirement, check_parity
                      coverage   check_routing, check_artifacts
                    `check_verification` runs several sub-gates and its exit covers all of

--- a/build/check_citations.py
+++ b/build/check_citations.py
@@ -1,0 +1,146 @@
+"""Gate: an arXiv `/abs` citation may not carry a claim that only the paper body carries.
+
+An arXiv abstract page holds a title, the authors, the abstract and the submission history. It
+does not hold the tables, the figures or the appendices, so a source that cites `/abs/<id>` for a
+number taken from a table is unfalsifiable as recorded: a re-reader who opens the cited page
+cannot find the figure, and cannot tell a transcription error from a page that never said it.
+
+The corpus had twelve of these (#263). `oasst1` claimed "Guanaco/QLoRA fine-tuned on OASST1"
+against `arxiv.org/abs/2305.14314`, where OASST1 occurs zero times; it occurs nineteen times in
+the PDF. `dolma-toolkit` cited an abstract page for a "Table 2" that page has never shown.
+
+**The convention.** Cite `/pdf/<id>` whenever the claim rests on something in the body. `/abs` is
+correct for what the abstract page itself carries: the abstract's own wording, the title, the
+authorship, the submission and withdrawal history. `/html/<id>vN` is not a substitute — it does
+not exist for older papers and its version suffix goes stale.
+
+## The two checks
+
+**Failure: a body locator over an `/abs` URL.** A `shows` that names a table, a figure, a
+section, an appendix or a page number, or that says in words that the claim is in the paper body,
+is a statement that the cited page does not carry the claim. The record says so itself, so this
+needs no judgment and fails. A locator inside a quotation does not count: an abstract page's own
+submission history can quote an author saying "specifically figure 5", and quoting it is what an
+`/abs` citation is for.
+
+**Report: a numeric claim over an `/abs` URL.** A `shows` containing a number may be quoting the
+abstract, which is legitimate and common, or may be a body figure nobody labelled. Telling those
+apart means reading the page, so this is the backlog and is reported rather than failed — the
+same ratchet the capability and verification gates use. A curation job must not be able to
+masquerade as a regression.
+
+Usage:
+    uv run python -m build.check_citations
+    uv run python -m build.check_citations --candidates
+
+Exit status is 1 on any failure, so CI can gate on it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+from build.vocabulary import axes
+
+ROOT = Path(__file__).resolve().parents[1]
+
+ABS = re.compile(r"https?://arxiv\.org/abs/", re.I)
+
+# Each of these says, in the record's own words, that the claim sits somewhere an abstract page
+# does not reach. Deliberately narrow: every pattern here is a positive statement by the curator,
+# so a hit is the record contradicting its own URL rather than a guess about the page.
+LOCATOR = re.compile(
+    r"\b(?:in|from)\s+the\s+(?:paper|pdf)\s+body\b"
+    r"|\bnot\s+on\s+(?:this|the\s+abstract)\s+page\b"
+    r"|\b(?:table|figure|fig\.|appendix)\s*\d"
+    r"|\bsection\s*\d"
+    r"|\bp\.\s*\d",
+    re.I,
+)
+
+DIGIT = re.compile(r"\d")
+
+# A locator inside a quotation is part of what the page says, not a claim about where the
+# evidence lives. `lamini` quotes an arXiv withdrawal comment - "I want to revisit some of the
+# experiments in this paper, specifically figure 5" - and that comment IS on the abstract page,
+# in the submission history, which is exactly what an /abs citation is for.
+QUOTED = re.compile(r"\"[^\"]*\"|'[^']*'")
+
+
+def unquoted(shows: str) -> str:
+    return QUOTED.sub(" ", shows)
+
+
+def sources() -> list[tuple[str, str, str, str]]:
+    """(slug, axis, url, shows) for every recorded source, in file order."""
+    found = []
+    for path in sorted((ROOT / "sources" / "scores").glob("*.yaml")):
+        doc = yaml.safe_load(path.read_text()) or {}
+        slug = doc.get("product")
+        if not slug:
+            continue
+        for axis in axes():
+            block = doc.get(axis)
+            if not isinstance(block, dict):
+                continue
+            for source in block.get("sources") or []:
+                if not isinstance(source, dict):
+                    continue
+                found.append((slug, axis, source.get("url") or "", source.get("shows") or ""))
+    return found
+
+
+def check(rows: list[tuple[str, str, str, str]] | None = None) -> list[str]:
+    """An `/abs` citation whose own `shows` places the claim in the body."""
+    failures = []
+    for slug, axis, url, shows in rows if rows is not None else sources():
+        if not ABS.match(url):
+            continue
+        hit = LOCATOR.search(unquoted(shows))
+        if hit:
+            failures.append(
+                f"{slug}:{axis} cites {url} for a claim its own `shows` places in the body "
+                f"({hit.group(0)!r}). An abstract page carries the abstract and the submission "
+                f"history and nothing else, so cite https://arxiv.org/pdf/ instead and re-fetch "
+                f"for the digest: uv run python -m build.fetch_source <url>"
+            )
+    return failures
+
+
+def candidates(rows: list[tuple[str, str, str, str]] | None = None) -> list[str]:
+    """An `/abs` citation carrying a number. Backlog, not a failure: it may be quoting the abstract."""
+    return [
+        f"{slug}:{axis} {url} - {shows[:90]}"
+        for slug, axis, url, shows in (rows if rows is not None else sources())
+        if ABS.match(url) and DIGIT.search(shows)
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--candidates", action="store_true",
+                        help="list the `/abs` citations carrying a number, which are the backlog")
+    args = parser.parse_args()
+
+    failures = check()
+    for line in failures:
+        print(f"  x {line}")
+
+    if args.candidates:
+        backlog = candidates()
+        print(f"\n  {len(backlog)} `/abs` citation(s) carrying a number, to read by hand:")
+        for line in backlog:
+            print(f"    ~ {line}")
+
+    print(f"\ncitations gate   an arXiv /abs citation for a claim only the body carries  "
+          f"{'[OK]' if not failures else f'{len(failures)} failure(s)'}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/preflight.py
+++ b/build/preflight.py
@@ -62,6 +62,7 @@ PLAN: dict[str, tuple[str, str]] = {
     "Adoption gate (every band exists on its instrument's scale)": (RUN, ""),
     "Instrument gate (every signal_type claim has what it needs to be falsifiable)": (RUN, ""),
     "Routing table structure": (RUN, ""),
+    "Citations gate (an arXiv /abs cited for a claim only the body carries)": (RUN, ""),
     "Freshness report (informational, does not gate)": (RUN, ""),
     "Serialize dry-run": (RUN, ""),
     "Retirement gate (a removed slug carries a redirect alias)": (RUN, ""),

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -476,6 +476,21 @@ and checks whether a cited page says what it was recorded as saying. Three were 
 2026-08-13 by padding truncated prefixes out to 64 characters, which is why this is stated here
 rather than assumed. `docs/workflows/refresh-category.md` carries the command that produces one.
 
+### Which arXiv URL to cite
+
+An arXiv abstract page carries the title, the authors, the abstract and the submission history.
+Tables, figures and appendices are not on it. So cite `https://arxiv.org/pdf/<id>` whenever the
+claim rests on something in the body, and `https://arxiv.org/abs/<id>` only for what the abstract
+page itself carries: the abstract's own wording, the authorship, a withdrawal notice. Do not cite
+`https://arxiv.org/html/<id>vN`, which does not exist for older papers and whose version suffix
+goes stale.
+
+A digest over a PDF is a digest over a binary, so reading one back means `pdftotext` first. That
+cost is why the convention was not free, and it is the smaller cost: twelve sources cited an
+abstract page for a table or a figure a reader could not find there (#263), and a claim whose
+cited page cannot carry it is unfalsifiable as recorded. `build/check_citations.py` gates it, on
+the record's own words rather than on a fetch, so it is free and runs per pull request.
+
 ## The gates, and why they ratchet
 
 Every failure mode this project has actually hit gets a mechanism, not a note. Cheap ones
@@ -488,6 +503,7 @@ gate every PR. The ones needing the network run periodically.
 | producible-pairs | an impossible score/class pair | the pair must be producible by some rule in the recipe | free |
 | refetch | fabricated or rotted sources | sampled re-fetch, digest and `shows` token match | network, weekly |
 | parity | repo and warehouse drifting apart | `build/check_parity.py`, a per-product differential | network, weekly |
+| citations | an arXiv `/abs` cited for a claim only the paper body carries | `build/check_citations.py`, on the record's own locator | free |
 | capability-anchors | a recorded peer comparison that does not hold | `relation` must agree with both scores, and a dated band's peer must be confirmed at least as recently | free |
 | age | a corpus that was confirmed once and then quietly aged | `build/check_freshness.py --max-age-days 45`, scheduled weekly | free, weekly |
 

--- a/docs/workflows/add-product.md
+++ b/docs/workflows/add-product.md
@@ -75,6 +75,14 @@ workflow that clears its row, so this is the only place it happens.
    source its capability axis cites, in which case it has been re-derived and may be dated.
    `uv run python -m build.check_refetch --product <peer>` first is cheap triage: where everything
    reproduces, the peer's recorded values are known unchanged and the read is a formality.
+   That promotion carries one further condition, because a peer can be a dependent itself (#443).
+   A peer may take the promoted `last_verified` only if it records no `relative_to`/`relation` at
+   all, or its own edge carries a `comparison` block whose `last_attested` is on or after the date
+   being claimed, or its own root's capability `last_verified` is already on or after that date.
+   The test is on the edge fields, not on whether a `comparison` key is present: `verl` at
+   `megatron-lm` and `pytorch` at `tensorflow` both carry bare edges, and re-dating either made it
+   outrun its own root, which `check_capability` rejected. The middle clause severs the chain rather
+   than pushing the obligation upstream, so the rule does not recurse.
 6. **Update both rosters** (category and org), and the org file if the org is new — and with it
    `sources/org_handles.yaml`, per the note above. A slug
    appears in exactly one of each. **If the product came from a registry row, delete that row

--- a/sources/categories/orchestration_agents.yaml
+++ b/sources/categories/orchestration_agents.yaml
@@ -57,6 +57,7 @@ products:
 - openfn
 - hexabot
 - mastra
+- agenta
 scoring_recipe:
   version: 1
   extends: software

--- a/sources/categories/telemetry_observability.yaml
+++ b/sources/categories/telemetry_observability.yaml
@@ -11,7 +11,6 @@ products:
 - openllmetry
 - opik
 - agentops
-- agenta
 - laminar
 - openlit
 - langtrace

--- a/sources/products/agenta.yaml
+++ b/sources/products/agenta.yaml
@@ -9,7 +9,7 @@ github:
 - url: https://github.com/Agenta-AI/agenta
 pypi:
 - url: https://pypi.org/project/agenta
-comments: 'Agenta 2.0 repositioned from an LLMOps prompt and evaluation platform to an agent workspace; capability
-  was re-scored on 2026-08-14 with its peer anchor removed rather than repointed. The open question is placement,
-  not the band: this sits closer to orchestration_agents than to telemetry. Verified 2026-08-14 via the Agenta
-  documentation and repository.'
+comments: 'Agenta 2.0 repositioned from an LLMOps prompt and evaluation platform to an agent workspace;
+  capability was re-scored on 2026-08-14 and the band stands. The record moved from telemetry_observability
+  to orchestration_agents on the ruling in #302, which also restores the peer anchor the earlier category
+  could not supply. Verified 2026-08-14 via the Agenta documentation and repository.'

--- a/sources/products/llama-factory.yaml
+++ b/sources/products/llama-factory.yaml
@@ -1,7 +1,9 @@
 name: llama-factory
-display_name: LLaMA-Factory
+display_name: LlamaFactory
 type: software
-description: LLaMA-Factory is a toolkit for fine-tuning 100+ open LLM and vision-language architectures, including
+aliases:
+- llamafactory
+description: LlamaFactory is a toolkit for fine-tuning 100+ open LLM and vision-language architectures, including
   LLaMA, Qwen, DeepSeek, Gemma, and GLM. It covers continued pre-training, supervised fine-tuning, reward modeling,
   and preference or RL methods such as PPO, DPO, KTO, and ORPO, across full, LoRA, and QLoRA tuning. A CLI
   and the Gradio-based LLaMA Board web UI run the same pipeline without custom code, and the project appeared
@@ -10,4 +12,8 @@ github:
 - url: https://github.com/hiyouga/LlamaFactory
 pypi:
 - url: https://pypi.org/project/llamafactory
-comments: Verified 2026-08-09 via GitHub and the LICENSE body.
+comments: The project renamed itself from LLaMA-Factory to LlamaFactory during 2026, and the old repository
+  URL 301-redirects to https://github.com/hiyouga/LlamaFactory (same owner, repo id 646410686). The slug stays
+  llama-factory because a slug is immutable once links are built on it, and the former name normalizes onto
+  that same slug; the new name resolves through the llamafactory alias. Verified 2026-08-09 via GitHub and
+  the LICENSE body, with the redirect read on 2026-09-09.

--- a/sources/scores/agenta.yaml
+++ b/sources/scores/agenta.yaml
@@ -99,33 +99,26 @@ adoption:
 capability:
   score: 3
   basis: feature_matrix
+  relative_to: openhands
+  relation: two_below
   value: 'Agenta 2.0, an agent workspace - no-code agent and automation building by chat; multiplayer
     workspace with a shared folder per agent; 1000+ integrations via built-ins or MCP servers; reusable
     skills; human approval and per-tool permissions; background agents on a schedule or an event;
     per-agent isolated sandboxes; version history; harness choice across Claude Code, Codex and Pi with
-    your own model subscription. Against this category''s matrix all that remains is "Tracing and usage.
-    Inspect every model and tool call. Track requests, tokens, latency, and estimated cost." No evaluator
-    catalogue, no datasets or experiments, no prompt management, and no OTel/OpenLLMetry/OpenInference
-    claim.'
+    your own model subscription. Tracing covers every model and tool call, with requests, tokens, latency
+    and estimated cost. No evaluator catalogue, no datasets or experiments, and no prompt management.'
   confidence: medium
-  note: 'The recorded feature list describes a product that has since been repositioned, and both readings
-    are kept here. The older one is a broad feature matrix spanning prompt management, evaluations and OpenTelemetry
-    observability, comparable to the Langfuse anchor at 4, with capability judged independently of Agenta''s
-    lower adoption. What the docs now open with is different: "Agenta is a workspace where you and your
-    team build agents and automations. You do not need to know how to code." Against what this category
-    grades, the whole remaining observability surface is tracing with request, token, latency and estimated-cost
-    tracking. There is no evaluator catalogue anywhere in the docs, the prompt-engineering section 404s,
-    and the OpenTelemetry, OpenLLMetry and OpenInference compatibility claims are gone; in their place is
-    a multiplayer workspace with per-agent folders, 1000+ integrations and MCP servers, reusable skills,
-    permissions with human approval, scheduled and event-triggered background agents, per-agent isolated
-    sandboxes and version history. The rungs above 3 in this category require an evaluation layer, datasets
-    and experiments, or prompt management on top of tracing, and Agenta 2.0 has none of the three; the rung
-    below is for monitoring that does not trace individual model and tool calls, which this does. So 3,
-    at medium confidence, with the honest caveat that the product is strong at something this category does
-    not measure. No peer comparison is recorded, because nothing else in this category is an agent workspace
-    and any target would assert a comparison class that does not exist. The open question is placement rather
-    than band: a no-code agent workspace sits closer to agent orchestration than to telemetry, which is
-    a recategorization for a human rather than a re-score.'
+  note: 'A no-code agent workspace, graded on features. The docs open "Agenta is a workspace where you
+    and your team build agents and automations. You do not need to know how to code." The older LLMOps
+    surface is gone: no evaluator catalogue anywhere in the docs, the prompt-engineering section 404s,
+    and the OpenTelemetry, OpenLLMetry and OpenInference compatibility claims have been dropped. In their
+    place are a multiplayer workspace with per-agent folders, 1000+ integrations and MCP servers, reusable
+    skills, permissions with human approval, scheduled and event-triggered background agents, per-agent
+    isolated sandboxes and version history, with tracing over every model and tool call. No peer was recorded
+    while the record sat in telemetry_observability, because nothing there is an agent workspace; in orchestration_agents
+    (#302) the anchor is the category''s root, two tiers below OpenHands, where the other feature-matrix
+    agent platforms of this breadth sit. The feature breadth is real and there is no published agent-benchmark
+    placement, so this stays a mid-tier judgment at medium confidence.'
   last_verified: '2026-08-14'
   sources:
   - url: https://agenta.ai/docs/

--- a/sources/scores/c4.yaml
+++ b/sources/scores/c4.yaml
@@ -49,9 +49,12 @@ capability:
   relation: one_below
   last_verified: '2026-08-13'
   sources:
-  - url: https://arxiv.org/abs/2406.17557
-    shows: Abstract - FineWeb produces better-performing LLMs than other open pretraining datasets. The
-      C4 baseline row is in the paper body, not on this page
-    accessed: '2026-08-13'
+  - url: https://arxiv.org/pdf/2406.17557
+    shows: FineWeb paper full text. The per-corpus ablation places C4 in the comparison set - "RefinedWeb (500B
+      tokens), C4 (172B tokens); the Common Crawl-based part of Dolma 1.6 (3T tokens) and 1.7 (1.2T tokens),
+      The Pile (340B tokens), SlimPajama (627B tokens)" - and section 3.4 records that "the C4 dataset, while
+      smaller than FineWeb, still showed stronger performance", which is what set the filtering work that followed.
+      The arXiv abstract page carries none of this.
+    accessed: '2026-09-11'
     http_status: 200
-    content_sha256: a12bfcd47f835ad4a2c5630a228778370ed54509afa65bed1c6dfc264f2182da
+    content_sha256: ae632bd6618d2566e708962670f27ab1fbc5ba9bc8de3acaceee8fbda85fbdd4

--- a/sources/scores/dolma.yaml
+++ b/sources/scores/dolma.yaml
@@ -51,12 +51,14 @@ capability:
   relation: one_below
   last_verified: '2026-08-13'
   sources:
-  - url: https://arxiv.org/abs/2406.17557
-    shows: Abstract - FineWeb produces better-performing LLMs than other open pretraining datasets. The
-      Dolma v1.6/v1.7 ablation rows are in the paper body, not on this page
-    accessed: '2026-08-13'
+  - url: https://arxiv.org/pdf/2406.17557
+    shows: FineWeb paper full text. Dolma enters the comparison as "the Common Crawl-based part of Dolma 1.6
+      (3T tokens) and 1.7 (1.2T tokens)", and both versions appear as rows in the per-corpus ablation figures
+      alongside RefinedWeb, C4, The Pile, SlimPajama and RedPajama2. The arXiv abstract page names no comparison
+      corpus at all.
+    accessed: '2026-09-11'
     http_status: 200
-    content_sha256: a12bfcd47f835ad4a2c5630a228778370ed54509afa65bed1c6dfc264f2182da
+    content_sha256: ae632bd6618d2566e708962670f27ab1fbc5ba9bc8de3acaceee8fbda85fbdd4
   - url: https://allenai.org/blog/olmo3
     shows: Dolma superseded by Dolma 3 for OLMo 3
     accessed: '2026-08-13'

--- a/sources/scores/fineweb-2.yaml
+++ b/sources/scores/fineweb-2.yaml
@@ -50,12 +50,14 @@ capability:
     mC4, CC-100 and HPLT, and Apertus is trained on 15T tokens at 8B and 70B.
   last_verified: '2026-08-13'
   sources:
-  - url: https://arxiv.org/abs/2509.14233
-    shows: Abstract - Apertus 8B and 70B train on 15T tokens from over 1800 languages. The FineWeb-2 attribution
-      is in the paper body, not on this page
-    accessed: '2026-08-13'
+  - url: https://arxiv.org/pdf/2509.14233
+    shows: 'Apertus paper full text. The attribution is in the body: "We train our model on 15T tokens from 1811
+      languages during pretraining, taken from the FineWeb-2 web crawl dataset", with FineWeb-2 also carrying
+      the URL-ranking and multilingual toxicity filtering the paper runs, and Appendix G giving the FineWeb-2
+      language distribution. The arXiv abstract page gives the token and language counts without naming the corpus.'
+    accessed: '2026-09-11'
     http_status: 200
-    content_sha256: 708c422a40898842cec08532b4f86917f8648837d96e5a3149aca899b6168d2a
+    content_sha256: 692729497efde76e0e1801b128ea7e8b310a20fb275c9e7c6429258ff3fa0b5f
   - url: https://huggingface.co/datasets/HuggingFaceFW/fineweb-2
     shows: FineWeb-2 outperforms CulturaX/mC4/CC-100/HPLT on FineTasks in controlled ablations
     accessed: '2026-08-13'

--- a/sources/scores/fineweb-edu.yaml
+++ b/sources/scores/fineweb-edu.yaml
@@ -49,15 +49,21 @@ capability:
     default web corpus for SmolLM2/3 and Apertus.
   last_verified: '2026-08-13'
   sources:
-  - url: https://arxiv.org/abs/2406.17557
-    shows: Abstract - LLMs pretrained on FineWeb-Edu, a 1.3T-token educational subset, do dramatically better
-      on MMLU and ARC. The ~10x token-efficiency figure is in the paper body, not on this page
-    accessed: '2026-08-13'
+  - url: https://arxiv.org/pdf/2406.17557
+    shows: 'FineWeb paper full text. The token-efficiency figure is in the body: "On MMLU, FineWeb-Edu can match
+      the final performance of Matrix with almost 10x fewer tokens, demonstrating the effectiveness of classifiers
+      trained on LLM annotations for large-scale data" - and Fig. 16 compares FineWeb-Edu with other open web
+      datasets on nine benchmarks at 1.71B parameters over 350B tokens. The arXiv abstract page gives the MMLU
+      and ARC claim without the multiple.'
+    accessed: '2026-09-11'
     http_status: 200
-    content_sha256: a12bfcd47f835ad4a2c5630a228778370ed54509afa65bed1c6dfc264f2182da
-  - url: https://arxiv.org/abs/2502.02737
-    shows: Abstract - SmolLM2 is overtrained on ~11T tokens mixing web text with specialised math, code
-      and instruction data. The named FineWeb-Edu component is in the paper body, not on this page
-    accessed: '2026-08-13'
+    content_sha256: ae632bd6618d2566e708962670f27ab1fbc5ba9bc8de3acaceee8fbda85fbdd4
+  - url: https://arxiv.org/pdf/2502.02737
+    shows: 'SmolLM2 paper full text. FineWeb-Edu is named as a training component and measured against DCLM:
+      Table 1 evaluates models trained on each for 350B tokens, "FineWeb-Edu achieves higher scores on the educational
+      benchmarks MMLU, ARC, and OpenBookQA, while DCLM performs better on HellaSwag and CommonsenseQA", and the
+      released mixture uses "a 60% FineWeb-Edu and 40% DCLM mix". The arXiv abstract page names no component
+      dataset.'
+    accessed: '2026-09-11'
     http_status: 200
-    content_sha256: f19a89b93bdd5a66445878803fa6ad900599fe4792c84080a02b4dae77699a1d
+    content_sha256: a95fbda201d21cd25c89e949636373d36c288bd2d287e3cabd208e2041ea36d3

--- a/sources/scores/fineweb.yaml
+++ b/sources/scores/fineweb.yaml
@@ -51,10 +51,11 @@ capability:
   relation: one_below
   last_verified: '2026-08-13'
   sources:
-  - url: https://arxiv.org/abs/2406.17557
-    shows: Abstract - FineWeb, 15T tokens from 96 Common Crawl snapshots, produces better-performing LLMs
-      than other open pretraining datasets. The per-corpus ablation table is in the paper body, not on this
-      page
-    accessed: '2026-08-13'
+  - url: https://arxiv.org/pdf/2406.17557
+    shows: FineWeb paper full text. The per-corpus ablation compares FineWeb against RefinedWeb (500B tokens),
+      C4 (172B tokens), the Common Crawl-based part of Dolma 1.6 (3T) and 1.7 (1.2T), The Pile (340B), SlimPajama
+      (627B) and the deduplicated RedPajama2 (20T), all trained at 1.71B parameters on matched token budgets
+      with the nanotron library. The arXiv abstract page carries the headline claim and none of the table.
+    accessed: '2026-09-11'
     http_status: 200
-    content_sha256: a12bfcd47f835ad4a2c5630a228778370ed54509afa65bed1c6dfc264f2182da
+    content_sha256: ae632bd6618d2566e708962670f27ab1fbc5ba9bc8de3acaceee8fbda85fbdd4

--- a/sources/scores/flan-collection.yaml
+++ b/sources/scores/flan-collection.yaml
@@ -62,13 +62,14 @@ capability:
     SFT card still consumes FLAN v2.
   last_verified: '2026-08-13'
   sources:
-  - url: https://arxiv.org/abs/2301.13688
-    shows: Abstract - ablations on the Flan Collection show Flan-T5 outperforming prior work by 3-17%+ across
-      evaluation settings. The per-collection P3/Super-NaturalInstructions rows are in the paper body, not
-      on this page
-    accessed: '2026-08-13'
+  - url: https://arxiv.org/pdf/2301.13688
+    shows: 'Flan Collection paper full text. The per-collection comparison is in the body and in Figure 1: T5-XL-LM
+      finetuned on Flan 2022 is set against the same model finetuned on Flan 2021, P3++ and Super-Natural Instructions,
+      and "P3++" is defined there as all datasets in the Public Pool of Prompts. The arXiv abstract page gives
+      the 3-17%+ headline without the per-collection rows.'
+    accessed: '2026-09-11'
     http_status: 200
-    content_sha256: c87f46d42a0899f9db968728890fa3ac150e8163f206263fee7331d346d0ea77
+    content_sha256: 9b7644ffbe0a2c896fdefa202c79a6020f8a2cb73f655914ff77bdc9b308f5d8
   - url: https://huggingface.co/datasets/allenai/Dolci-Instruct-SFT
     shows: OLMo 3 Dolci still consumes FLAN v2 (89,981 prompts)
     accessed: '2026-08-13'

--- a/sources/scores/hh-rlhf.yaml
+++ b/sources/scores/hh-rlhf.yaml
@@ -53,12 +53,15 @@ capability:
     mixes (absent from Tulu 3 and OLMo 3 Dolci DPO).
   last_verified: '2026-08-13'
   sources:
-  - url: https://arxiv.org/abs/2204.05862
-    shows: Abstract - RLHF on the HH preference data improves performance on almost all NLP evaluations.
-      The per-benchmark Elo, TruthfulQA and BBQ numbers are in the paper body, not on this page
-    accessed: '2026-08-13'
+  - url: https://arxiv.org/pdf/2204.05862
+    shows: 'Anthropic HH paper full text. The per-benchmark results are in the body: Elo scores fitted from crowdworker
+      win rates compare context-distilled, static-RLHF and online-RLHF models (Figure 1), TruthfulQA (MC1) improves
+      with RLHF and with model size (Figure 5), and BBQ-Lite is reported with the authors'' own caution that
+      "none of our models appear particularly biased" under that metric (Figure 18). The arXiv abstract page
+      carries none of these numbers.'
+    accessed: '2026-09-11'
     http_status: 200
-    content_sha256: e8485045e8148841fdcbea46cd7837c6ed2e97d39c6f8d8675e81e0c3f72a25c
+    content_sha256: 26e390d4f76938d2e2591225603637c643cc108e94afb756c65f5d2e0fc9037b
   - url: https://huggingface.co/datasets/allenai/llama-3.1-tulu-3-8b-preference-mixture
     shows: HH-RLHF is not used in the Tulu 3 preference mixture
     accessed: '2026-08-13'

--- a/sources/scores/llama-factory.yaml
+++ b/sources/scores/llama-factory.yaml
@@ -8,7 +8,7 @@ openness:
       detail: OSI
     source:
       value: public
-      detail: hiyouga/LLaMA-Factory
+      detail: hiyouga/LlamaFactory
     core-gated:
       value: ungated
     free_text:
@@ -18,7 +18,7 @@ openness:
   note: Apache-2.0, an OSI license, with the full source public including the web UI, and no features held
     back for a paid tier.
   last_verified: '2026-09-09'
-  raw: license:Apache-2.0(OSI);source:public(hiyouga/LLaMA-Factory);CLI+WebUI;no proprietary managed tier;core-gated:ungated
+  raw: license:Apache-2.0(OSI);source:public(hiyouga/LlamaFactory);CLI+WebUI;no proprietary managed tier;core-gated:ungated
   sources:
   - url: https://github.com/hiyouga/LLaMA-Factory
     shows: Redirects (301) to the renamed repository https://github.com/hiyouga/LlamaFactory (same owner,

--- a/sources/scores/personahub.yaml
+++ b/sources/scores/personahub.yaml
@@ -60,13 +60,14 @@ capability:
     That is the same shape as tulu-3-sft-mixture and fineweb, both also 4.'
   last_verified: '2026-08-13'
   sources:
-  - url: https://arxiv.org/abs/2406.20094
-    shows: Abstract - Persona Hub is 1 billion personas curated from web data, showcased on synthesised
-      mathematical and logical reasoning problems. The Qwen2-7B MATH result is in the paper body, not on
-      this page
-    accessed: '2026-08-13'
+  - url: https://arxiv.org/pdf/2406.20094
+    shows: 'Persona Hub paper full text. The result is in the body: Qwen2-7B fine-tuned on the 1.07M synthesized
+      math instances is evaluated by greedy decoding, and "our approach allows a 7B LLM to achieve 65% on MATH,
+      matching the performance of gpt-4-turbo-preview", with Figure 9 scaling accuracy against the number of
+      synthetic instances. The arXiv abstract page describes the use case without the score.'
+    accessed: '2026-09-11'
     http_status: 200
-    content_sha256: c2afd401fde3e5f27e49713b190624f91bddce361fc07efab2023d49de41db06
+    content_sha256: df49d01d1289417319eccd9ebac1ddf5ce2b383a1b833ad9e821c15667517ea0
   - url: https://huggingface.co/datasets/allenai/tulu-3-sft-personas-math
     shows: Card - 149,960 synthetic math examples built by expanding the persona methodology of Ge et al.
       2024

--- a/sources/scores/redpajama-data-v2.yaml
+++ b/sources/scores/redpajama-data-v2.yaml
@@ -53,13 +53,14 @@ capability:
   relation: one_below
   last_verified: '2026-08-13'
   sources:
-  - url: https://arxiv.org/abs/2411.12372
-    shows: Abstract - RedPajama-V2 is a raw, unfiltered web corpus of over 100T tokens shipped with quality
-      signals for downstream filtering. The Gopher-filtered ablation against C4/Dolma/RefinedWeb is in the
-      paper body, not on this page
-    accessed: '2026-08-13'
+  - url: https://arxiv.org/pdf/2411.12372
+    shows: 'RedPajama paper full text. The ablation is in the body: Table 5 varies the C4 and Gopher rule sets
+      over RPv2, and "fuzzy deduplication and filtering with Gopher has the highest aggregated scores across
+      all RPv2 datasets", second only to RefinedWeb on both the average and the normalized average benchmark
+      score. The arXiv abstract page describes the corpus and its quality signals and reports no ablation.'
+    accessed: '2026-09-11'
     http_status: 200
-    content_sha256: 2267c9f00b499961cb995dad139f932a0567bb1b326ddbb22ed75b19b718f9cf
+    content_sha256: f40ed61d29d59f2f26ffd8cf78ee8177e5e56eca2fd3beb7511d9ceaf53e9fbb
   - url: https://arxiv.org/abs/2406.17557
     shows: FineWeb outperforms RedPajama2 in the FineWeb ablation
     accessed: '2026-08-13'

--- a/sources/scores/refinedweb.yaml
+++ b/sources/scores/refinedweb.yaml
@@ -57,10 +57,11 @@ capability:
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: ff401c9e67db2503c67320fc867f3d245f796802154da023cfedd5d7febf4998
-  - url: https://arxiv.org/abs/2406.11794
-    shows: Abstract - DCLM-Baseline reaches 64% MMLU at 2.6T tokens, 6.6 points over the prior open-data
-      state of the art. The legacy-corpus ranking that places RefinedWeb is in the paper body, not on this
-      page
-    accessed: '2026-08-13'
+  - url: https://arxiv.org/pdf/2406.11794
+    shows: 'DCLM paper full text. The legacy-corpus ranking is in the body: Table 2 evaluates C4, RefinedWeb,
+      RedPajama and Dolma-V1, "we find that RefinedWeb performs the best on our CORE and EXTENDED metrics at
+      the 7B-1x scale", and the takeaway is "For DCLM-BASELINE and other experiments, we adopt RefinedWeb''s
+      heuristic filters." The arXiv abstract page carries the DCLM-Baseline headline and no corpus ranking.'
+    accessed: '2026-09-11'
     http_status: 200
-    content_sha256: f665620bfe7fe32ea36cf6f4daab947bd13e925c191d80444c02c8ceb14fd974
+    content_sha256: af8fc884ccd601f8c6fbbba8f8e381de652fce1233949c0c64f64b4ab4b0f5b2

--- a/sources/scores/ultrafeedback.yaml
+++ b/sources/scores/ultrafeedback.yaml
@@ -58,9 +58,11 @@ capability:
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: a7a4e8be5d00f66bb16d3da7601dc4c207327b353dd110257d4ab8137dc7475b
-  - url: https://arxiv.org/abs/2411.15124
-    shows: Tulu 3 releases an open preference-data pipeline at scale; the UltraFeedback lineage is described
-      in the paper body, not on this page
-    accessed: '2026-08-13'
+  - url: https://arxiv.org/pdf/2411.15124
+    shows: 'Tulu 3 paper full text. The lineage is in the body: the SFT mixture includes "a decontaminated subset
+      of UltraFeedback", the preference stage works "by adapting and advancing the UltraFeedback pipeline", and
+      the released prompt sets are named tulu-3-sft-prompts-ultrafeedback and tulu-3-wildchat-ultrafeedback,
+      with Figure 7 giving the pipeline. The arXiv abstract page does not mention UltraFeedback.'
+    accessed: '2026-09-11'
     http_status: 200
-    content_sha256: b09d632f6108756e4a3fc59de2fb15acc5cd1152a2b873d90eba51008e6ee883
+    content_sha256: 79bed1ef4ce4bb332f43bdc87d60709e644560f8f3bb6d14913a473cc82c251f

--- a/tests/test_adoption_evaluation.py
+++ b/tests/test_adoption_evaluation.py
@@ -45,7 +45,10 @@ BASELINE_SNAPSHOT_ID = "9bd4d93a6fc67a2b9d89d91adeb4bb3f4fd9b612cc26e6647c67210c
 # Moved on 2026-09-11 by the embeddings_retrieval promotion. MEASUREMENT_COUNT is unchanged at
 # 377 - the new products carry no observation in the pinned snapshot, so no row was added - but
 # the recorded bands they contribute change the content the digest covers.
-MEASUREMENTS_DIGEST = "4df6f5d9b71ee7ab04d940168a2343ae9de38662160f623e14991d9ec57931d0"
+# Moved again on 2026-09-11 by the agenta recategorization (#302): the product left
+# telemetry_observability for orchestration_agents, and `category_slug` is one of the columns
+# this digest covers. Same 377 rows, same band, one row's category.
+MEASUREMENTS_DIGEST = "5e27bfeb2652c6e9c187bcb86506503d2e3f6a4840cbdba8b19e5919e8d8bf31"
 # Moved 2026-09-01 by the areal and xtuner relabels (#435): a recorded instrument change
 # is a declaration change, which is one of the four things this digest tracks. Both
 # levels stay where they were.

--- a/tests/test_check_citations.py
+++ b/tests/test_check_citations.py
@@ -1,0 +1,60 @@
+"""Tests for the arXiv citation gate.
+
+The two that carry the design are `test_a_quoted_locator_is_not_a_body_claim` and
+`test_a_number_over_abs_is_reported_not_failed`. The first is the distinction the gate rests on:
+a table or figure named inside a quotation is part of what the abstract page says, and the
+submission history is exactly what an `/abs` citation is good for. The second is the ratchet —
+most numeric `/abs` citations quote the abstract and are correct, so telling them apart needs a
+reader, and a gate that failed on the backlog would be switched off.
+"""
+
+from build.check_citations import candidates, check
+
+ABS = "https://arxiv.org/abs/2406.17557"
+PDF = "https://arxiv.org/pdf/2406.17557"
+
+
+def rows(*entries):
+    return [("prod", "capability", url, shows) for url, shows in entries]
+
+
+def test_an_abs_cited_for_the_paper_body_fails():
+    problems = check(rows((ABS, "Abstract. The per-corpus ablation table is in the paper body, not on this page")))
+    assert len(problems) == 1
+    assert "arxiv.org/pdf" in problems[0]
+
+
+def test_a_table_locator_over_abs_fails():
+    assert len(check(rows((ABS, "Table 2 gives the token counts per corpus")))) == 1
+
+
+def test_the_same_claim_over_pdf_passes():
+    assert check(rows((PDF, "Table 2 gives the token counts per corpus"))) == []
+
+
+def test_a_quoted_locator_is_not_a_body_claim():
+    """An abstract page's submission history can quote an author naming a figure."""
+    shows = ('The paper was withdrawn by its authors. Submission history: "[v2] Wed, 3 Sep 2025 '
+             '(withdrawn)", with the comment "I want to revisit some of the experiments in this '
+             'paper, specifically figure 5."')
+    assert check(rows((ABS, shows))) == []
+
+
+def test_an_abstract_quote_passes():
+    assert check(rows((ABS, 'the abstract still reads "817 questions that span 38 categories"'))) == []
+
+
+def test_a_number_over_abs_is_reported_not_failed():
+    entries = rows((ABS, 'the abstract still reads "817 questions that span 38 categories"'))
+    assert check(entries) == []
+    assert len(candidates(entries)) == 1
+
+
+def test_a_non_arxiv_source_is_out_of_scope():
+    entries = rows(("https://example.com/paper", "Table 2 gives the token counts"))
+    assert check(entries) == []
+    assert candidates(entries) == []
+
+
+def test_the_corpus_passes():
+    assert check() == []


### PR DESCRIPTION
Four rulings that each needed a small, specified edit. The fifth in the batch (#508) could not be done here; see the note at the bottom.

## What is in here

**Agenta moves category — closes #302.** `agenta` leaves `telemetry_observability` for `orchestration_agents`. The capability re-score from 4 to 3 stands and is untouched. The peer anchor comes back as `relative_to: openhands, relation: two_below`, which is where every other feature-matrix agent platform at band 3 in that category sits, and which the old category could not supply because nothing there is an agent workspace. The capability note and the product comment are rewritten to describe the record as it now stands rather than the open placement question.

**The re-dating rule — closes #443.** `docs/workflows/add-product.md`, step 5, now says when a peer may take a promoted `last_verified`: only if it records no `relative_to`/`relation` at all, or its own edge carries a `comparison` block whose `last_attested` is on or after the date claimed, or its own root's capability `last_verified` already is. The test is on the edge fields, not on whether a `comparison` key exists, which is what would have let `verl` and `pytorch` through.

**LlamaFactory rename.** `github.com/hiyouga/LLaMA-Factory` 301-redirects to `github.com/hiyouga/LlamaFactory` (same owner, repo id 646410686). Same treatment as the Perplexica to Vane rename in #523: the slug stays `llama-factory`, `display_name` reads LlamaFactory, the new name resolves through an `aliases` entry, and the rename is recorded in the product comment. The openness `components.source` detail and its `raw` string stop naming the old repository path.

**Ten arXiv citations, and a lint — closes #263.** The corpus held **twelve** sources, not ten, whose `shows` said in as many words that the claim was in the paper body rather than on the cited abstract page: `c4`, `dolma`, `fineweb`, `fineweb-edu` (twice), `fineweb-2`, `flan-collection`, `hh-rlhf`, `personahub`, `redpajama-data-v2`, `refinedweb`, `ultrafeedback`. Every one is repointed to `arxiv.org/pdf/<id>`, re-fetched with `build.fetch_source` for a real `accessed`, `http_status` and `content_sha256`, and its `shows` rewritten to quote what the body carries — each claim was checked against the PDF text before the wording was written.

`build/check_citations.py` is the new gate. It fails an `/abs` citation whose own `shows` names a table, a figure, a section, an appendix or a page, or says the claim is in the body; a locator inside a quotation does not count, because an abstract page's submission history can quote an author naming a figure and that is exactly what `/abs` is good for (`lamini` is the live case). An `/abs` citation merely carrying a number is reported by `--candidates` and does not fail: most of those quote the abstract and are correct, so that set is backlog, the same ratchet `check_capability` uses. Wired into `.github/workflows/validate.yml`, `build/preflight.py`'s PLAN, the gate table in `docs/reference/evidence-and-freshness.md` and the map in `AGENTS.md`, with the convention itself written into the evidence guide.

The adoption measurement golden in `tests/test_adoption_evaluation.py` moves with the agenta recategorization: same 377 rows, same band, one row's `category_slug`.

## Not in here

**#508, labelling the frozen `scores.taxonomy` read, could not be done in this PR.** The `state-of-os-ai` notebook is not in this repository. `.gitignore` tracks four release notebooks by allowlist and that is not one of them, so the notebook exists only on the OSO platform and no edit to it can travel in a pull request. Either the notebook comes into the repository first, or the change is made on the platform, which is a publish. Flagging rather than substituting something else.

## Test plan

```
$ uv run python -m build.validate
0 error(s), 2 warning(s)

$ uv run python -m build.check_verification --verbose
invariant          a confirmation with no supporting evidence   [OK]
digests            a claimed date with no fetch digest          [OK]
producible-pairs   an impossible score/class pair               [OK]
placeholder-shows  a `shows` that records a batch marker, not the page [OK]

$ uv run python -m build.check_citations
citations gate   an arXiv /abs citation for a claim only the body carries  [OK]

$ uv run python -m build.check_capability
capability-anchors  a recorded comparison that does not hold  [OK]

$ uv run pytest -q
1896 passed, 1 skipped in 816.57s (0:13:36)
```

The two `validate` warnings are the pre-existing `model_families` pattern overlaps (`deepseek-*`/`deepseek-coder-*`, `llama-*`/`llama-guard-*`).

`check_refetch --strict` on every product whose score file changed — `agenta`, `llama-factory` and the twelve repointed records — passes with no fabricated digests, and each repointed `/pdf` reproduced its recorded digest exactly:

```
$ uv run python -m build.check_refetch --product c4 --strict
3 sources carry a digest, 3 re-fetched: 1 confirmed, 2 drifted, 0 dead, 0 unreachable.
1 digest(s) reproduced exactly, which only an actual fetch could have produced.
[OK] no fabricated digests
```

The drift reported across those runs is on GitHub, PyPI and Hugging Face pages that change on their own; no arXiv PDF drifted.
