### PR TITLE
Abstain on capability for the four scored evaluation datasets

### DIFF
--- a/sources/scores/gaia.yaml
+++ b/sources/scores/gaia.yaml
@@ -64,13 +64,17 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: 'A dataset is not ''capable'', so this axis is left unscored and the product is graded on adoption
-    alone. What the record otherwise recorded: GAIA is 466 questions across three levels requiring multi-step
-    tool use, live browsing and multimodal files, each with a single checkable answer. That is what makes
-    it the canonical end-to-end agentic-assistant benchmark, distinct from knowledge and code benchmarks,
-    and contamination-resistant. That is a quality caveat about the instrument rather than a capability
-    score: read as discriminative power, capability would decay as the field trains on a benchmark, which
-    makes it anti-correlated with adoption and unfit to blend with it. See #319.'
+  note: 'A dataset is not ''capable'' in the sense this axis measures elsewhere, so it is left unscored
+    and the product is graded on adoption alone. What the record previously asserted, kept as the quality
+    caveat it always was: GAIA is the canonical end-to-end agentic-assistant benchmark, 466 questions across
+    three levels requiring multi-step tool use, live browsing and multimodal files, each with a single checkable
+    answer. It is distinct from knowledge and code benchmarks, and contamination-resistant. This records
+    the absence of an agreed rubric, not a claim that an evaluation set has no measurable quality. #319
+    proposed reading the axis as discriminative power, whether a benchmark still separates frontier models,
+    and that reading was set aside on two grounds: it decays as the field trains on a benchmark, so it works
+    against adoption in the maturity blend, and the evidence assembled for it did not establish the bands
+    it assigned. A reading built on the artifact instead - coverage, grading validity, refresh cadence -
+    would not decay and has not been worked out. Until one exists this axis abstains. See #546.'
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2311.12983

--- a/sources/scores/gaia.yaml
+++ b/sources/scores/gaia.yaml
@@ -60,12 +60,17 @@ adoption:
     http_status: 200
     content_sha256: 0bcfa21e0181419fa7c6c33c382a5e50ac59e8d343ab40a9ad4557a33377c4f0
 capability:
-  score: 5
-  basis: feature_matrix
-  value: 466 questions, 3 levels; multi-step tool use, live browsing, multi-modal files with one checkable answer
+  score: null
+  basis: n/a
+  value: null
   confidence: high
-  note: 'The canonical end-to-end agentic-assistant benchmark: distinct from knowledge and code benchmarks,
-    and contamination-resistant.'
+  note: 'A dataset is not ''capable'', so this axis is left unscored and the product is graded on adoption
+    alone. What the record otherwise recorded: GAIA is 466 questions across three levels requiring multi-step
+    tool use, live browsing and multimodal files, each with a single checkable answer. That is what makes
+    it the canonical end-to-end agentic-assistant benchmark, distinct from knowledge and code benchmarks,
+    and contamination-resistant. That is a quality caveat about the instrument rather than a capability
+    score: read as discriminative power, capability would decay as the field trains on a benchmark, which
+    makes it anti-correlated with adoption and unfit to blend with it. See #319.'
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2311.12983

--- a/sources/scores/humanitys-last-exam.yaml
+++ b/sources/scores/humanitys-last-exam.yaml
@@ -61,12 +61,17 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: 'A dataset is not ''capable'', so this axis is left unscored and the product is graded on adoption
-    alone. What the record otherwise recorded: 2,500 expert questions across more than 100 subjects, multimodal,
-    with a private held-out set, built as a successor to a saturated MMLU and MATH. GPQA is the nearest
-    narrower peer on difficulty. That is a quality caveat about the instrument rather than a capability
-    score: read as discriminative power, capability would decay as the field trains on a benchmark, which
-    makes it anti-correlated with adoption and unfit to blend with it. See #319.'
+  note: 'A dataset is not ''capable'' in the sense this axis measures elsewhere, so it is left unscored
+    and the product is graded on adoption alone. What the record previously asserted, kept as the quality
+    caveat it always was: 2,500 expert questions across more than 100 subjects, multimodal, with a private
+    held-out set, built as a successor to a saturated MMLU and MATH. It is far harder and broader than either,
+    with GPQA the nearest narrower peer on difficulty. This records the absence of an agreed rubric, not
+    a claim that an evaluation set has no measurable quality. #319 proposed reading the axis as discriminative
+    power, whether a benchmark still separates frontier models, and that reading was set aside on two grounds:
+    it decays as the field trains on a benchmark, so it works against adoption in the maturity blend, and
+    the evidence assembled for it did not establish the bands it assigned. A reading built on the artifact
+    instead - coverage, grading validity, refresh cadence - would not decay and has not been worked out.
+    Until one exists this axis abstains. See #546.'
   last_verified: '2026-08-13'
   sources:
   - url: https://lastexam.ai

--- a/sources/scores/humanitys-last-exam.yaml
+++ b/sources/scores/humanitys-last-exam.yaml
@@ -57,12 +57,16 @@ adoption:
     http_status: 200
     content_sha256: 27e476a04eaa2d4c5c81ec22ec8f6707e50eff416228060b26d01a70d5cae230
 capability:
