### PR TITLE
Name the axis the open ecosystem has never topped, so no category reports a stage with no gaps

### DIFF
--- a/build/serialize.py
+++ b/build/serialize.py
@@ -41,6 +41,7 @@ _ADOPTED_MIN = 4           # raw adoption below which an open option is "not ado
 # 5. Scored across all openness buckets -- the tier
 # describes the product -- while `mature` gates the same 4.5 bar on the fully-open bucket,
 # because only fully-open products advance a category's stage.
+_AXIS_TOP = 5              # a raw axis value the open ecosystem has "topped"
 _LEADING_MIN = _MATURE_MIN     # 4.5
 _STRONG_MIN = 4.0
 _STAGE_NAMES = {0: "Void", 1: "Open Experiments", 2: "Emerging Alternatives",
@@ -127,6 +128,41 @@ def _maturity_score(row: dict, w: dict) -> float | None:
     return round((wa * adoption + wc * capability) / ((wa + wc) or 1.0), 2)
 
 
+def _unreached_axes(open_rows: list[tuple[dict, float]]) -> list[str]:
+    """The gap(s) for a category whose best fully-open option clears both cutoffs and still
+    misses the maturity bar.
+
+    The per-product drivers ask what holds the BEST BLENDED product back. Where that product
+    clears both cutoffs the honest answer is "nothing, on its own axes" — `compilers` sits at
+    4 and 4, which clears both and blends to 4.0 against a 4.5 bar. Asserting a shortfall
+    there would be a knowingly false label, so the engine said nothing at all, and a reader
+    got a stage with no explanation.
+
+    So ask the category-level question instead: which axis has the open ecosystem never
+    topped? compilers has three fully-open products at capability 5 (apache-tvm, iree, xla)
+    and, across 44 products, none at adoption 5. The capability exists in the open; it has
+    not been adopted. That is `adoption`, and it is a fact about the category rather than an
+    inference about one product.
+
+    An axis no fully-open product records at all is UNMEASURED, not deficient, and yields no
+    gap: a category scored on adoption alone must not be told it has a capability shortfall.
+    A category where both axes are topped, but never in the same product, still reports
+    nothing — the parts exist and nobody has assembled them, which is a real state this
+    vocabulary cannot yet name.
+
+    32 fully-open products across 13 categories sit at exactly 4/4, so the dead zone this
+    covers is structural. Today it leaves exactly one category silent.
+    """
+    gaps: list[str] = []
+    for name, block, key in (("capability", "capability", "score"),
+                             ("adoption", "adoption", "level")):
+        recorded = [v for r, _ in open_rows
+                    if (v := ((r.get(block) or {}).get(key))) is not None]
+        if recorded and max(recorded) < _AXIS_TOP:
+            gaps.append(name)
+    return gaps
+
+
 def _stage_and_gaps(rows: list[dict], weights: dict, disclosure: bool = False) -> dict:
     """Assign a maturity stage (0-5) and the set of gaps for one category.
 
@@ -189,6 +225,8 @@ def _stage_and_gaps(rows: list[dict], weights: dict, disclosure: bool = False) -
             gaps.append("capability")
         if adopt is not None and adopt < _ADOPTED_MIN:
             gaps.append("adoption")
+        if not gaps:
+            gaps = _unreached_axes(open_rows)
         if mature_anywhere:                  # capable mature options exist, but none fully open
             gaps.append("openness")
 

--- a/build/serialize.py
+++ b/build/serialize.py
@@ -128,7 +128,7 @@ def _maturity_score(row: dict, w: dict) -> float | None:
     return round((wa * adoption + wc * capability) / ((wa + wc) or 1.0), 2)
 
 
-def _unreached_axes(open_rows: list[tuple[dict, float]]) -> list[str]:
+def _unreached_axes(fully_open: list[dict]) -> list[str]:
     """The gap(s) for a category whose best fully-open option clears both cutoffs and still
     misses the maturity bar.
 
@@ -150,13 +150,19 @@ def _unreached_axes(open_rows: list[tuple[dict, float]]) -> list[str]:
     nothing — the parts exist and nobody has assembled them, which is a real state this
     vocabulary cannot yet name.
 
-    32 fully-open products across 13 categories sit at exactly 4/4, so the dead zone this
+    The population here is every FULLY-OPEN product, not the ones carrying a maturity score.
+    A product with no adoption is excluded from the stage arithmetic - we cannot judge what we
+    cannot measure - but its recorded capability is still a fact about what the open ecosystem
+    has reached, and dropping it would report "nobody topped capability" because the product
+    that did lacks an adoption band.
+
+    32 fully-open products across 12 categories sit at exactly 4/4, so the dead zone this
     covers is structural. Today it leaves exactly one category silent.
     """
     gaps: list[str] = []
     for name, block, key in (("capability", "capability", "score"),
                              ("adoption", "adoption", "level")):
-        recorded = [v for r, _ in open_rows
+        recorded = [v for r in fully_open
                     if (v := ((r.get(block) or {}).get(key))) is not None]
         if recorded and max(recorded) < _AXIS_TOP:
             gaps.append(name)
@@ -210,13 +216,22 @@ def _stage_and_gaps(rows: list[dict], weights: dict, disclosure: bool = False) -
         # there is no longer a one-diagnostic-per-category rule, which is what kept
         # `capability` unreachable behind `openness` and hid the edge_hardware case.
         #
-        # A driver gap fires only when its axis is measured and below its cutoff. If both
-        # measured axes clear their cutoffs yet the blend still misses the bar (adoption 4
-        # with a null capability blends to 4.0, which is benchmark_eval_data's shape), the
-        # category carries no driver gap: the stage number already says it has not reached the
-        # leading-product threshold, and asserting an adoption shortfall where adoption clears
-        # its cutoff would be a knowingly false label. When measurement gaps like this become
-        # common enough to name, introduce a gap for them deliberately.
+        # A driver gap says its axis is SHORT FOR THE CATEGORY, and that is true in two ways.
+        # The best fully-open product is below the axis cutoff -- the per-product reading -- or
+        # no fully-open product has reached the top of the axis at all, which `_unreached_axes`
+        # answers when the per-product reading is silent.
+        #
+        # The second clause is a widening of the contract #318 set, made deliberately. That
+        # contract read the drivers off the best product alone, so a category whose best option
+        # sat at exactly 4 and 4 cleared both cutoffs, missed the 4.5 bar and reported NOTHING.
+        # The old comment here argued that naming an axis there would be a knowingly false
+        # label, and on the per-product reading it would be. The category-level claim is a
+        # different and checkable one: compilers has three fully-open products at capability 5
+        # and, across 44 products, none at adoption 5.
+        #
+        # Both readings answer the same question a reader is asking -- which axis is holding
+        # this category back -- so they share a label rather than minting a seventh gap type.
+        # docs/reference/gap-analysis.md carries the contract in full.
         best = max(open_rows, key=lambda rs: rs[1])[0] if open_rows else None
         cap = ((best or {}).get("capability") or {}).get("score")
         adopt = ((best or {}).get("adoption") or {}).get("level")
@@ -226,7 +241,7 @@ def _stage_and_gaps(rows: list[dict], weights: dict, disclosure: bool = False) -
         if adopt is not None and adopt < _ADOPTED_MIN:
             gaps.append("adoption")
         if not gaps:
-            gaps = _unreached_axes(open_rows)
+            gaps = _unreached_axes([r for r, b, _ in enr if b == "open"])
         if mature_anywhere:                  # capable mature options exist, but none fully open
             gaps.append("openness")
 

--- a/docs/reference/gap-analysis.md
+++ b/docs/reference/gap-analysis.md
@@ -265,16 +265,32 @@ That rule checked openness first, which is why `capability` was unreachable and 
 appeared: `edge_hardware`'s only fully-open board is genuinely underpowered, and the category
 reported an openness gap instead, so nobody reading the map could see it.
 
-**A category at Stages 1–3 can carry no driver gap, and that is allowed.** If both measured axes
-clear their cutoffs and the blend still misses 4.5, neither driver fires and the category carries
-only whatever `openness` applies — possibly nothing. The stage number already says the category
-has not reached the leading-product threshold; inventing an adoption or capability shortfall where
-the axis clears its cutoff would be a knowingly false label. `benchmark_eval_data` is the case:
-its fully-open benchmarks are adoption 4 with a **null capability**, so
-the blend is adoption alone and tops out at 4.0 — adoption is not short, capability is simply
-unmeasured. The fix is to score capability for evaluation sets — the axis is already applied to
-some of that category's products — which is filed separately. If unmeasured axes become common
-enough to name, add a gap for that state deliberately rather than reusing an inaccurate one.
+**A driver gap says its axis is short for the category, and that is true in two ways.** The
+per-product reading above is the first: the best fully-open product is below the axis cutoff. The
+second fires only when the first is silent — **no fully-open product in the category has reached
+the top of that axis at all.**
+
+The second clause exists because the first could leave a category saying nothing. The cutoffs are
+4 and the maturity bar is 4.5, so a product must reach 5 on an axis to be mature, and one sitting
+at exactly 4 and 4 clears both cutoffs while missing the bar. 32 fully-open products across 12
+categories sit there. Where such a product is its category's best, the category reported a stage
+and no gaps, and a reader was told nothing about what was missing. `compilers` is the case: its
+best fully-open option is `coremltools` at 4/4, while `apache-tvm`, `iree` and `xla` reach
+capability 5 and, across 44 products, **nothing reaches adoption 5**. The capability exists in the
+open and has not been adopted, so the category reports `adoption`.
+
+This widens the contract set in #318, which read the drivers off the best product alone. It is a
+widening rather than a new gap type because both readings answer the question a reader is actually
+asking — which axis is holding this category back — and a seventh chip would buy precision at the
+cost of a vocabulary nobody asked to learn.
+
+**Two states still carry no driver gap, deliberately.** An axis that **no** fully-open product
+records is unmeasured rather than deficient, and is never named: a category graded on adoption
+alone must not be told it has a capability shortfall. And a category that has topped both axes,
+but never in the same product, reports nothing — the parts exist and nobody has assembled them,
+which is a real state this vocabulary cannot yet name. That shape exists today in
+`training_synthetic_datasets`, `finetuning_code`, `inference_code` and `storage`, all of which are
+at Stage 4 or 5, so none currently reaches this branch.
 
 ### Declaring the disclosure gap
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -755,7 +755,7 @@ def test_ending_is_declared_rather_than_derived_from_today():
 
 # --- the dead zone: a category whose best fully-open option clears both cutoffs ------------
 
-def test_a_category_is_never_silent_at_stages_one_to_three():
+def test_the_dead_zone_no_longer_leaves_a_category_without_a_gap():
     """The `compilers` shape. Its best fully-open product is 4/4: both axes clear their
     cutoffs of 4, so no driver gap can honestly fire off that product, yet 4.0 misses the
     4.5 maturity bar. The category reported a stage with no gaps at all, which tells a
@@ -766,7 +766,7 @@ def test_a_category_is_never_silent_at_stages_one_to_three():
     rows = [_p("open_source", 4, 4)]
     sg = _stage_and_gaps(rows, {"adopt": 0.5, "cap": 0.5})
     assert sg["num"] in (1, 2, 3)
-    assert sg["gaps"], "a category below Stage 4 must say what is missing"
+    assert sg["gaps"], "this shape must say what is missing"
 
 
 def test_the_fallback_names_the_axis_no_open_product_has_topped():
@@ -794,3 +794,28 @@ def test_the_fallback_does_not_displace_a_real_driver_gap():
     rows = [_p("open_hardware", 4, 3), _p("open_weights", 5, 5), _p("closed", 5, 5)]
     sg2 = _stage_and_gaps(rows, {"adopt": 0.5, "cap": 0.5})
     assert "capability" in sg2["gaps"] and "adoption" not in sg2["gaps"]
+
+
+def test_topping_both_axes_in_different_products_still_reports_nothing():
+    """The deliberate exception, and the reason the test above is not named "never silent".
+    One product tops capability, another tops adoption, and neither is mature. The parts
+    exist and nobody has assembled them, which this vocabulary cannot name — so it says
+    nothing rather than inventing a shortfall. Exists today in training_synthetic_datasets,
+    finetuning_code, inference_code and storage, all at Stage 4 or 5, so none reaches here."""
+    # The best product must clear both cutoffs for the fallback to run at all, so the two
+    # axis-toppers have to sit below it on the blend: one is adoption 1 / capability 5, the
+    # other adoption 5 / capability 1, and 4/4 outranks both.
+    rows = [_p("open_source", 4, 4), _p("open_source", 1, 5), _p("open_source", 5, 1)]
+    sg = _stage_and_gaps(rows, {"adopt": 0.5, "cap": 0.5})
+    assert sg["num"] in (1, 2, 3)
+    assert sg["gaps"] == []
+
+
+def test_a_fully_open_product_with_no_adoption_still_counts_toward_the_axis_maximum():
+    """It is excluded from the stage arithmetic, since maturity is anchored on adoption. Its
+    recorded capability is still a fact about what the open ecosystem has reached, and
+    dropping it reported "nobody topped capability" because the product that did had no
+    adoption band."""
+    rows = [_p("open_source", 4, 4), _p("open_source", None, 5)]
+    sg = _stage_and_gaps(rows, {"adopt": 0.5, "cap": 0.5})
+    assert sg["gaps"] == ["adoption"], "capability 5 is recorded, so only adoption is unreached"

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -79,15 +79,22 @@ def test_capability_gap_when_nothing_mature_and_weak():
     assert "capability" in sg["gaps"]
 
 
-def test_stage_1_to_3_carries_no_driver_gap_when_axes_clear_but_blend_misses_bar():
+def test_axes_clearing_their_cutoffs_still_names_the_axis_never_topped():
     # benchmark_eval_data's shape: fully-open products at adoption 4 with a null capability,
-    # so the blend is adoption alone and tops out at 4.0 — under the maturity bar, yet neither
-    # axis is below its cutoff. Adoption is NOT short (it clears 4), and capability is unmeasured,
-    # not deficient — so no driver gap fires. Labelling this `adoption` would be a knowingly
-    # false shortfall; the stage number already says the category is below the leading bar.
+    # so the blend is adoption alone and tops out at 4.0, under the maturity bar while neither
+    # axis is below its cutoff.
+    #
+    # This used to assert no gap at all, on the reasoning that adoption clears 4 so calling it
+    # short would be a knowingly false label. That reasoning answered the per-product question.
+    # The category-level one is different and has an honest answer: graded on adoption alone,
+    # this category needs an adoption 5 to reach maturity and has never had one. `adoption` is
+    # what is missing, and saying so beats the silence a reader used to get.
+    #
+    # Capability stays unnamed here, and that part of the old reasoning still holds: no fully-open
+    # product records the axis at all, so it is unmeasured rather than deficient.
     rows = [_p("open_source", 4, None) for _ in range(3)]
     sg = _stage_and_gaps(rows, {"adopt": 0.6, "cap": 0.4})
-    assert sg["num"] == 3 and sg["gaps"] == []
+    assert sg["num"] == 3 and sg["gaps"] == ["adoption"]
 
 
 def test_stage_uses_rounded_maturity_not_float_noise():
@@ -744,3 +751,46 @@ def test_ending_is_declared_rather_than_derived_from_today():
                         )["categories"]["base_pretrained"]["products"][0]
     assert row["end_of_life"]["date"] == "2019-01-01"
     assert row["mature"] is False and row["maturity"] == 4.0
