### PR TITLE
Guard the identity coverage pin in both directions

### DIFF
--- a/build/identity_eval.py
+++ b/build/identity_eval.py
@@ -2043,7 +2043,10 @@ def main(argv: list[str] | None = None) -> int:
     # here forever. The pytest gate requires every route in the committed file; the scoring
     # path refuses the same shape so the weekly run cannot report green on a route it never
     # checked. A missing file (no ratchet at all, an older tree) is still the lenient case.
-    unpinned = [route for route, _label in ORG_ROUTE_LABELS if route not in baseline] if baseline else []
+    unpinned = (
+        [route for route, _label in ORG_ROUTE_LABELS if route not in baseline]
+        if COVERAGE_BASELINE_PATH.exists() else []  # the FILE decides, not the dict: `{}` is a file with every pin deleted
+    )
     if unpinned:
         print(
             f"[FAIL] {_repo_path(COVERAGE_BASELINE_PATH)} pins no value for {', '.join(unpinned)}; "

--- a/build/identity_eval.py
+++ b/build/identity_eval.py
@@ -1135,11 +1135,15 @@ def coverage_lowered(
 
     A route's pin may go down only with a `lowered_because` that is new or changed in this
     PR; one inherited verbatim from the merge base explained an earlier lowering and excuses
-    nothing now. A pin that vanished (the route was in `before`, not in `current`) is a
-    lowering to nothing, and so is a pin rewritten to `0/0` (see `_pin_lowered`). A fresh
-    `lowered_because` with no route lowered is stale and is reported too: an explanation
-    that explains nothing is how a guard rots.
+    nothing now. A pin rewritten to `0/0` is a lowering (see `_pin_lowered`). A pin that
+    VANISHED (the route was in `before`, not in `current`) is not a lowering that a note can
+    excuse: an unpinned route is skipped by both live-coverage gates, so an explained deletion
+    would switch the ratchet off for that route and every later PR would inherit the silence.
+    Lower it, to `0/0` if need be, and keep the key. A fresh `lowered_because` with no route
+    lowered is stale and is reported too: an explanation that explains nothing is how a guard
+    rots.
     """
+    vanished: list[str] = []
     lowered: list[str] = []
     for route, _label in ORG_ROUTE_LABELS:
         prior = before.get(route)
@@ -1147,10 +1151,19 @@ def coverage_lowered(
             continue
         now = current.get(route)
         if now is None:
-            lowered.append(f"{route}: pinned {prior[0]}/{prior[1]} at the merge base, unpinned now")
+            vanished.append(
+                f"{route}: pinned {prior[0]}/{prior[1]} at the merge base, unpinned now -- a route "
+                f"may be lowered with a {LOWERED_BECAUSE_KEY!r}, never unpinned; pin it (0/0 if need be)"
+            )
         elif _pin_lowered(now, prior):
             lowered.append(f"{route}: pin lowered from {prior[0]}/{prior[1]} to {now[0]}/{now[1]}")
     fresh_note = lowered_because is not None and lowered_because != before_lowered_because
+    if vanished:
+        needs_note = lowered and not fresh_note
+        return vanished + lowered + (
+            [f"a pin may only go down with a {LOWERED_BECAUSE_KEY!r} written or changed in this PR"]
+            if needs_note else []
+        )
     if lowered and not fresh_note:
         return lowered + [
             f"a pin may only go down with a {LOWERED_BECAUSE_KEY!r} written or changed in this PR"

--- a/build/identity_eval.py
+++ b/build/identity_eval.py
@@ -1113,6 +1113,18 @@ def coverage_stale(
     return failures
 
 
+def _pin_lowered(now: tuple[int, int], prior: tuple[int, int]) -> bool:
+    """Is the pin `now` strictly below the pin `prior`? Cross-multiplied like
+    `_below_baseline`, but this compares two PINS, not live coverage to a pin, so a
+    denominator of 0 on either side is read as the ratio 0 it pins rather than as "no orgs
+    to cover". Without that, rewriting 211/328 to 0/0 would pass vacuously, and a re-pin
+    after every eligible org was removed could erase positive coverage unexplained.
+    """
+    now_n, now_d = now if now[1] else (0, 1)
+    prior_n, prior_d = prior if prior[1] else (0, 1)
+    return now_n * prior_d < prior_n * now_d
+
+
 def coverage_lowered(
     current: dict[str, tuple[int, int]],
     before: dict[str, tuple[int, int]],
@@ -1124,8 +1136,9 @@ def coverage_lowered(
     A route's pin may go down only with a `lowered_because` that is new or changed in this
     PR; one inherited verbatim from the merge base explained an earlier lowering and excuses
     nothing now. A pin that vanished (the route was in `before`, not in `current`) is a
-    lowering to nothing. A fresh `lowered_because` with no route lowered is stale and is
-    reported too: an explanation that explains nothing is how a guard rots.
+    lowering to nothing, and so is a pin rewritten to `0/0` (see `_pin_lowered`). A fresh
+    `lowered_because` with no route lowered is stale and is reported too: an explanation
+    that explains nothing is how a guard rots.
     """
     lowered: list[str] = []
     for route, _label in ORG_ROUTE_LABELS:
@@ -1135,7 +1148,7 @@ def coverage_lowered(
         now = current.get(route)
         if now is None:
             lowered.append(f"{route}: pinned {prior[0]}/{prior[1]} at the merge base, unpinned now")
-        elif _below_baseline(now, prior):
+        elif _pin_lowered(now, prior):
             lowered.append(f"{route}: pin lowered from {prior[0]}/{prior[1]} to {now[0]}/{now[1]}")
     fresh_note = lowered_because is not None and lowered_because != before_lowered_because
     if lowered and not fresh_note:

--- a/build/identity_eval.py
+++ b/build/identity_eval.py
@@ -2038,6 +2038,18 @@ def main(argv: list[str] | None = None) -> int:
     except CoverageBaselineInvalid as exc:
         print(f"[FAIL] {exc}")
         return 2
+    # A baseline file that pins some routes and not others is not a partial ratchet, it is a
+    # switched-off one: both live gates skip an unpinned route, so a deleted pin would pass
+    # here forever. The pytest gate requires every route in the committed file; the scoring
+    # path refuses the same shape so the weekly run cannot report green on a route it never
+    # checked. A missing file (no ratchet at all, an older tree) is still the lenient case.
+    unpinned = [route for route, _label in ORG_ROUTE_LABELS if route not in baseline] if baseline else []
+    if unpinned:
+        print(
+            f"[FAIL] {_repo_path(COVERAGE_BASELINE_PATH)} pins no value for {', '.join(unpinned)}; "
+            f"every route must be pinned (0/0 if need be) or the ratchet is off for it"
+        )
+        return 2
     print("")
     for line in coverage_lines(coverage, baseline):
         print(line)

--- a/build/identity_eval.py
+++ b/build/identity_eval.py
@@ -176,8 +176,33 @@ falls BELOW its pinned ratio. So coverage can only go up. `--write-coverage-base
 rewrites that file from the live corpus; it is a deliberate act in its own commit, never
 something a failing run does for itself, or the ratchet would ratchet nothing.
 
+A ratchet that only fails downward has two holes, and the pin is guarded on both sides:
+
+- **The pin cannot be quietly lowered** (#493). `tests/test_identity_eval.py` reads the
+  file as of `git merge-base HEAD origin/main` (`merge_base_coverage_baseline`) and
+  `coverage_lowered` fails any route whose pinned ratio went down unless the file carries a
+  `lowered_because` string that is new or changed in the same PR. A `lowered_because` that
+  is new but excuses nothing is reported as stale; one inherited unchanged from the merge
+  base excuses nothing either, so it cannot rot into a standing permission. When the
+  merge-base copy cannot be read the test says so in its output rather than passing: it
+  fails under `GITHUB_ACTIONS` (a checkout that cannot see `origin/main` is a CI bug) and
+  skips with the reason elsewhere (a clone with no remote has nothing to compare against).
+  The scoring path does not run this check: it needs git history, and the weekly run sits
+  on `main` where the merge base is HEAD itself.
+- **The pin cannot fall far behind reality** (#506). `coverage_stale` fails any route whose
+  live ratio exceeds its pin by more than `COVERAGE_MARGIN_POINTS` percentage points, and
+  tells the author to re-pin with `--write-coverage-baseline` in the same PR. It runs in
+  both places: as a test over the live corpus, because the PR that earns the gain is the
+  one that must re-pin (and PR CI is the only run that fires on every PR), and on the
+  scoring path, so the weekly report reads the same status vocabulary. The margin is in
+  percentage points because the ratchet itself compares ratios: a single handle is 0.3
+  points on `github` (350 orgs) and 2 on `homepage_domain` (50 orgs), so a zero margin would
+  fail every single-handle PR on the small route, while the 79-point gap #506 found clears
+  any sane margin. Five points is roughly a dozen `github` handles or three `homepage_domain`
+  ones -- a batch, not a typo.
+
 A route whose denominator falls to 0 passes vacuously -- there are no orgs on it to cover.
-The comparison is by cross-multiplication rather than float division, so a pinned ratio is
+Every comparison is by cross-multiplication rather than float division, so a pinned ratio is
 never re-derived at a different precision than it was written at.
 
 **The invariant is scored only under `--from-warehouse`.** A fixture is a snapshot of what the
@@ -299,6 +324,7 @@ from __future__ import annotations
 import argparse
 import itertools
 import json
+import subprocess
 import sys
 from collections import Counter
 from collections.abc import Iterable
@@ -463,6 +489,15 @@ ORG_ROUTE_ARTIFACTS: dict[str, str] = {
 # It sits under `tests/fixtures/` with the eval's other committed inputs rather than in
 # `sources/`: it is a gate's reference value, not a declaration about any product.
 COVERAGE_BASELINE_PATH = ROOT / "tests" / "fixtures" / "identity_coverage_baseline.json"
+
+# How far, in percentage points, live coverage on a route may sit ABOVE its pin before the
+# pin is stale and must be re-pinned in the same PR. Zero would fail every single-handle gain
+# on the smallest route (one org in 50 is 2 points); the gap #506 found was 79 points.
+COVERAGE_MARGIN_POINTS = 5
+
+# The one non-route key the baseline file accepts: a non-empty string saying why a route's
+# pin was lowered on purpose. It excuses a lowering only in the PR that writes or changes it.
+LOWERED_BECAUSE_KEY = "lowered_because"
 
 # Eight storage-category products whose same- or near-same-named PyPI package is a verified
 # client library, not the product's own countable artifact -- read from each product's
@@ -873,51 +908,122 @@ class CoverageBaselineInvalid(RuntimeError):
     """
 
 
+def _parse_coverage_baseline(
+    text: str, where: str
+) -> tuple[dict[str, tuple[int, int]], str | None]:
+    """Parse one baseline document: `(route -> (with_handle, rostered), lowered_because)`.
+
+    `where` names the document in every message -- a path for the working tree, a
+    `<merge-base>:<path>` spec for the copy read out of git.
+    """
+    try:
+        doc = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise CoverageBaselineInvalid(f"{where} is not valid JSON: {exc}") from exc
+    if not isinstance(doc, dict):
+        raise CoverageBaselineInvalid(f"{where} must be an object of route -> [with_handle, rostered]")
+    routes = set(ORG_ROUTES.values())
+    out: dict[str, tuple[int, int]] = {}
+    lowered_because: str | None = None
+    for route, pair in doc.items():
+        if route == LOWERED_BECAUSE_KEY:
+            if not (isinstance(pair, str) and pair.strip()):
+                raise CoverageBaselineInvalid(
+                    f"{where}: {LOWERED_BECAUSE_KEY!r} must be a non-empty string saying why a "
+                    f"route's pin went down, got {pair!r}"
+                )
+            lowered_because = pair
+            continue
+        if route not in routes:
+            raise CoverageBaselineInvalid(
+                f"{where} names route {route!r}, which is not one of {sorted(routes)}"
+            )
+        if not (isinstance(pair, (list, tuple)) and len(pair) == 2):
+            raise CoverageBaselineInvalid(f"{where}: {route!r} must be [with_handle, rostered], got {pair!r}")
+        with_handle, rostered = pair
+        if not (isinstance(with_handle, int) and isinstance(rostered, int)):
+            raise CoverageBaselineInvalid(f"{where}: {route!r} must be two integers, got {pair!r}")
+        if with_handle < 0 or rostered < 0 or with_handle > rostered:
+            raise CoverageBaselineInvalid(
+                f"{where}: {route!r} = {pair!r} is not a coverage ratio (0 <= with_handle <= rostered)"
+            )
+        out[route] = (with_handle, rostered)
+    return out, lowered_because
+
+
 def load_coverage_baseline(path: Path = COVERAGE_BASELINE_PATH) -> dict[str, tuple[int, int]]:
     """The pinned per-route coverage, `route -> (with_handle, rostered)`.
 
     A missing file reads as `{}` -- an older tree that predates the ratchet has nothing to
     ratchet against, and that is not a failure. A file that EXISTS but is malformed raises:
-    the whole point of the ratchet is that it cannot be defeated by accident.
+    the whole point of the ratchet is that it cannot be defeated by accident. The only key
+    that is not a route is `lowered_because` (see `load_lowered_because`).
     """
     if not path.exists():
         return {}
+    routes, _note = _parse_coverage_baseline(path.read_text(), str(path))
+    return routes
+
+
+def load_lowered_because(path: Path = COVERAGE_BASELINE_PATH) -> str | None:
+    """The file's `lowered_because` explanation, or None when it carries none (or is absent)."""
+    if not path.exists():
+        return None
+    _routes, note = _parse_coverage_baseline(path.read_text(), str(path))
+    return note
+
+
+def merge_base_coverage_baseline(
+    base: str = "origin/main", rel: str = "tests/fixtures/identity_coverage_baseline.json"
+) -> tuple[dict[str, tuple[int, int]] | None, str | None, str]:
+    """The baseline as of the merge base with `base`: `(routes, lowered_because, where)`.
+
+    `where` names what was read, `<merge-base sha>:<rel>`, so a message can say which two
+    copies were compared. When the copy cannot be read, `routes` is None and `where` carries
+    git's own words for why -- unlike `build.assets.merge_base_assets`, which returns a bare
+    None for a caller that may skip, this caller must PRINT that it could not compare (#493).
+    A copy that exists but is malformed raises `CoverageBaselineInvalid`.
+    """
     try:
-        doc = json.loads(path.read_text())
-    except json.JSONDecodeError as exc:
-        raise CoverageBaselineInvalid(f"{path} is not valid JSON: {exc}") from exc
-    if not isinstance(doc, dict):
-        raise CoverageBaselineInvalid(f"{path} must be an object of route -> [with_handle, rostered]")
-    routes = set(ORG_ROUTES.values())
-    out: dict[str, tuple[int, int]] = {}
-    for route, pair in doc.items():
-        if route not in routes:
-            raise CoverageBaselineInvalid(
-                f"{path} names route {route!r}, which is not one of {sorted(routes)}"
-            )
-        if not (isinstance(pair, (list, tuple)) and len(pair) == 2):
-            raise CoverageBaselineInvalid(f"{path}: {route!r} must be [with_handle, rostered], got {pair!r}")
-        with_handle, rostered = pair
-        if not (isinstance(with_handle, int) and isinstance(rostered, int)):
-            raise CoverageBaselineInvalid(f"{path}: {route!r} must be two integers, got {pair!r}")
-        if with_handle < 0 or rostered < 0 or with_handle > rostered:
-            raise CoverageBaselineInvalid(
-                f"{path}: {route!r} = {pair!r} is not a coverage ratio (0 <= with_handle <= rostered)"
-            )
-        out[route] = (with_handle, rostered)
-    return out
+        merge_base = subprocess.run(
+            ["git", "-C", str(ROOT), "merge-base", "HEAD", base],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        return None, None, (
+            f"`git merge-base HEAD {base}` failed: {exc.stderr.strip() or exc.stdout.strip() or exc}"
+        )
+    spec = f"{merge_base}:{rel}"
+    try:
+        blob = subprocess.run(
+            ["git", "-C", str(ROOT), "show", spec],
+            capture_output=True, text=True, check=True,
+        ).stdout
+    except subprocess.CalledProcessError as exc:
+        return None, None, f"`git show {spec}` failed: {exc.stderr.strip() or exc}"
+    routes, note = _parse_coverage_baseline(blob, spec)
+    return routes, note, spec
 
 
 def write_coverage_baseline(
-    coverage: dict[str, tuple[int, int]], path: Path = COVERAGE_BASELINE_PATH
+    coverage: dict[str, tuple[int, int]],
+    path: Path = COVERAGE_BASELINE_PATH,
+    lowered_because: str | None = None,
 ) -> dict[str, tuple[int, int]]:
     """Pin `coverage` as the new baseline, in `ORG_ROUTE_LABELS` order. Returns what it wrote.
 
-    Only `--write-coverage-baseline` calls this; nothing on the scoring path does.
+    Only `--write-coverage-baseline` calls this; nothing on the scoring path does. A
+    `lowered_because` already in the file is NOT carried forward: it explained a previous
+    lowering, and carrying it would let it excuse this one too. Pass the explanation for this
+    write explicitly (`--lowered-because`), or the file goes out without one.
     """
-    doc = {route: list(coverage.get(route, (0, 0))) for route, _label in ORG_ROUTE_LABELS}
+    if lowered_because is not None and not lowered_because.strip():
+        raise ValueError("lowered_because must be a non-empty string when given")
+    doc: dict = {route: list(coverage.get(route, (0, 0))) for route, _label in ORG_ROUTE_LABELS}
+    if lowered_because is not None:
+        doc[LOWERED_BECAUSE_KEY] = lowered_because
     path.write_text(json.dumps(doc, indent=2) + "\n")
-    return {route: tuple(pair) for route, pair in doc.items()}  # type: ignore[misc]
+    return {route: (pair[0], pair[1]) for route, pair in doc.items() if route != LOWERED_BECAUSE_KEY}
 
 
 def _below_baseline(live: tuple[int, int], pinned: tuple[int, int]) -> bool:
@@ -955,8 +1061,100 @@ def coverage_ratchet(
     return failures
 
 
+def _points_above(live: tuple[int, int], pinned: tuple[int, int]) -> float:
+    """`live`'s ratio minus `pinned`'s, in percentage points; for messages only -- the
+    decision is made by `_above_baseline_by_more_than`, in integers."""
+    live_n, live_d = live
+    base_n, base_d = pinned
+    live_r = live_n / live_d if live_d else 0.0
+    base_r = base_n / base_d if base_d else 0.0
+    return 100 * (live_r - base_r)
+
+
+def _above_baseline_by_more_than(
+    live: tuple[int, int], pinned: tuple[int, int], margin_points: int
+) -> bool:
+    """Is `live`'s ratio more than `margin_points` percentage points above `pinned`'s?
+    Cross-multiplied like `_below_baseline`, so the margin is applied to exact ratios.
+
+    A live denominator of 0 has no coverage to overstate and passes. A pinned denominator of
+    0 pins a ratio of 0 (as `_below_baseline` reads it), so a route that has since gained
+    orgs with handles is stale like any other.
+    """
+    live_n, live_d = live
+    base_n, base_d = pinned
+    if live_d == 0:
+        return False
+    if base_d == 0:
+        base_n, base_d = 0, 1
+    return 100 * (live_n * base_d - base_n * live_d) > margin_points * live_d * base_d
+
+
+def coverage_stale(
+    coverage: dict[str, tuple[int, int]],
+    baseline: dict[str, tuple[int, int]],
+    margin_points: int = COVERAGE_MARGIN_POINTS,
+) -> list[str]:
+    """Routes whose live coverage sits more than `margin_points` above the pin, one message
+    each. The pin is stale on those routes and must be re-pinned in the PR that raised them
+    (#506). Unpinned routes are not checked, as in `coverage_ratchet`.
+    """
+    failures: list[str] = []
+    for route, _label in ORG_ROUTE_LABELS:
+        pinned = baseline.get(route)
+        if pinned is None:
+            continue
+        live = coverage.get(route, (0, 0))
+        if _above_baseline_by_more_than(live, pinned, margin_points):
+            failures.append(
+                f"{route}: coverage {live[0]}/{live[1]} is {_points_above(live, pinned):.1f} points "
+                f"above the pinned {pinned[0]}/{pinned[1]} (margin {margin_points})"
+            )
+    return failures
+
+
+def coverage_lowered(
+    current: dict[str, tuple[int, int]],
+    before: dict[str, tuple[int, int]],
+    lowered_because: str | None,
+    before_lowered_because: str | None = None,
+) -> list[str]:
+    """Why the committed baseline is not an honest successor to the merge-base copy (#493).
+
+    A route's pin may go down only with a `lowered_because` that is new or changed in this
+    PR; one inherited verbatim from the merge base explained an earlier lowering and excuses
+    nothing now. A pin that vanished (the route was in `before`, not in `current`) is a
+    lowering to nothing. A fresh `lowered_because` with no route lowered is stale and is
+    reported too: an explanation that explains nothing is how a guard rots.
+    """
+    lowered: list[str] = []
+    for route, _label in ORG_ROUTE_LABELS:
+        prior = before.get(route)
+        if prior is None:
+            continue
+        now = current.get(route)
+        if now is None:
+            lowered.append(f"{route}: pinned {prior[0]}/{prior[1]} at the merge base, unpinned now")
+        elif _below_baseline(now, prior):
+            lowered.append(f"{route}: pin lowered from {prior[0]}/{prior[1]} to {now[0]}/{now[1]}")
+    fresh_note = lowered_because is not None and lowered_because != before_lowered_because
+    if lowered and not fresh_note:
+        return lowered + [
+            f"a pin may only go down with a {LOWERED_BECAUSE_KEY!r} written or changed in this PR"
+            + (" (the one in the file is inherited from the merge base)" if lowered_because else "")
+        ]
+    if fresh_note and not lowered:
+        return [
+            f"{LOWERED_BECAUSE_KEY!r} is set ({lowered_because!r}) but no route's pin is lower than "
+            f"at the merge base; delete the explanation, it excuses nothing"
+        ]
+    return []
+
+
 def coverage_lines(
-    coverage: dict[str, tuple[int, int]], baseline: dict[str, tuple[int, int]]
+    coverage: dict[str, tuple[int, int]],
+    baseline: dict[str, tuple[int, int]],
+    margin_points: int = COVERAGE_MARGIN_POINTS,
 ) -> list[str]:
     """The three `handle coverage` lines, one per route, each with its ratchet status."""
     lines = [
@@ -969,6 +1167,8 @@ def coverage_lines(
             status = "no baseline"
         elif _below_baseline((live_n, live_d), pinned):
             status = f"BELOW BASELINE {pinned[0]}/{pinned[1]}"
+        elif _above_baseline_by_more_than((live_n, live_d), pinned, margin_points):
+            status = f"STALE BASELINE {pinned[0]}/{pinned[1]} (more than {margin_points} points below live)"
         else:
             status = f"at or above baseline {pinned[0]}/{pinned[1]}"
         lines.append(
@@ -1686,6 +1886,14 @@ def main(argv: list[str] | None = None) -> int:
             f"rewrites its own baseline."
         ),
     )
+    parser.add_argument(
+        "--lowered-because", metavar="TEXT",
+        help=(
+            f"with --write-coverage-baseline: why a route's pin is going DOWN. Written into the "
+            f"file as {LOWERED_BECAUSE_KEY!r}; the PR test that compares the file to its merge-base "
+            f"copy fails a lowering without one. A previous explanation is never carried forward."
+        ),
+    )
     source.add_argument(
         "--write-fixture", type=Path, metavar="PATH",
         help=(
@@ -1713,12 +1921,24 @@ def main(argv: list[str] | None = None) -> int:
         print("[FAIL] --allow-unprovisioned only applies to --from-warehouse")
         return 2
 
+    if args.lowered_because is not None and not args.write_coverage_baseline:
+        parser.error("--lowered-because only means something with --write-coverage-baseline")
     if args.write_coverage_baseline:
         # Explicit path, not the bound default -- see the `--allow-unprovisioned` block below
         # for the same reason: a default parameter is bound once at definition time, so a test
         # that monkeypatches the module-level path would otherwise be ignored.
-        pinned = write_coverage_baseline(org_handle_coverage(load_truth()), COVERAGE_BASELINE_PATH)
+        prior_note = load_lowered_because(COVERAGE_BASELINE_PATH)
+        pinned = write_coverage_baseline(
+            org_handle_coverage(load_truth()), COVERAGE_BASELINE_PATH, args.lowered_because
+        )
         print(f"{_repo_path(COVERAGE_BASELINE_PATH)}: pinned handle coverage")
+        if prior_note is not None and args.lowered_because is None:
+            print(
+                f"  dropped the previous {LOWERED_BECAUSE_KEY!r} ({prior_note!r}): it explained an "
+                f"earlier lowering, not this write"
+            )
+        if args.lowered_because is not None:
+            print(f"  {LOWERED_BECAUSE_KEY}: {args.lowered_because}")
         for route, label in ORG_ROUTE_LABELS:
             n, d = pinned[route]
             print(f"  {label:18s} {n}/{d}")
@@ -1811,6 +2031,19 @@ def main(argv: list[str] | None = None) -> int:
             f"  shrank) -- re-pin it on purpose with `uv run python -m build.identity_eval\n"
             f"  --write-coverage-baseline` in its own commit, saying why. Nothing rewrites\n"
             f"  {_repo_path(COVERAGE_BASELINE_PATH)} automatically."
+        )
+        exit_code = 1
+
+    # The other direction (#506): a pin the corpus has outrun is a gate that guards nothing.
+    stale = coverage_stale(coverage, baseline)
+    if stale:
+        print(f"\n[FAIL] handle coverage has outrun its pinned baseline by more than {COVERAGE_MARGIN_POINTS} points:")
+        for line in stale:
+            print(f"  {line}")
+        print(
+            f"\n  The PR that raises coverage re-pins it. Run `uv run python -m build.identity_eval\n"
+            f"  --write-coverage-baseline` and commit {_repo_path(COVERAGE_BASELINE_PATH)} in the\n"
+            f"  same PR, in its own commit, so the gate keeps guarding what the corpus actually has."
         )
         exit_code = 1
 

--- a/tests/fixtures/identity_coverage_baseline.json
+++ b/tests/fixtures/identity_coverage_baseline.json
@@ -1,11 +1,11 @@
 {
   "github": [
-    211,
-    328
+    237,
+    350
   ],
   "huggingface": [
-    51,
-    81
+    72,
+    103
   ],
   "homepage_domain": [
     7,

--- a/tests/test_identity_eval.py
+++ b/tests/test_identity_eval.py
@@ -1308,9 +1308,18 @@ def test_coverage_lines_flag_a_stale_pin():
     assert "STALE BASELINE 1/300" in lines[1]
 
 
+def _pinned_at_live(**overrides):
+    """A complete baseline (every route pinned at its live corpus value, so the scoring path's
+    completeness check passes) with the routes under test overridden."""
+    live = org_handle_coverage(REAL_TRUTH)
+    doc = {route: list(live[route]) for route in ORG_ROUTES.values()}
+    doc.update({k: list(v) for k, v in overrides.items()})
+    return doc
+
+
 def test_main_exits_one_when_the_corpus_has_outrun_the_pin(tmp_path, monkeypatch, capsys):
     baseline = tmp_path / "baseline.json"
-    baseline.write_text(json.dumps({"github": [0, 400]}))
+    baseline.write_text(json.dumps(_pinned_at_live(github=(0, 400))))
     monkeypatch.setattr(identity_eval_module, "COVERAGE_BASELINE_PATH", baseline)
     fixture = tmp_path / "edges.json"
     fixture.write_text('{"equivalence": []}')
@@ -1319,7 +1328,7 @@ def test_main_exits_one_when_the_corpus_has_outrun_the_pin(tmp_path, monkeypatch
     assert "[FAIL] handle coverage has outrun its pinned baseline" in out
     assert "above the pinned 0/400" in out
     assert "--write-coverage-baseline" in out and "same PR" in out
-    assert json.loads(baseline.read_text()) == {"github": [0, 400]}  # never rewritten by a run
+    assert json.loads(baseline.read_text()) == _pinned_at_live(github=(0, 400))  # never rewritten by a run
 
 
 def test_load_coverage_baseline_accepts_lowered_because_and_only_that():
@@ -1423,7 +1432,7 @@ def test_main_exits_one_when_a_route_falls_below_its_baseline(tmp_path, monkeypa
     """The ratchet holds without `--floors`: it is a fact about the corpus, not a judgment
     about the graph."""
     baseline = tmp_path / "baseline.json"
-    baseline.write_text(json.dumps({"github": [299, 299]}))
+    baseline.write_text(json.dumps(_pinned_at_live(github=(299, 299))))
     monkeypatch.setattr(identity_eval_module, "COVERAGE_BASELINE_PATH", baseline)
     fixture = tmp_path / "edges.json"
     fixture.write_text('{"equivalence": []}')
@@ -1438,7 +1447,7 @@ def test_main_exits_zero_at_the_baseline(tmp_path, monkeypatch, capsys):
     """Pinned at exactly the live ratio: neither below the pin nor far enough above it."""
     live_n, live_d = org_handle_coverage(REAL_TRUTH)["github"]
     baseline = tmp_path / "baseline.json"
-    baseline.write_text(json.dumps({"github": [live_n, live_d]}))
+    baseline.write_text(json.dumps(_pinned_at_live()))
     monkeypatch.setattr(identity_eval_module, "COVERAGE_BASELINE_PATH", baseline)
     fixture = tmp_path / "edges.json"
     fixture.write_text('{"equivalence": []}')
@@ -1468,7 +1477,7 @@ def test_the_write_coverage_baseline_flag_pins_and_scores_nothing(tmp_path, monk
 def test_the_baseline_is_never_rewritten_by_a_scoring_run(tmp_path, monkeypatch):
     """A ratchet that raises its own reference value on failure ratchets nothing."""
     baseline = tmp_path / "baseline.json"
-    pinned = {"github": [299, 299]}
+    pinned = _pinned_at_live(github=(299, 299))
     baseline.write_text(json.dumps(pinned))
     monkeypatch.setattr(identity_eval_module, "COVERAGE_BASELINE_PATH", baseline)
     fixture = tmp_path / "edges.json"

--- a/tests/test_identity_eval.py
+++ b/tests/test_identity_eval.py
@@ -1240,6 +1240,22 @@ def test_coverage_lowered_treats_a_vanished_pin_as_lowered():
     assert findings[0] == "github: pinned 2/4 at the merge base, unpinned now"
 
 
+def test_coverage_lowered_reads_a_zero_denominator_pin_as_zero():
+    # Regression: 211/328 -> 0/0 used to pass vacuously because the live-coverage comparator
+    # treats an empty denominator as "no orgs to cover". A pin is not live coverage.
+    before = {"github": (211, 328)}
+    findings = coverage_lowered({"github": (0, 0)}, before, None)
+    assert findings[0] == "github: pin lowered from 211/328 to 0/0"
+    assert len(findings) == 2
+    assert coverage_lowered({"github": (0, 0)}, before, "every eligible org was removed") == []
+    # a zero pin at the merge base is ratio 0: nothing goes below it, and 0/0 -> 0/0 is unchanged
+    assert coverage_lowered({"github": (0, 0)}, {"github": (0, 0)}, None) == []
+    assert coverage_lowered({"github": (0, 5)}, {"github": (0, 0)}, None) == []
+    assert coverage_lowered({"github": (3, 5)}, {"github": (0, 0)}, None) == []
+    # 0/0 -> positive with a fresh note is a stale note, same as any other non-lowering
+    assert coverage_lowered({"github": (3, 5)}, {"github": (0, 0)}, "why", None)
+
+
 def test_coverage_lowered_compares_ratios_and_passes_a_raise():
     before = {"github": (2, 4)}
     assert coverage_lowered({"github": (1, 2)}, before, None) == []  # same ratio

--- a/tests/test_identity_eval.py
+++ b/tests/test_identity_eval.py
@@ -1235,9 +1235,18 @@ def test_a_fresh_explanation_with_nothing_lowered_is_stale():
     assert coverage_lowered({"github": (3, 4)}, before, "old reason", "old reason") == []
 
 
-def test_coverage_lowered_treats_a_vanished_pin_as_lowered():
-    findings = coverage_lowered({}, {"github": (2, 4)}, None)
-    assert findings[0] == "github: pinned 2/4 at the merge base, unpinned now"
+def test_coverage_lowered_never_excuses_a_vanished_pin():
+    """Deleting a route's pin would switch both live gates off for that route, and every later
+    PR would inherit the silence because the merge-base pin is then already absent. So a
+    vanished pin fails with or without a fresh explanation; the remedy is to pin it, to 0/0
+    if need be, and explain the lowering."""
+    without = coverage_lowered({}, {"github": (2, 4)}, None)
+    assert without[0].startswith("github: pinned 2/4 at the merge base, unpinned now")
+    assert "never unpinned" in without[0]
+    with_fresh_note = coverage_lowered({}, {"github": (2, 4)}, "route retired", None)
+    assert with_fresh_note == without
+    # Pinning it to 0/0 with a fresh explanation is the sanctioned path.
+    assert coverage_lowered({"github": (0, 0)}, {"github": (2, 4)}, "route retired", None) == []
 
 
 def test_coverage_lowered_reads_a_zero_denominator_pin_as_zero():

--- a/tests/test_identity_eval.py
+++ b/tests/test_identity_eval.py
@@ -1499,6 +1499,20 @@ def test_a_malformed_baseline_raises_rather_than_defaulting_to_empty(tmp_path, b
         load_coverage_baseline(path)
 
 
+def test_a_baseline_missing_a_route_exits_two_from_main(tmp_path, monkeypatch, capsys):
+    """The scoring path refuses a baseline that pins some routes and not others: both live
+    gates skip an unpinned route, so a deleted pin would otherwise pass the weekly run forever.
+    A missing FILE stays lenient (no ratchet at all); a file with a hole does not."""
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text('{"github": [1, 2]}')
+    monkeypatch.setattr(identity_eval_module, "COVERAGE_BASELINE_PATH", baseline)
+    fixture = tmp_path / "edges.json"
+    fixture.write_text('{"equivalence": []}')
+    assert main(["--edges", str(fixture)]) == 2
+    out = capsys.readouterr().out
+    assert "pins no value for huggingface, homepage_domain" in out
+
+
 def test_a_malformed_baseline_exits_two_from_main(tmp_path, monkeypatch, capsys):
     baseline = tmp_path / "baseline.json"
     baseline.write_text('{"gitlab": [1, 2]}')

--- a/tests/test_identity_eval.py
+++ b/tests/test_identity_eval.py
@@ -1520,6 +1520,12 @@ def test_a_baseline_missing_a_route_exits_two_from_main(tmp_path, monkeypatch, c
     assert main(["--edges", str(fixture)]) == 2
     out = capsys.readouterr().out
     assert "pins no value for huggingface, homepage_domain" in out
+    # A file with every pin deleted is the same hole, not the lenient missing-file case.
+    baseline.write_text("{}")
+    assert main(["--edges", str(fixture)]) == 2
+    assert "pins no value for github, huggingface, homepage_domain" in capsys.readouterr().out
+    baseline.write_text('{"lowered_because": "all gone"}')
+    assert main(["--edges", str(fixture)]) == 2
 
 
 def test_a_malformed_baseline_exits_two_from_main(tmp_path, monkeypatch, capsys):

--- a/tests/test_identity_eval.py
+++ b/tests/test_identity_eval.py
@@ -13,6 +13,9 @@ the F2 tests stub `build.warehouse.query` directly rather than hitting a real en
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -23,6 +26,8 @@ import build.warehouse as warehouse_module
 from build.identity import fold_for_proposal
 from build.identity_eval import (
     COVERAGE_BASELINE_PATH,
+    COVERAGE_MARGIN_POINTS,
+    LOWERED_BECAUSE_KEY,
     FLOORS,
     KNOWN_NEGATIVES,
     MIN_TRUTH,
@@ -40,9 +45,12 @@ from build.identity_eval import (
     _identity_dataset_deployed,
     _is_table_not_found,
     _membership_from_ledger,
+    _repo_path,
     candidate_key,
     coverage_lines,
+    coverage_lowered,
     coverage_ratchet,
+    coverage_stale,
     digest_items,
     emits,
     emitted_at_threshold,
@@ -52,6 +60,8 @@ from build.identity_eval import (
     invariant_failures,
     load_coverage_baseline,
     load_edges_from_warehouse,
+    load_lowered_because,
+    merge_base_coverage_baseline,
     load_truth,
     main,
     org_handle_coverage,
@@ -1108,6 +1118,234 @@ def test_the_live_corpus_is_at_or_above_the_committed_baseline():
     assert coverage_ratchet(coverage, load_coverage_baseline(COVERAGE_BASELINE_PATH)) == []
 
 
+def test_the_live_corpus_is_within_the_margin_above_the_committed_baseline():
+    """The other direction (#506): the PR that raises coverage by more than the margin is the
+    PR that re-pins it, so the gate never sits far below reality until a person notices."""
+    coverage = org_handle_coverage(REAL_TRUTH)
+    stale = coverage_stale(coverage, load_coverage_baseline(COVERAGE_BASELINE_PATH))
+    assert stale == [], (
+        "the pin is stale:\n  " + "\n  ".join(stale)
+        + "\nre-pin with `uv run python -m build.identity_eval --write-coverage-baseline` in "
+        "this PR, in its own commit"
+    )
+
+
+def _lowering_check_or_explain(
+    before: tuple[dict | None, str | None, str], in_ci: bool
+) -> list[str]:
+    """The merge-base half of the lowering gate (#493). Returns `coverage_lowered`'s
+    findings; when the merge-base copy cannot be read it does not pass: it fails in CI (the
+    checkout should always see origin/main, and a merge-base it cannot see is a CI bug) and
+    skips with the reason elsewhere. Either way the output names both sides."""
+    before_routes, before_note, where = before
+    committed = _repo_path(COVERAGE_BASELINE_PATH)
+    if before_routes is None:
+        message = (
+            f"cannot compare the committed {committed} to its merge-base copy: {where}. "
+            f"Nothing was checked for a lowered pin."
+        )
+        if in_ci:
+            pytest.fail(message)
+        pytest.skip(message)
+    return coverage_lowered(
+        load_coverage_baseline(COVERAGE_BASELINE_PATH),
+        before_routes,
+        load_lowered_because(COVERAGE_BASELINE_PATH),
+        before_note,
+    )
+
+
+def test_the_committed_baseline_was_not_lowered_against_the_merge_base():
+    """The real gate: HEAD's pin against `git show <merge-base HEAD origin/main>:<file>`."""
+    findings = _lowering_check_or_explain(
+        merge_base_coverage_baseline(), in_ci=bool(os.environ.get("GITHUB_ACTIONS"))
+    )
+    assert findings == [], (
+        f"{_repo_path(COVERAGE_BASELINE_PATH)} against its merge-base copy:\n  "
+        + "\n  ".join(findings)
+    )
+
+
+def test_an_unreadable_merge_base_copy_is_said_out_loud_not_passed():
+    """Synthetic: the None branch must not read as 'nothing lowered'."""
+    unreadable = (None, None, "`git merge-base HEAD origin/main` failed: fatal: Not a valid object name origin/main")
+    with pytest.raises(pytest.fail.Exception) as ci:
+        _lowering_check_or_explain(unreadable, in_ci=True)
+    assert "cannot compare the committed tests/fixtures/identity_coverage_baseline.json" in str(ci.value)
+    assert "Not a valid object name origin/main" in str(ci.value)
+    with pytest.raises(pytest.skip.Exception) as local:
+        _lowering_check_or_explain(unreadable, in_ci=False)
+    assert "Nothing was checked for a lowered pin" in str(local.value)
+
+
+def test_merge_base_coverage_baseline_names_git_when_the_base_is_unresolvable():
+    routes, note, where = merge_base_coverage_baseline(base="no-such-ref-anywhere")
+    assert routes is None and note is None
+    assert "git merge-base HEAD no-such-ref-anywhere" in where
+
+
+def test_merge_base_coverage_baseline_reads_head_when_head_is_the_base():
+    """Against HEAD itself the merge base is HEAD, so the copy read out of git is the
+    committed file byte for byte -- the one case exercisable in any clone."""
+    routes, note, where = merge_base_coverage_baseline(base="HEAD")
+    committed = json.loads(subprocess.run(
+        ["git", "-C", str(COVERAGE_BASELINE_PATH.parents[2]), "show",
+         "HEAD:tests/fixtures/identity_coverage_baseline.json"],
+        capture_output=True, text=True, check=True,
+    ).stdout)
+    assert routes == {r: tuple(v) for r, v in committed.items() if r != LOWERED_BECAUSE_KEY}
+    assert note == committed.get(LOWERED_BECAUSE_KEY)
+    assert where.endswith(":tests/fixtures/identity_coverage_baseline.json")
+
+
+def test_merge_base_coverage_baseline_says_when_the_file_is_absent_at_the_base():
+    routes, _note, where = merge_base_coverage_baseline(base="HEAD", rel="tests/fixtures/no_such_file.json")
+    assert routes is None
+    assert "git show" in where and "no_such_file.json" in where
+
+
+def test_coverage_lowered_fails_a_lowered_pin_without_an_explanation():
+    before = {"github": (2, 4), "huggingface": (1, 10)}
+    now = {"github": (1, 4), "huggingface": (1, 10)}
+    findings = coverage_lowered(now, before, None)
+    assert findings[0] == "github: pin lowered from 2/4 to 1/4"
+    assert LOWERED_BECAUSE_KEY in findings[1]
+
+
+def test_coverage_lowered_is_excused_by_a_fresh_explanation():
+    before = {"github": (2, 4)}
+    assert coverage_lowered({"github": (1, 4)}, before, "an org file was removed", None) == []
+    # changed from the merge-base note counts as fresh too
+    assert coverage_lowered({"github": (1, 4)}, before, "second lowering", "first lowering") == []
+
+
+def test_an_inherited_explanation_excuses_nothing():
+    """The note that excused the last lowering must not become a standing permission."""
+    before = {"github": (2, 4)}
+    findings = coverage_lowered({"github": (1, 4)}, before, "old reason", "old reason")
+    assert findings[0] == "github: pin lowered from 2/4 to 1/4"
+    assert "inherited from the merge base" in findings[1]
+
+
+def test_a_fresh_explanation_with_nothing_lowered_is_stale():
+    before = {"github": (2, 4)}
+    findings = coverage_lowered({"github": (3, 4)}, before, "nothing happened", None)
+    assert len(findings) == 1 and "excuses nothing" in findings[0]
+    # inherited and inert: not this PR's problem
+    assert coverage_lowered({"github": (3, 4)}, before, "old reason", "old reason") == []
+
+
+def test_coverage_lowered_treats_a_vanished_pin_as_lowered():
+    findings = coverage_lowered({}, {"github": (2, 4)}, None)
+    assert findings[0] == "github: pinned 2/4 at the merge base, unpinned now"
+
+
+def test_coverage_lowered_compares_ratios_and_passes_a_raise():
+    before = {"github": (2, 4)}
+    assert coverage_lowered({"github": (1, 2)}, before, None) == []  # same ratio
+    assert coverage_lowered({"github": (3, 4)}, before, None) == []
+    assert coverage_lowered({"github": (3, 4), "huggingface": (1, 1)}, before, None) == []  # new route
+
+
+def test_coverage_stale_passes_within_the_margin_and_fails_beyond_it():
+    baseline = {"github": (200, 400)}  # 50.0%
+    assert coverage_stale({"github": (220, 400)}, baseline, 5) == []  # exactly +5.0 points passes
+    assert coverage_stale({"github": (221, 400)}, baseline, 5) == [
+        "github: coverage 221/400 is 5.2 points above the pinned 200/400 (margin 5)"
+    ]
+    assert coverage_stale({"github": (190, 400)}, baseline, 5) == []  # below is the other gate's job
+
+
+def test_coverage_stale_uses_the_module_margin_by_default():
+    baseline = {"github": (0, 100)}
+    assert coverage_stale({"github": (COVERAGE_MARGIN_POINTS, 100)}, baseline) == []
+    assert coverage_stale({"github": (COVERAGE_MARGIN_POINTS + 1, 100)}, baseline) != []
+
+
+def test_coverage_stale_is_a_ratio_not_a_count():
+    """Ten more handles on a route that also gained ten orgs is no change in coverage."""
+    assert coverage_stale({"github": (210, 420)}, {"github": (200, 400)}, 0) == []
+
+
+def test_coverage_stale_passes_an_empty_live_denominator_and_fails_an_outgrown_zero_pin():
+    assert coverage_stale({"github": (0, 0)}, {"github": (2, 4)}, 5) == []
+    # pinned 0/0 reads as ratio 0 (as `_below_baseline` reads it); 50/50 has outgrown it
+    assert coverage_stale({"github": (50, 50)}, {"github": (0, 0)}, 5) != []
+    assert coverage_stale({"github": (2, 50)}, {"github": (0, 0)}, 5) == []
+
+
+def test_coverage_stale_skips_unpinned_routes():
+    assert coverage_stale({"github": (300, 300)}, {}) == []
+
+
+def test_coverage_lines_flag_a_stale_pin():
+    lines = coverage_lines({"github": (300, 300)}, {"github": (1, 300)})
+    assert "STALE BASELINE 1/300" in lines[1]
+
+
+def test_main_exits_one_when_the_corpus_has_outrun_the_pin(tmp_path, monkeypatch, capsys):
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({"github": [0, 400]}))
+    monkeypatch.setattr(identity_eval_module, "COVERAGE_BASELINE_PATH", baseline)
+    fixture = tmp_path / "edges.json"
+    fixture.write_text('{"equivalence": []}')
+    assert main(["--edges", str(fixture)]) == 1
+    out = capsys.readouterr().out
+    assert "[FAIL] handle coverage has outrun its pinned baseline" in out
+    assert "above the pinned 0/400" in out
+    assert "--write-coverage-baseline" in out and "same PR" in out
+    assert json.loads(baseline.read_text()) == {"github": [0, 400]}  # never rewritten by a run
+
+
+def test_load_coverage_baseline_accepts_lowered_because_and_only_that():
+    good = {"github": [1, 2], LOWERED_BECAUSE_KEY: "an org file was removed"}
+    assert load_coverage_baseline(_write(good)) == {"github": (1, 2)}
+    assert load_lowered_because(_write(good)) == "an org file was removed"
+    assert load_lowered_because(_write({"github": [1, 2]})) is None
+    for bad in ({"github": [1, 2], LOWERED_BECAUSE_KEY: ""}, {"github": [1, 2], LOWERED_BECAUSE_KEY: 3},
+                {"github": [1, 2], LOWERED_BECAUSE_KEY: "   "}, {"github": [1, 2], "raised_because": "x"}):
+        with pytest.raises(CoverageBaselineInvalid):
+            load_coverage_baseline(_write(bad))
+
+
+def _write(doc: dict) -> Path:
+    path = Path(tempfile.mkdtemp()) / "baseline.json"
+    path.write_text(json.dumps(doc))
+    return path
+
+
+def test_write_coverage_baseline_drops_a_previous_explanation_and_writes_a_given_one(tmp_path):
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({"github": [1, 1], LOWERED_BECAUSE_KEY: "an earlier lowering"}))
+    write_coverage_baseline({"github": (1, 2)}, baseline)
+    assert LOWERED_BECAUSE_KEY not in json.loads(baseline.read_text())  # never carried forward
+    written = write_coverage_baseline({"github": (1, 2)}, baseline, lowered_because="removed acme")
+    assert written == {route: (1, 2) if route == "github" else (0, 0) for route in ORG_ROUTES.values()}
+    assert json.loads(baseline.read_text())[LOWERED_BECAUSE_KEY] == "removed acme"
+    assert load_lowered_because(baseline) == "removed acme"
+    with pytest.raises(ValueError):
+        write_coverage_baseline({"github": (1, 2)}, baseline, lowered_because="  ")
+
+
+def test_the_write_flag_reports_a_dropped_explanation_and_writes_a_given_one(tmp_path, monkeypatch, capsys):
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({"github": [0, 1], LOWERED_BECAUSE_KEY: "stale reason"}))
+    monkeypatch.setattr(identity_eval_module, "COVERAGE_BASELINE_PATH", baseline)
+    assert main(["--write-coverage-baseline"]) == 0
+    out = capsys.readouterr().out
+    assert "dropped the previous 'lowered_because' ('stale reason')" in out
+    assert load_lowered_because(baseline) is None
+    assert main(["--write-coverage-baseline", "--lowered-because", "acme left the roster"]) == 0
+    assert load_lowered_because(baseline) == "acme left the roster"
+
+
+def test_lowered_because_without_the_write_flag_is_refused(tmp_path):
+    fixture = tmp_path / "edges.json"
+    fixture.write_text('{"equivalence": []}')
+    with pytest.raises(SystemExit):
+        main(["--edges", str(fixture), "--lowered-because", "x"])
+
+
 def test_coverage_ratchet_passes_at_the_baseline_and_above_it():
     baseline = {"github": (2, 4), "huggingface": (1, 10), "homepage_domain": (0, 0)}
     assert coverage_ratchet(baseline, baseline) == []
@@ -1172,13 +1410,15 @@ def test_main_exits_one_when_a_route_falls_below_its_baseline(tmp_path, monkeypa
 
 
 def test_main_exits_zero_at_the_baseline(tmp_path, monkeypatch, capsys):
+    """Pinned at exactly the live ratio: neither below the pin nor far enough above it."""
+    live_n, live_d = org_handle_coverage(REAL_TRUTH)["github"]
     baseline = tmp_path / "baseline.json"
-    baseline.write_text(json.dumps({"github": [0, 299]}))
+    baseline.write_text(json.dumps({"github": [live_n, live_d]}))
     monkeypatch.setattr(identity_eval_module, "COVERAGE_BASELINE_PATH", baseline)
     fixture = tmp_path / "edges.json"
     fixture.write_text('{"equivalence": []}')
     assert main(["--edges", str(fixture)]) == 0
-    assert "at or above baseline 0/299" in capsys.readouterr().out
+    assert f"at or above baseline {live_n}/{live_d}" in capsys.readouterr().out
 
 
 def test_write_coverage_baseline_rewrites_the_file_from_the_corpus(tmp_path):


### PR DESCRIPTION
## Summary

`tests/fixtures/identity_coverage_baseline.json` only ever failed when live coverage fell below the pin. This closes both holes #493 and #506 describe with one comparison over one file.

- **Lowering (#493).** A test reads the baseline as of the merge base with `origin/main` (`git show <sha>:tests/fixtures/identity_coverage_baseline.json`) and fails when any route's pinned ratio went down, or a pinned route vanished, unless the file carries a `lowered_because` that is new or changed in the same PR. An inherited note excuses nothing, and a fresh note with no route lowered is reported as stale. A pin rewritten to `0/0` counts as a lowering (a pin is a written claim of ratio 0, unlike a live route with no orgs). A pin that vanishes is never excusable: an unpinned route is skipped by both live gates, so an explained deletion would switch the ratchet off for that route and every later PR would inherit the silence. The committed file must pin every route (an existing test), the weekly scoring run exits 2 on a baseline file that pins fewer than every route, `{}` included (only a missing file is the lenient no-ratchet case), and the remedy is to pin to `0/0` with a note. When the merge-base copy cannot be read, the test prints git's own words and the path it tried: a hard fail under `GITHUB_ACTIONS`, a visible skip elsewhere.
- **Slack (#506).** Live coverage more than `COVERAGE_MARGIN_POINTS` (5 percentage points) above the pin fails, in both the pytest gate and the weekly `identity_eval` run, with a message telling the author to re-pin with `--write-coverage-baseline` in the same PR. Five points is about a dozen GitHub handles or three homepage ones, so a single-handle PR passes and a #498-sized gap (79 points) cannot.
- **`lowered_because`** is the only non-route key `load_coverage_baseline` accepts; it must be a non-empty string. `--write-coverage-baseline` drops any prior note and says so; `--lowered-because` writes a new one.
- **The re-pin.** The new gate fired on its own PR: live coverage was already above the pin on two routes. Re-pinned in its own commit, after the code commit, so the history reads as "gate found it, fix follows".

| route | pinned before | live now |
|---|---|---|
| github | 211/328 | 237/350 |
| huggingface | 51/81 | 72/103 |
| homepage_domain | 7/50 | 7/50 |

Closes #493. Closes #506.

## Test plan

- `uv run pytest -q` passes on the branch
- `uv run python -m build.validate` reports 0 errors
- New tests cover: lowering without a note fails, with a fresh note passes, inherited note is inert, stale note fails, vanished route is a lowering, `0/0` pin is a lowering, margin boundary at exactly +5.0 passes and above fails, unreadable merge base prints the reason
- Codex reviewed round 1 and found one hole (the `0/0` pin); round 2 fixed it. The loop's reviewer step could not read round 2 out of the build clone, so a second Codex pass was run by hand on the PR: it confirmed the `0/0` fix and found the vanished-pin case, closed in the third and fourth commits on both the pytest gate and the scoring path, and re-checked. Known limit, accepted: note freshness is string inequality against the merge base, so a reworded old reason counts as fresh; the code does not judge the explanation's substance.