-  score: 5
-  basis: feature_matrix
-  value: 2,500 expert questions across 100+ subjects; multimodal; private held-out set; designed as successor to
-    saturated MMLU/MATH
+  score: null
+  basis: n/a
+  value: null
   confidence: high
-  note: Far harder and broader than MMLU or MATH, with GPQA the nearest narrower peer on difficulty.
+  note: 'A dataset is not ''capable'', so this axis is left unscored and the product is graded on adoption
+    alone. What the record otherwise recorded: 2,500 expert questions across more than 100 subjects, multimodal,
+    with a private held-out set, built as a successor to a saturated MMLU and MATH. GPQA is the nearest
+    narrower peer on difficulty. That is a quality caveat about the instrument rather than a capability
+    score: read as discriminative power, capability would decay as the field trains on a benchmark, which
+    makes it anti-correlated with adoption and unfit to blend with it. See #319.'
   last_verified: '2026-08-13'
   sources:
   - url: https://lastexam.ai

--- a/sources/scores/livebench.yaml
+++ b/sources/scores/livebench.yaml
@@ -123,13 +123,18 @@ capability:
   basis: n/a
   value: null
   confidence: high
-  note: 'A dataset is not ''capable'', so this axis is left unscored and the product is graded on adoption
-    alone. What the record otherwise recorded: LiveBench covers six domains, auto-scores every question
-    against objective ground truth with no LLM judge, and rotates its questions monthly, which is what makes
-    it contamination-resistant and broader than the code-only LiveCodeBench. That is a quality caveat about
-    the instrument rather than a capability score: read as discriminative power, capability would decay
-    as the field trains on a benchmark, which makes it anti-correlated with adoption and unfit to blend
-    with it. See #319.'
+  note: 'A dataset is not ''capable'' in the sense this axis measures elsewhere, so it is left unscored
+    and the product is graded on adoption alone. What the record previously asserted, kept as the quality
+    caveat it always was: LiveBench is among the most influential contamination-resistant benchmarks, covering
+    six domains, auto-scoring every question against objective ground truth with no LLM judge, and rotating
+    its questions monthly. That rotation is a standing counterexample to the idea that a benchmark must
+    decay, and one reason the discriminative-power reading is not obviously right. This records the absence
+    of an agreed rubric, not a claim that an evaluation set has no measurable quality. #319 proposed reading
+    the axis as discriminative power, whether a benchmark still separates frontier models, and that reading
+    was set aside on two grounds: it decays as the field trains on a benchmark, so it works against adoption
+    in the maturity blend, and the evidence assembled for it did not establish the bands it assigned. A
+    reading built on the artifact instead - coverage, grading validity, refresh cadence - would not decay
+    and has not been worked out. Until one exists this axis abstains. See #546.'
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2406.19314

--- a/sources/scores/livebench.yaml
+++ b/sources/scores/livebench.yaml
@@ -119,13 +119,17 @@ adoption:
     http_status: 200
     content_sha256: 30cc3108d8d653424b31bff4d2643d1590558ab46b4153d0e6feaa5bfc8504b7
 capability:
-  score: 5
-  basis: feature_matrix
-  value: 6 domains; objective ground-truth auto-scoring (no LLM judge); monthly question rotation for contamination
-    resistance
+  score: null
+  basis: n/a
+  value: null
   confidence: high
-  note: 'Among the most influential contamination-resistant benchmarks: broader than the code-only LiveCodeBench,
-    and judge-free, since every question is auto-scored against objective ground truth.'
+  note: 'A dataset is not ''capable'', so this axis is left unscored and the product is graded on adoption
+    alone. What the record otherwise recorded: LiveBench covers six domains, auto-scores every question
+    against objective ground truth with no LLM judge, and rotates its questions monthly, which is what makes
+    it contamination-resistant and broader than the code-only LiveCodeBench. That is a quality caveat about
+    the instrument rather than a capability score: read as discriminative power, capability would decay
+    as the field trains on a benchmark, which makes it anti-correlated with adoption and unfit to blend
+    with it. See #319.'
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2406.19314

--- a/sources/scores/mt-bench.yaml
+++ b/sources/scores/mt-bench.yaml
@@ -69,12 +69,16 @@ adoption:
     http_status: 200
     content_sha256: bb5032889aa6e0b79acc62edb60394b16ae50d4fb0a2359bad79d155cb4d7bf2
 capability:
-  score: 4
-  basis: feature_matrix
-  value: 80 multi-turn questions across 8 categories; LLM-as-judge scoring
+  score: null
+  basis: n/a
+  value: null
   confidence: medium
-  note: The seminal multi-turn chat benchmark, and the one that pioneered LLM-as-judge scoring, though it
-    is now small and partly saturated next to harder peers.
+  note: 'A dataset is not ''capable'', so this axis is left unscored and the product is graded on adoption
+    alone. What the record otherwise recorded: 80 multi-turn questions across eight categories, scored by
+    an LLM judge. It is the seminal multi-turn chat benchmark and the one that pioneered LLM-as-judge scoring,
+    and it is now small and partly saturated next to harder peers. That is a quality caveat about the instrument
+    rather than a capability score: read as discriminative power, capability would decay as the field trains
+    on a benchmark, which makes it anti-correlated with adoption and unfit to blend with it. See #319.'
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2306.05685