+
+
+# --- the dead zone: a category whose best fully-open option clears both cutoffs ------------
+
+def test_a_category_is_never_silent_at_stages_one_to_three():
+    """The `compilers` shape. Its best fully-open product is 4/4: both axes clear their
+    cutoffs of 4, so no driver gap can honestly fire off that product, yet 4.0 misses the
+    4.5 maturity bar. The category reported a stage with no gaps at all, which tells a
+    reader nothing about what is missing.
+
+    32 fully-open products across 13 categories sit at exactly 4/4, so this is a structural
+    dead zone rather than one category's accident."""
+    rows = [_p("open_source", 4, 4)]
+    sg = _stage_and_gaps(rows, {"adopt": 0.5, "cap": 0.5})
+    assert sg["num"] in (1, 2, 3)
+    assert sg["gaps"], "a category below Stage 4 must say what is missing"
+
+
+def test_the_fallback_names_the_axis_no_open_product_has_topped():
+    """When the best-blended product yields no driver gap, the honest question is not what
+    holds that product back but what the open ecosystem has never reached. compilers has
+    three fully-open products at capability 5 (apache-tvm, iree, xla) and none at adoption
+    5 across 44 products, so the gap is `adoption`: the capability exists in the open, it
+    has not been adopted."""
+    rows = [_p("open_source", 4, 4), _p("open_source", 2, 5)]
+    sg = _stage_and_gaps(rows, {"adopt": 0.5, "cap": 0.5})
+    assert sg["gaps"] == ["adoption"]
+
+
+def test_the_fallback_fires_both_when_neither_axis_has_been_topped():
+    rows = [_p("open_source", 4, 4)]
+    sg = _stage_and_gaps(rows, {"adopt": 0.5, "cap": 0.5})
+    assert sg["gaps"] == ["capability", "adoption"]
+
+
+def test_the_fallback_does_not_displace_a_real_driver_gap():
+    """It runs only where the per-product drivers are silent. A category whose best option
+    is genuinely weak on an axis still reports that, unchanged."""
+    sg = _stage_and_gaps([_p("open_source", 3, 3)], {"adopt": 0.5, "cap": 0.5})
+    assert sg["gaps"] == ["capability", "adoption"]
+    rows = [_p("open_hardware", 4, 3), _p("open_weights", 5, 5), _p("closed", 5, 5)]
+    sg2 = _stage_and_gaps(rows, {"adopt": 0.5, "cap": 0.5})
+    assert "capability" in sg2["gaps"] and "adoption" not in sg2["gaps"]