--- a/sources/scores/mt-bench.yaml
+++ b/sources/scores/mt-bench.yaml
@@ -73,12 +73,17 @@ capability:
   basis: n/a
   value: null
   confidence: medium
-  note: 'A dataset is not ''capable'', so this axis is left unscored and the product is graded on adoption
-    alone. What the record otherwise recorded: 80 multi-turn questions across eight categories, scored by
-    an LLM judge. It is the seminal multi-turn chat benchmark and the one that pioneered LLM-as-judge scoring,
-    and it is now small and partly saturated next to harder peers. That is a quality caveat about the instrument
-    rather than a capability score: read as discriminative power, capability would decay as the field trains
-    on a benchmark, which makes it anti-correlated with adoption and unfit to blend with it. See #319.'
+  note: 'A dataset is not ''capable'' in the sense this axis measures elsewhere, so it is left unscored
+    and the product is graded on adoption alone. What the record previously asserted, kept as the quality
+    caveat it always was: 80 multi-turn questions across eight categories, scored by an LLM judge. It is
+    the seminal multi-turn chat benchmark and the one that pioneered LLM-as-judge scoring, and it is now
+    small and partly saturated next to harder peers. This records the absence of an agreed rubric, not a
+    claim that an evaluation set has no measurable quality. #319 proposed reading the axis as discriminative
+    power, whether a benchmark still separates frontier models, and that reading was set aside on two grounds:
+    it decays as the field trains on a benchmark, so it works against adoption in the maturity blend, and
+    the evidence assembled for it did not establish the bands it assigned. A reading built on the artifact
+    instead - coverage, grading validity, refresh cadence - would not decay and has not been worked out.
+    Until one exists this axis abstains. See #546.'
   last_verified: '2026-08-13'
   sources:
   - url: https://arxiv.org/abs/2306.05685


### PR DESCRIPTION
Closes #319, resolved in the opposite direction to the one it proposed.

## Why

#319 was right that `benchmark_eval_data` was internally inconsistent: four benchmarks carried a capability score and twenty-eight abstained, and both positions cannot be right. It proposed closing the gap by scoring the remaining twenty-three on **evaluative power** — does this benchmark still separate frontier models. A five-product calibration slice (#543) was built against that reading and then rejected.

**Capability read as discriminative power decays with use.** The more a benchmark is adopted, the more models train on it, the less it separates them. That makes capability anti-correlated with adoption — and `maturity` blends the two at equal weight, so the composite means very little and every successful benchmark trends toward 1 over time. That is not a correction to apply once. It is a treadmill that would re-score the category on a calendar and move published stage numbers with it.

The calibration slice showed it concretely: gsm8k scored **1**, which dropped the category from Stage 4 to Stage 3 on the strength of the single product whose capability had been null.

The abstaining records already had this right. They recorded saturation and contamination as a quality caveat in prose and left the axis unscored. `build/serialize.py` says the same in its own comment: capability may be legitimately null for some product types, which are graded on adoption alone.

## What changed

`livebench`, `gaia`, `humanitys-last-exam` and `mt-bench` now abstain, matching the shape `humaneval` and `mmlu` already use: `score: null`, `basis: n/a`, `value: null`.

Each note carries forward what the record previously asserted, as the quality caveat it always was:

- LiveBench's six domains, judge-free auto-scoring and monthly rotation
- GAIA's 466 tool-use questions with one checkable answer
- Humanity's Last Exam's 2,500 expert questions and private held-out set
- MT-Bench's 80 multi-turn questions and LLM-as-judge scoring

**Every source is kept.** Nothing that was read is lost, and the arXiv and lastexam.ai citations still carry their digests.

## No published number moves

`benchmark_eval_data` stays **Stage 4, Competitive Open Ecosystem, gaps `[resiliency]`** — re-derived through `_stage_and_gaps` before and after.

## Test plan

- `build.validate` — 0 errors, 2 pre-existing warnings
- `build.check_verification` — invariant / digests / producible-pairs / placeholder-shows all OK
- `build.check_capability` — OK
- `build.check_rubric` — `benchmark_eval_data` 30/30 reproduced, 2 deferred
- `build.check_recipe` — 0 failures
- `uv run pytest -q` — 1895 passed, 1 skipped, **1 failed**: `test_publish_evaluation.py::test_plan_validates_offline_and_writes_nothing`. It passes in isolation, and a sibling test in the same file failed once earlier today under different conditions. Reported rather than explained away — CI runs the suite split (`-n auto -m "not serial"`, then `-m serial`) and is the arbiter.

## Follow-ups filed

- **#546** records the methodology argument, including the artifact-based reading of capability that was *not* evaluated and is the version to argue if anyone reopens this, plus the Hugging Face contamination instrument that is now measured and has nowhere to live.
- **#547** the null-capability hole: a null both grades on adoption alone and suppresses the capability gap.

#543 stays closed and unmerged as the rejected calibration.