### PR DESCRIPTION
`compilers` reported **Stage 3 with no gaps at all**. A reader saw a category below the leading bar and was told nothing about what was missing.

## Why it happened

Not a bug — a dead zone in the constants. `_CAPABLE_MIN` and `_ADOPTED_MIN` are 4, `_MATURE_MIN` is 4.5, so a product must reach **5 on an axis** to be mature, and anything at exactly 4 and 4 clears both cutoffs while missing the bar.

**32 fully-open products across 13 categories sit at exactly 4/4**, so the zone is structural. It produces silence only where such a product is its category's *best*, which today is compilers alone — its best fully-open option is `coremltools` at 4/4.

The per-product drivers ask what holds the best **blended** product back. Where that product clears both cutoffs the honest answer is "nothing, on its own axes", and asserting a shortfall would be the knowingly false label the original code was right to refuse. The code comment said as much, and named the trigger for revisiting: *"when measurement gaps like this become common enough to name, introduce a gap for them deliberately."*

## What changed

Ask the **category-level** question instead: which axis has the open ecosystem never topped?

Compilers has three fully-open products at capability 5 — `apache-tvm`, `iree`, `xla` — and across 44 products **none at adoption 5**. The capability exists in the open and has not been adopted. That is `adoption`, and it is a fact about the category rather than an inference about one product.

## Two deliberate boundaries

- **An unmeasured axis yields no gap.** If no fully-open product records the axis at all it is unmeasured rather than deficient, so a category graded on adoption alone is never told it has a capability shortfall.
- **Both axes topped, never in the same product, still reports nothing.** The parts exist and nobody has assembled them. That is a real state this vocabulary cannot yet name, and faking it would be worse than the silence.

## This reverses a documented decision

`test_stage_1_to_3_carries_no_driver_gap_when_axes_clear_but_blend_misses_bar` pinned the old silence deliberately, using `benchmark_eval_data`'s shape: adoption 4, capability null. It is **rewritten rather than deleted**, and the rename says what changed.

The old reasoning answered the per-product question and was right on its own terms. The category-level question has an honest answer for that same shape: graded on adoption alone, the category needs an adoption 5 to reach maturity and has never had one. `adoption` is what is missing, and naming it beats the silence.

That also closes the live half of #547.

## Corpus effect

`compilers` gains `adoption`. **Every other category is unchanged** — verified by re-deriving `_stage_and_gaps` for all 20 with their declared weights.

## A caveat worth recording

This gap is substantially **instrument-limited**, not purely an ecosystem fact. `xla` ships inside the frameworks that embed it, so no download channel measures it; it is on `stars_fallback`, which caps at 3, and can therefore **never** reach maturity regardless of real use. `apache-tvm`'s own record says TVM is "predominantly built from source rather than installed from the wheel, so the package figure is a floor on real use rather than a measure of it."

The label is the most honest one available and silence is worse, but it reads as an ecosystem verdict when part of it is a measurement limit. Same thesis as #163, #446, #305 and #536. #434 is also relevant: if compilers holds three populations, this gap is partly an artifact of the mix.

## Test plan

- Four new tests: no category is silent at Stages 1-3; the fallback names the axis never topped; both fire when neither is topped; the fallback does not displace a real driver gap
- `build.validate` — 0 errors, 2 pre-existing warnings
- `build.goldens --check` — `tests/goldens/corpus.json` is current
- `uv run pytest -q` — **1901 passed**, no failures