### PR TITLE
Ask board questions only of boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Removed, Fixed, Security), one line, newest first, in plain past tense, with the
 
 ### Added
 
+- A `form_factor` dimension on the hardware openness ladder — board, module or chipset — recorded on
+  all 20 `edge_hardware` products, with every rung that reads `schematics` now testing it first and a
+  chipset rung that asks instead whether the datasheets are public and whether anybody can buy one.
+  `rockchip-rk3588` is no longer deferred and reproduces the 3/documented it already recorded; no
+  other score moved ([#219](https://github.com/currentai-org/os-ai-map/issues/219)).
 - `embeddings_retrieval`, a published category of 35 products — models whose headline output is a
   vector or a relevance score rather than a chat completion. Extends the shared `pretrained`
   openness ladder, the first reuse of it outside `base_pretrained`; capability is anchored on

--- a/docs/reference/openness.md
+++ b/docs/reference/openness.md
@@ -50,8 +50,11 @@ Three caveats, because "a formula exists" is easy to over-read:
   facts.
 - **A category can hold products back.** `scoring_recipe.deferred` lists products the rules do
   not decide, usually because a dimension is not recorded in a form the ladder can read. As of
-  2026-08-18 there are 5 such products across 4 categories (`benchmark_eval_data` 2, and
-  `dataset_processing_tools`, `edge_hardware` and `training_synthetic_datasets` 1 each). The
+  2026-09-12 there are 4 such products across 3 categories (`benchmark_eval_data` 2, and
+  `dataset_processing_tools` and `training_synthetic_datasets` 1 each). `edge_hardware`'s came
+  off that day: `rockchip-rk3588` was blocked on being asked a board question, and #219 gave the
+  hardware ladder a `form_factor` dimension so it asks a chipset about its datasheets and whether
+  anybody can buy one instead. The
   compilers and storage promotions each added one and then closed it the same day: `liger-kernel`
   and `pgvector` recorded `BSD-2-Clause` and the PostgreSQL License, which the shared `osi` tier
   covers by definition and had never been asked to name. Down
@@ -369,6 +372,32 @@ it to 3/documented without any new evidence about the HAT. A frozen number would
 accessory reading more open than the system it completes. That is why `accessory_host` now has a
 rung for each host class the corpus has seen, `open_toolchain` and `documented`, and none for
 `open_hardware`, which no accessory has met.
+
+### A board question asked of a chipset answers about the wrong artifact
+
+The same lesson one kind of product over, ruled on 2026-09-08 and landed in #219.
+
+`edge_hardware` holds boards, modules and bare chipsets, and five of the ladder's eight rungs turn
+on `schematics` — were the board design files published, and may they be reused. A chipset has no
+board, so it records nothing there, correctly, and the ladder abstained. `rockchip-rk3588` sat
+deferred for a month on a question it could not be asked.
+
+`form_factor` (`board` / `module` / `chipset`) is recorded on all 20 products and decides which
+questions apply before any of them are asked. A chipset takes a rung of its own, testing whether
+its datasheets are public and whether anybody can buy one — which is what `documented` means in
+this category, "datasheets public + buyable, but no design files of its own". A module keeps the
+design rungs, because `schematics: none` on an M.2 card means withheld, which is an answer; on a
+chipset it means there was never a board.
+
+Two details are worth carrying forward. **Rung order is not a guard.** First match wins, so
+putting the chipset rung above the design rungs does not keep a chipset off them — a chipset that
+fails its own rung meets a board's next, and scores 3 on a reference design that is not its own.
+Every design rung tests `board_design` as its first condition instead. **And `board_design` is a
+derived dimension**: `reads: [form_factor]`, with `board` and `module` both aliased onto `exists`
+and `chipset` onto `none`, because a rung matches one value exactly and "board or module" needs a
+name of its own. `availability` does the same over `retail`, collapsing `open_market` and
+`distributor` onto `buyable`. Both use the `reads:`/`value_aliases:` pair described above — the
+first use of it to give a ladder its own vocabulary rather than to absorb a contributor's.
 
 ### The toolchain gates the ceiling, the design sets it
 

--- a/sources/categories/edge_hardware.yaml
+++ b/sources/categories/edge_hardware.yaml
@@ -22,9 +22,27 @@ scoring_recipe:
     71% of them were prose sentences, where every other category was curated against
     controlled tokens, and check_rubric reads a token. The normalization preserved each
     original phrase in a parenthetical and moved no score. Where a product recorded nothing
-    for a dimension, nothing was written: `rockchip-rk3588` is deferred rather than given an
-    inferred `schematics` value, which is the honest way to surface that the ladder asks a
+    for a dimension, nothing was written: `rockchip-rk3588` was deferred rather than given an
+    inferred `schematics` value, which was the honest way to surface that the ladder asks a
     board question of a bare chipset.
+
+    That deferral closed on 2026-09-12 (#219). Every product now records a `form_factor` -
+    board, module or chipset - and every rung that reads `schematics` tests it first, so a
+    chipset is scored on what a chipset can be open about and is never offered a question
+    about design files it was never going to have. Eleven boards, six modules and three
+    chipsets. The chipset rung asks two things, because `documented` means two things in this
+    category: datasheets public AND buyable. All three chipsets answer both and all three land
+    on the same 3/documented they already recorded, two of them by a different route than
+    before, and no other score moved. `rockchip-rk3588` gained a `retail` component in the
+    same change - it had never recorded one, and the rung that scores it asks - established by
+    a module partner selling a system-on-module built on the part.
+
+    A module keeps climbing the design rungs on purpose: `schematics: none` on an M.2 card
+    means withheld, which is an answer, where on a chipset it means there was never a board.
+    And a chipset that fails its own rung falls off the ladder rather than down to the board
+    rungs. That is deliberate and it is tested - tests/test_hardware_form_factor.py replays
+    fact sets no product records, because every product on today's roster answers its own
+    questions and the category would reproduce 20/20 either way.
 
     The other two deferrals were real disagreements between the ladder and a recorded score,
     and the owner ruled on both on 2026-08-12. `arduino-uno-q` moved 3 to 5, matching
@@ -39,20 +57,6 @@ scoring_recipe:
     ranked weaker evidence higher.
 
   extends: hardware
-  deferred:
-    rockchip-rk3588:
-      because: >-
-        Records nothing about board design files, and correctly: it is an application-processor
-        SoC, not a board, so `schematics` - the dimension every rung turns on - has no answer
-        rather than a negative one. Recording `none` would conflate "not applicable" with
-        "withheld", and would be inferring evidence from the product description rather than
-        transcribing what the openness axis records. The other four chip-class products all
-        record a schematics clause of their own and so are scored normally; this one does not,
-        which means the line between scored and deferred for a chipset currently falls wherever
-        a curator happened to write something in that field. The owner ruled on 2026-08-12 not
-        to score it and to raise the taxonomy change instead: a `form_factor` key distinguishing
-        board / module / chipset would let the ladder ask the right question of each. That is
-        issue #219, and this deferral stands until it lands.
 products:
 - raspberry-pi-5
 - raspberry-pi-ai-hat-plus

--- a/sources/rubrics/hardware.yaml
+++ b/sources/rubrics/hardware.yaml
@@ -236,7 +236,7 @@ openness:
       machine_signal: none - a listing on a distributor site is checkable in principle,
         but absence of a listing does not establish restriction
     availability:
-      question: Can anybody go and buy one today?
+      question: Can this part be obtained commercially today, in the form it is sold in?
       # `retail` in the vocabulary the chipset rung needs, by the same mechanism and for the
       # same reason as `board_design`: two of the four recorded spellings mean the part is on
       # sale, and a rung matches one value at a time.
@@ -266,10 +266,17 @@ openness:
         restricted: gated
         discontinued: gated
       evidence:
-      - '`buyable`: on sale to anyone, whether off a shelf (`open_market`) or through a
-        distributor or module partner (`distributor`). `ti-am67a` is ACTIVE and orderable from
-        TI, `nxp-imx-8m-plus` reaches buyers through DigiKey and Toradex, and
-        `rockchip-rk3588` through the module and board partners who build on it'
+      - '`buyable`: the silicon can be obtained commercially today, in the form it is sold in.
+        For a board that means the board is on sale; for a chipset it means the part reaches
+        buyers, and the channel that does that is module and board partners rather than a reel
+        of chips - that IS the retail channel for application-processor silicon, not a proxy for
+        one. The question is deliberately about obtaining the part, not about a bare-part
+        purchase: requiring a cut-tape listing would mark almost every SoC in the category
+        ungated-and-unbuyable, which is the less true answer. So a partner listing is evidence
+        FOR this claim rather than an inference about a different artifact, and the note on each
+        record says which channel was read. `ti-am67a` is ACTIVE with an order path on TI''s own
+        product page; `nxp-imx-8m-plus` and `rockchip-rk3588` reach buyers through the module
+        partners who build on them. Ruled 2026-09-12'
       - '`gated`: nobody can buy one, either because the part is behind an NDA or a design win
         (`restricted`, which nothing on the roster records) or because it has been withdrawn
         (`discontinued`, which is `google-coral-dev-board`)'

--- a/sources/rubrics/hardware.yaml
+++ b/sources/rubrics/hardware.yaml
@@ -21,9 +21,89 @@
 # certified, which is the closest thing hardware has to OSI approval, and that is what keeps
 # `open_hardware` in the `open` bucket honest - see docs/reference/openness.md.
 #
-# Verified against edge_hardware, 18/20.
+# Verified against edge_hardware. Run `build.check_rubric` for the reproduction figure rather
+# than reading one typed here - the figure that used to sit on this line, 18/20, was two
+# corrections out of date by the time anybody read it.
 openness:
   dimensions:
+    form_factor:
+      question: Is the thing being scored a board, a module, or a bare chipset?
+      # WHICH QUESTIONS APPLY, asked before any of them are.
+      #
+      # Every dimension below this one was written for a board, and `schematics` - the
+      # dimension five of the eight rungs turn on - asks whether the board design files were
+      # published. The roster holds three kinds of thing, and asking that of the other two
+      # answers about the wrong artifact. `rockchip-rk3588` is the case and it cost a
+      # deferral: an application-processor SoC records nothing under `schematics`, correctly,
+      # because there was never a board whose design could have been withheld, and the ladder
+      # could not tell that from a board whose designer published nothing. It abstained, and
+      # the category deferred it for a month. The owner ruled on 2026-09-08 that the
+      # distinction is a dimension rather than a special case. Issue #219.
+      #
+      # The line between the three is what the vendor SELLS, not what is inside it. Every
+      # board on the roster carries a chipset and several carry a module; the question is
+      # which of them the buyer receives.
+      values: [board, module, chipset]
+      evidence:
+      - '`board`: a finished PCB sold ready to power on, whose design somebody could have
+        published. Eleven of the twenty, `raspberry-pi-5` through `sipeed-maixcam`.
+        `raspberry-pi-ai-hat-plus` is one too: a HAT is an add-on rather than a host, but it
+        is still a board, and the HAT+ specification it publishes is a board specification.
+        Which host it completes is a separate question, answered by `accessory_host`'
+      - '`module`: a part sold to be carried by somebody else''s board - an M.2 or mPCIe
+        card, a SO-DIMM, a SoM. `nvidia-jetson-orin-nx` is a 260-pin SO-DIMM and `hailo-8`
+        an M.2 Key B+M card; both have a design their vendor could have released and did
+        not. So `schematics: none` on a module means withheld, which is a real answer to the
+        board question, and a module climbs the board rungs unchanged'
+      - '`chipset`: the silicon itself, sold to be designed onto a board that does not exist
+        yet. `rockchip-rk3588`, `ti-am67a` and `nxp-imx-8m-plus` are application processors.
+        `schematics` has no answer here rather than a negative one, and the clauses two of
+        them do record - `partial (reference designs)`, `none (EVK reference designs only)` -
+        are describing an evaluation kit the vendor sells separately, not the part being
+        scored. Those clauses are left as recorded; the chipset rung simply no longer reads
+        them'
+      machine_signal: none, and unusually there is nothing a fetcher could go and look at.
+        No feed, registry or distributor catalogue carries a product-class field; the vendor
+        says it in prose on its own page - "M.2 Key B+M", "260-pin SO-DIMM connector",
+        "applications processor family" - and a human reads the sentence. The nearest thing
+        to a route is a distributor's category tree, which is a taxonomy of what a shop
+        stocks rather than of what a part is
+    board_design:
+      question: Is there a board design of the product being scored, for the design
+        questions below to be about?
+      # The same fact as `form_factor`, in the vocabulary the design rungs need, and the
+      # guard that keeps them off a chipset. A board and a module both have a design
+      # somebody could have published; a chipset does not. Every one of the five rungs
+      # that turn on `schematics` asks this first, so a chipset is never scored by a
+      # question about design files it was never going to have.
+      #
+      # Rung order alone does not do that job, however much it looks as though it does.
+      # First match wins, so a chipset that falls past its own rung meets a board's next:
+      # put the chipset rung on top and leave the design rungs open, and a part whose
+      # datasheets are gated still collects 3/documented from somebody's reference-board
+      # files - a design that is not its own, read by a rung that never asked whose it was.
+      # The routing has to be a condition on the rung, not a position in the list.
+      #
+      # It is a second dimension rather than a condition on `form_factor` because a rung
+      # matches one value exactly - `check_rubric.matches` is equality, deliberately - so
+      # "board or module" needs a name of its own. `reads` plus `value_aliases` is the
+      # mechanism the ladders already use for exactly this, software.yaml reading
+      # `self-host` as `core_gated` and translating its spellings. Nothing new is recorded
+      # for it: it is the `form_factor` every product already carries, read one level up.
+      reads: [form_factor]
+      values: [exists, none]
+      value_aliases:
+        board: exists
+        module: exists
+        chipset: none
+      evidence:
+      - '`exists`: a board or a module, seventeen of the twenty. There is a design of the
+        product being sold, so whether it was published is a fair question and `schematics`
+        is asked'
+      - '`none`: a chipset. There is no board to have designed, so `schematics` has no
+        answer rather than a negative one, and the design rungs are not offered to it'
+      machine_signal: none, and it inherits that from `form_factor` rather than lacking a
+        route of its own - it is the same fact, read in the design rungs' terms
     schematics:
       question: Are the board design files published, and may they be reused?
       # THE deciding dimension. Every board rung turns on it, which is not an accident:
@@ -52,7 +132,9 @@ openness:
         `raspberry-pi-5` publishes a mechanical drawing and two STEP files, which is what a
         HAT or a case is designed against, and no schematic of the Pi itself'
       - '`none`: no design files. For an accelerator module that means withheld; for a bare
-        chipset it means there is no board to have designed. See the note on form factor'
+        chipset it means there is no board to have designed. That distinction now has
+        somewhere to live: `board_design` is tested by every rung below that reads this one,
+        so a chipset is never asked the question and a module still is'
       machine_signal: none - needs a human to find a design-file repo and read its license.
         OSHWA maintains a certification directory that a fetcher could check, which would
         settle the top rung but not the three below it
@@ -68,11 +150,15 @@ openness:
         never that the compiler is in it, which is exactly the open/partial distinction
     datasheets:
       question: Are the part's datasheets public, or behind an NDA?
-      # Declared and tested by no rung. Every product in the category publishes at least a
-      # product brief, so a rung on this would either be unsatisfiable or fire for all 20.
-      # It stays declared because it is recorded evidence, because it is half of what the
-      # `restricted` tier will turn on the first time an NDA-only part joins the roster, and
-      # because dropping it would make 17 products report vocabulary drift.
+      # Tested by exactly one rung, and only for a chipset. It used to be tested by none, on
+      # the reasoning that every product here publishes at least a product brief so a rung on
+      # it would either be unsatisfiable or fire for all 20 - true of a roster read as one
+      # population, and the thing `form_factor` splits. For a chipset this is one of the two
+      # openness questions the corpus can answer - `availability` is the other - because the
+      # design questions have no subject; for a board it is a caveat beside a design file,
+      # which is why no board rung reads it.
+      # It remains half of what the `restricted` tier will turn on the first time an NDA-only
+      # part joins the roster.
       values: [public, brief, nda]
       machine_signal: none - a vendor page either links a datasheet or it does not, but
         telling a full datasheet from a marketing brief needs a human
@@ -131,24 +217,82 @@ openness:
       machine_signal: none - needs a human to identify the host and read its score
     retail:
       question: Can anyone buy one?
-      # Declared, tested by no rung. Two products record nothing here and the rest split
-      # between open_market and distributor, neither of which any rung distinguishes. It is
-      # the other half of the future `restricted` tier: an NDA/design-win part is one nobody
+      # Read by the chipset rung, through `availability` below, which collapses the two
+      # buyable spellings into the one value a rung can match. No board rung reads it: for a
+      # board `schematics` carries the answer, and availability is a caveat beside it.
+      # `beagley-ai` is the only product recording nothing here, and it is a board.
+      # It is also half of the future `restricted` tier: an NDA/design-win part is one nobody
       # can buy AND whose docs nobody can read.
       # `discontinued` added 2026-08-14 for google-coral-dev-board, which no reachable
       # source describes as buyable: Seeed marks both variants Discontinued and out of
       # stock, coral.ai/products/dev-board 302s to a page naming no hardware and linking
       # no purchase route. None of open_market/distributor/restricted fits - `restricted`
       # means gated by NDA or design win, which is a part somebody CAN buy under terms,
-      # and a withdrawn part is a different fact about a different question. Score-neutral:
-      # no rung reads `retail`.
+      # and a withdrawn part is a different fact about a different question. Score-neutral when
+      # it landed, because no rung read `retail` at all then. It still is: the only rung that
+      # reads it now is the chipset one, `google-coral-dev-board` is a board, and the question
+      # `availability` asks of the two spellings is the same either way - nobody can buy one.
       values: [open_market, distributor, restricted, discontinued]
       machine_signal: none - a listing on a distributor site is checkable in principle,
         but absence of a listing does not establish restriction
+    availability:
+      question: Can anybody go and buy one today?
+      # `retail` in the vocabulary the chipset rung needs, by the same mechanism and for the
+      # same reason as `board_design`: two of the four recorded spellings mean the part is on
+      # sale, and a rung matches one value at a time.
+      #
+      # It is half of what `documented` means. The category defines the class as "datasheets
+      # public + buyable, but no design files of its own", and until #219 no rung tested
+      # either half - `schematics` carried the whole answer and the rest was inferred from it.
+      # For a board that is harmless. For a chipset there is no design to read, so both halves
+      # have to be asked or the rung is handing out `documented` on one fact, and a part
+      # nobody can buy would collect the word `buyable` on the strength of a PDF.
+      #
+      # No board rung asks it, and that is a choice with a cost worth naming: a module nobody
+      # could buy would still score on its design files alone. Adding the condition to the
+      # design rungs would move a recorded score - `google-coral-dev-board` records
+      # `discontinued` and is recorded at 3/documented - and re-scoring a board is a curation
+      # ruling rather than a side effect of giving the chipset a rung. #219 changed no score
+      # on purpose. Worth its own issue.
+      #
+      # `gated` covers two different reasons a part is not on sale - behind an NDA or a design
+      # win, or withdrawn - and this rung treats them alike because all it asks is whether
+      # anybody can buy one. The reasons stay apart in `retail`, which still records which.
+      reads: [retail]
+      values: [buyable, gated]
+      value_aliases:
+        open_market: buyable
+        distributor: buyable
+        restricted: gated
+        discontinued: gated
+      evidence:
+      - '`buyable`: on sale to anyone, whether off a shelf (`open_market`) or through a
+        distributor or module partner (`distributor`). `ti-am67a` is ACTIVE and orderable from
+        TI, `nxp-imx-8m-plus` reaches buyers through DigiKey and Toradex, and
+        `rockchip-rk3588` through the module and board partners who build on it'
+      - '`gated`: nobody can buy one, either because the part is behind an NDA or a design win
+        (`restricted`, which nothing on the roster records) or because it has been withdrawn
+        (`discontinued`, which is `google-coral-dev-board`)'
+      machine_signal: none, and the asymmetry `retail` records carries over - a distributor
+        listing is checkable in principle, but absence of a listing does not establish that
+        nobody can buy the part
 
   # Ordered, first match wins. No `otherwise`: a product recording no `schematics` value is
   # unrecorded rather than closed, and an `otherwise` would score it at whatever the last
-  # rung happened to be.
+  # rung happened to be. That absence is load-bearing in this change - it is what makes
+  # falling off the ladder an available outcome, and therefore what lets a rung insist on
+  # two facts instead of settling for one.
+  #
+  # The first three rungs decide which KIND of thing is being scored rather than how open it
+  # is, and they are first for that reason: an accessory answers about its host and a chipset
+  # answers about its documentation and its availability. The five below them are the board
+  # ladder, and each of them SAYS so - `board_design: exists` is the first condition on every
+  # one - rather than relying on its position in the list. Being lower down is not a guard:
+  # first match wins means a chipset that falls past its own rung meets a board's next, so
+  # without the condition a chipset whose datasheets are gated would collect 3/documented
+  # from somebody else's reference-board files. A module takes the board rungs deliberately - it has a
+  # design and its vendor chose not to release it, so `schematics` asks a module a question it
+  # can answer - and that is why the guard is `board_design` rather than `form_factor: board`.
   #
   # There is deliberately no `restricted`/1 rung. The category's prose ladder defines one
   # (NDA / design-win / private-sale only) and no product on the roster is one, so declaring
@@ -156,6 +300,12 @@ openness:
   # dangerous: a dead rule in a first-match-wins formula is a place for a later edit to hide.
   # #133 is what that looks like when it goes wrong. The tier is described in the category's
   # comments so the vocabulary is not lost; it becomes a rung when a part needs it.
+  #
+  # Until then, a part that would sit on it abstains: a chipset answering `datasheets: nda`
+  # or `availability: gated` matches no rung and the category defers it with a reason. That
+  # is the ladder reporting that it does not decide, which is a weaker claim than 1/restricted
+  # and the only one the evidence supports - being unable to read a datasheet is not the same
+  # finding as a vendor gating the part, and one rung cannot tell them apart.
   formula:
   - when: {accessory_host: open_toolchain}
     then: {score: 4, class: open_toolchain}
@@ -174,7 +324,39 @@ openness:
       accessory cannot offer a builder more openness than the system it completes. Reading
       the HAT's own answers instead would score the wrong artifact, which is what this
       dimension exists to prevent.
-  - when: {schematics: open, toolchain: open}
+  - when: {form_factor: chipset, datasheets: public, availability: buyable}
+    then: {score: 3, class: documented}
+    because: >-
+      The first rung that asks a chipset something it can answer, and it asks both halves of
+      what the answer means. `documented` is defined by this category as "datasheets public +
+      buyable, but no design files of its own", so the rung tests the documentation and tests
+      whether anybody can buy one. `rockchip-rk3588` publishes the full technical reference
+      manual and datasheet with no NDA and no registration and reaches buyers through the
+      module and board partners built on it; `ti-am67a` is ACTIVE and orderable from TI;
+      `nxp-imx-8m-plus` is stocked by DigiKey and carried by Toradex. A part whose datasheet
+      is behind a design win answers `nda`, a part nobody can buy answers `gated`, and either
+      one matches no rung and is deferred - the design rungs below all test `board_design`
+      first, so falling past this one leads off the ladder rather than onto a board's.
+
+      It does NOT test the toolchain, and that is a decision rather than an omission. There is
+      no way to let the toolchain decide a chipset's score here that is both true as a general
+      statement and consistent with what this ladder already says. Making an open SDK a
+      REQUIREMENT for 3 would put bare silicon below the module built on it: this category's
+      own vocabulary places "a closed or registration-gated SDK" inside `documented`, and
+      `nvidia-jetson-orin-nx` and `nvidia-jetson-agx-orin` both record `toolchain: closed` and
+      score 3. Making it a LIFT to 4 fails from the other side, because 4 is a claim about a
+      published design that a chipset does not have, and `ti-am67a` and `nxp-imx-8m-plus`
+      record `toolchain: open` and are recorded at 3. So the toolchain is recorded on all
+      three chipsets and read by no rung, which is the honest place to leave it. `blobs` sits
+      there too, for a neighbouring reason it has carried since #132: every part in this
+      category needs proprietary firmware, so it separates none of them.
+
+      3 is the ceiling for a chipset and it is not a consolation prize. The rungs above are
+      claims about a design somebody can READ (4) and REUSE (5), and a chipset has none to
+      publish. A rung splitting the three chipsets by toolchain was drafted and dropped: both
+      outcomes are 3 under this vocabulary, so it would have added a rule that changes no
+      number, which is the clutter the `restricted` tier is kept out of the ladder to avoid.
+  - when: {board_design: exists, schematics: open, toolchain: open}
     then: {score: 5, class: open_hardware}
     because: >-
       Design files published under terms permitting reuse, and a stack that builds from open
@@ -182,13 +364,13 @@ openness:
       runs on a closed SoC, so requiring open silicon would make the rung unreachable by
       construction. Reusable terms are what keep this in the `open` bucket - it is hardware's
       analogue of the OSI requirement the other ladders enforce.
-  - when: {schematics: published, toolchain: open}
+  - when: {board_design: exists, schematics: published, toolchain: open}
     then: {score: 4, class: open_toolchain}
     because: >-
       Schematics readable but not reusable, which is the distinction the class name draws:
       what is open here is the toolchain. `radxa-rock-5b` publishes PDFs, DXF and STP and
       explicitly withholds editable PCB source.
-  - when: {schematics: published}
+  - when: {board_design: exists, schematics: published}
     then: {score: 3, class: documented}
     because: >-
       A design you can read and a stack you cannot build. The rung above is a claim about the
@@ -198,19 +380,23 @@ openness:
       layout all published, Edge TPU compiler a closed binary. `documented` is the word the
       category's own ladder already uses for a closed or registration-gated SDK, so this
       rung names the state rather than inventing one.
-  - when: {schematics: partial}
+  - when: {board_design: exists, schematics: partial}
     then: {score: 3, class: documented}
     because: >-
       A carrier guide or an EVK design documents how to build your own board; it is not the
       design of the board being sold. An open SDK does not make the hardware open, which is
       why the rung ignores `toolchain` entirely.
-  - when: {schematics: none}
+  - when: {board_design: exists, schematics: none}
     then: {score: 3, class: documented}
     because: >-
-      Accelerator modules and bare chipsets publish datasheets and no design files. The tier
-      is named `documented` because that is precisely what it is - and it is the same 3 as
-      the rung above, because from a builder's position a partial design and no design differ
-      less than either differs from a design you may reuse.
+      An accelerator module whose vendor published nothing of its design. `none` here means
+      withheld, which is why the rung still reads as a judgment about openness: the four
+      products that reach it - `hailo-8`, `hailo-10h`, `axelera-metis-aipu`, `memryx-mx3` -
+      each have an M.2 or PCIe card whose files could have been released. A chipset recording
+      the same word means something else and does not reach this rung; that is what
+      `board_design` is for. The tier is named `documented` because that is precisely what it
+      is, and it is the same 3 as the rung above, because from a builder's position a partial
+      design and no design differ less than either differs from a design you may reuse.
 
 # Adoption bands: which monthly figure maps to which level, for this product type.
 #

--- a/sources/scores/arduino-uno-q.yaml
+++ b/sources/scores/arduino-uno-q.yaml
@@ -21,6 +21,10 @@ openness:
       value: open_market
       detail: global
       raw: open_market (global)
+    form_factor:
+      value: board
+      detail: SBC sold ready to run
+      raw: board (SBC sold ready to run)
   confidence: high
   note: 'Board schematics and gerbers are openly licensed under CC-BY-SA 4.0 and the App Lab toolchain is
     open, which is the same open-design-and-open-toolchain pair that puts beagley-ai at 5. This ladder scores
@@ -41,9 +45,9 @@ openness:
     graphics stack is open, with "hardware-accelerated 3D graphics rendering through open-source Mesa drivers",
     freedreno for OpenGL and turnip for Vulkan, and video encode and decode reached through plain V4L2.
     What remains closed is the SoC boot chain, which Arduino publishes nothing of.'
-  raw: schematics:open (gerbers + schematics CC-BY-SA 4.0);toolchain:open (App Lab GPL-3.0 + App
-    Bricks MPL-2.0, source published);datasheets:public;blobs:required (proprietary Qualcomm SoC
-    firmware);retail:open_market (global)
+  raw: schematics:open (gerbers + schematics CC-BY-SA 4.0);toolchain:open (App Lab GPL-3.0 + App Bricks
+    MPL-2.0, source published);datasheets:public;blobs:required (proprietary Qualcomm SoC firmware);retail:open_market
+    (global);form_factor:board (SBC sold ready to run)
   last_verified: '2026-08-14'
   sources:
   - url: https://www.arduino.cc/product-uno-q
@@ -60,6 +64,7 @@ openness:
     - schematics
     - toolchain
     - retail
+    - form_factor
   - url: https://github.com/arduino/arduino-app-lab
     shows: '"The cross-platform IDE for developing Arduino Apps, built with Wails" - public, GPL-3.0,
       ~19MB, Go plus TypeScript source in app/, ui-packages/ and standalone-apps/, last pushed

--- a/sources/scores/axelera-metis-aipu.yaml
+++ b/sources/scores/axelera-metis-aipu.yaml
@@ -21,11 +21,16 @@ openness:
       value: open_market
       detail: webstore + partners
       raw: open_market (webstore + partners)
+    form_factor:
+      value: module
+      detail: sold as M.2 modules and PCIe cards
+      raw: module (sold as M.2 modules and PCIe cards)
   confidence: medium
   note: Proprietary in-memory-compute silicon with a publicly available Voyager SDK on GitHub and retail
     purchasing, but board design files are not open.
   raw: schematics:none;toolchain:open (Voyager SDK on public GitHub);datasheets:brief (product pages/briefs
-    public);blobs:required (proprietary AIPU silicon + firmware);retail:open_market (webstore + partners)
+    public);blobs:required (proprietary AIPU silicon + firmware);retail:open_market (webstore + partners);form_factor:module
+    (sold as M.2 modules and PCIe cards)
   last_verified: '2026-08-13'
   sources:
   - url: https://www.axelera.ai/
@@ -38,6 +43,7 @@ openness:
     - datasheets
     - blobs
     - retail
+    - form_factor
     http_status: 200
     content_sha256: 1cbac435bb57fb831cfc088ab93b95edfdf022785053c407b19fd78c53dd2192
   - url: https://github.com/axelera-ai-hub/voyager-sdk

--- a/sources/scores/beagley-ai.yaml
+++ b/sources/scores/beagley-ai.yaml
@@ -19,6 +19,10 @@ openness:
       value: required
       detail: TI DSP/WiFi firmware blobs a caveat
       raw: required (TI DSP/WiFi firmware blobs a caveat)
+    form_factor:
+      value: board
+      detail: SBC sold ready to run, OSHWA-certified as a board
+      raw: board (SBC sold ready to run, OSHWA-certified as a board)
   confidence: high
   note: Full board design files published under Creative Commons and OSHWA-certified, with an open toolchain
     and a public datasheet, though proprietary AM67A silicon and firmware blobs are a caveat. The OSHWA
@@ -27,7 +31,7 @@ openness:
     the repository README both still do.
   raw: schematics:open (schematics + 3D/mechanical files, CC-BY/CC-BY-SA-4.0, OSHWA-certified US002616);toolchain:open
     (open Linux/U-Boot BSP);datasheets:public (public TI AM67A datasheet);blobs:required (TI DSP/WiFi firmware
-    blobs a caveat)
+    blobs a caveat);form_factor:board (SBC sold ready to run, OSHWA-certified as a board)
   last_verified: '2026-08-13'
   sources:
   - url: https://certification.oshwa.org/us002616.html
@@ -37,6 +41,7 @@ openness:
     establishes:
     - schematics
     - toolchain
+    - form_factor
     http_status: 200
     content_sha256: 2863573852c2ebfa8cf746eef592e52abd6fd1434365bba08fa1b170536499bf
   - url: https://github.com/beagleboard/beagley-ai

--- a/sources/scores/google-coral-dev-board.yaml
+++ b/sources/scores/google-coral-dev-board.yaml
@@ -45,8 +45,8 @@ openness:
     names no hardware and links no purchase route; and no reachable distributor confirms stock, with Mouser
     serving a bot-denial page and Farnell and Digi-Key refusing automated requests. Open market, distributor-only
     and restricted all describe a part somebody can still buy under some terms, so a withdrawn part is recorded
-    instead as discontinued. The wording is score-neutral either way, since no rung on the hardware ladder
-    reads the retail component.'
+    instead as discontinued. The wording is score-neutral for this product, since no BOARD rung
+    reads the retail component - the chipset rung does, through `availability`, and this is a board.'
   raw: schematics:published (baseboard schematic + Altium source + Allegro layout, Apache-2.0; SoM withheld);toolchain:partial
     (open runtime (libedgetpu) + TFLite, closed Edge TPU compiler);datasheets:public;blobs:required (proprietary
     Edge TPU ASIC + closed compiler);retail:open_market (broadly purchasable);form_factor:board (baseboard

--- a/sources/scores/google-coral-dev-board.yaml
+++ b/sources/scores/google-coral-dev-board.yaml
@@ -21,6 +21,10 @@ openness:
       value: discontinued
       detail: broadly purchasable
       raw: open_market (broadly purchasable)
+    form_factor:
+      value: board
+      detail: baseboard carrying a Google SoM, sold as one board
+      raw: board (baseboard carrying a Google SoM, sold as one board)
   confidence: high
   note: 'Google publishes a public datasheet and the baseboard design files, and there is an open runtime
     with a TensorFlow Lite path, but the Edge TPU silicon and the model compiler are proprietary closed
@@ -43,9 +47,10 @@ openness:
     and restricted all describe a part somebody can still buy under some terms, so a withdrawn part is recorded
     instead as discontinued. The wording is score-neutral either way, since no rung on the hardware ladder
     reads the retail component.'
-  raw: schematics:published (baseboard schematic + Altium source + Allegro layout, Apache-2.0; SoM
-    withheld);toolchain:partial (open runtime (libedgetpu) + TFLite, closed Edge TPU compiler);datasheets:public;blobs:required
-    (proprietary Edge TPU ASIC + closed compiler);retail:open_market (broadly purchasable)
+  raw: schematics:published (baseboard schematic + Altium source + Allegro layout, Apache-2.0; SoM withheld);toolchain:partial
+    (open runtime (libedgetpu) + TFLite, closed Edge TPU compiler);datasheets:public;blobs:required (proprietary
+    Edge TPU ASIC + closed compiler);retail:open_market (broadly purchasable);form_factor:board (baseboard
+    carrying a Google SoM, sold as one board)
   last_verified: '2026-08-14'
   sources:
   - url: https://coral.ai/products/dev-board
@@ -69,6 +74,7 @@ openness:
     establishes:
     - schematics
     - datasheets
+    - form_factor
   - url: https://github.com/google-coral/electricals
     shows: '"Electrical designs for coral.ai projects", Apache-2.0, public; dev_board/ holds
       Coral-Dev-Board-baseboard-schematic.pdf, -schematic-Altium.zip and -layout-Allegro.brd, which is

--- a/sources/scores/hailo-10h.yaml
+++ b/sources/scores/hailo-10h.yaml
@@ -21,6 +21,10 @@ openness:
       value: open_market
       detail: M.2 modules purchasable
       raw: open_market (M.2 modules purchasable)
+    form_factor:
+      value: module
+      detail: M.2 accelerator module, also sold as bare silicon
+      raw: module (M.2 accelerator module, also sold as bare silicon)
   confidence: high
   note: Proprietary silicon with published datasheets and an open generative-AI model zoo, but the silicon
     and the full toolchain are closed. The GenAI model zoo is MIT-licensed, as GitHub's own repository metadata
@@ -31,7 +35,8 @@ openness:
     is that same page plus Geniatech shipping an independent Hailo-10 module. hailo.ai itself refuses every
     automated request, so all of this rests on substitute sources.
   raw: schematics:none;toolchain:partial (open runtime + MIT GenAI model zoo);datasheets:public (June 2025);blobs:required
-    (proprietary silicon/firmware);retail:open_market (M.2 modules purchasable)
+    (proprietary silicon/firmware);retail:open_market (M.2 modules purchasable);form_factor:module (M.2
+    accelerator module, also sold as bare silicon)
   last_verified: '2026-08-14'
   sources:
   - url: https://hailo.ai/products/ai-accelerators/hailo-10h-m-2-ai-acceleration-module/
@@ -61,7 +66,7 @@ openness:
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: d70178bfb0c8e89a1d7a283be27db74b083aea6c9155b4edb41be277b30097eb
-    establishes: [datasheets, retail, schematics]
+    establishes: [datasheets, retail, schematics, form_factor]
   - url: https://www.geniatech.com/product/aim-m-h10/
     shows: 'a second vendor''s purchasable Hailo-10 M.2 module - "Up to 40 TOPS AI performance",
       "M.2 Key-M form factor"'

--- a/sources/scores/hailo-8.yaml
+++ b/sources/scores/hailo-8.yaml
@@ -21,6 +21,10 @@ openness:
       value: open_market
       detail: global modules
       raw: open_market (global modules)
+    form_factor:
+      value: module
+      detail: M.2 Key B+M accelerator card, also sold as bare silicon
+      raw: module (M.2 Key B+M accelerator card, also sold as bare silicon)
   confidence: high
   note: 'Proprietary silicon with an open source runtime and public product briefs, but the model-compiler
     toolchain requires registration and the silicon itself is closed. HailoRT''s README carries the open
@@ -34,7 +38,8 @@ openness:
     at $179.99 with an add-to-cart button. hailo.ai refuses every automated request, so all of this rests
     on substitute sources.'
   raw: schematics:none;toolchain:partial (open runtime (HailoRT) + closed/registration Dataflow Compiler);datasheets:brief
-    (public briefs);blobs:required (proprietary silicon + firmware);retail:open_market (global modules)
+    (public briefs);blobs:required (proprietary silicon + firmware);retail:open_market (global modules);form_factor:module
+    (M.2 Key B+M accelerator card, also sold as bare silicon)
   last_verified: '2026-08-14'
   sources:
   - url: https://hailo.ai/products/ai-accelerators/hailo-8-ai-accelerator/
@@ -65,7 +70,7 @@ openness:
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: b4b4953effe80c43eeafe323505d4d71ba4ab9f5612c05f9ce71e65c6008256c
-    establishes: [datasheets, schematics]
+    establishes: [datasheets, schematics, form_factor]
   - url: https://www.waveshare.com/hailo-8.htm
     shows: 'the module on open sale - "Hailo-8 M.2 AI Accelerator Module, based on the 26TOPS Hailo-8
       AI processor", SKU 27812, $179.99, Add to Cart'

--- a/sources/scores/khadas-edge2.yaml
+++ b/sources/scores/khadas-edge2.yaml
@@ -23,6 +23,10 @@ openness:
       value: open_market
       detail: global
       raw: open_market (global)
+    form_factor:
+      value: board
+      detail: SBC sold ready to run
+      raw: board (SBC sold ready to run)
   confidence: high
   note: 'Khadas publishes versioned board schematics and an open toolchain with mainline Armbian support,
     but proprietary Rockchip silicon and required firmware blobs keep it at the open-toolchain tier rather
@@ -30,7 +34,8 @@ openness:
     as an RK3588S2 technical reference manual, where what is actually readable is Rockchip''s brief RK3588
     datasheet plus Khadas''s own published specification.'
   raw: schematics:published (versioned PDFs published);toolchain:open (open GPL-2.0 Fenix + mainline Armbian);datasheets:public
-    (public SoC TRM);blobs:required (Rockchip NPU/boot blobs required);retail:open_market (global)
+    (public SoC TRM);blobs:required (Rockchip NPU/boot blobs required);retail:open_market (global);form_factor:board
+    (SBC sold ready to run)
   last_verified: '2026-08-13'
   sources:
   - url: https://dl.khadas.com/products/edge2/schematics/
@@ -39,6 +44,7 @@ openness:
     accessed: '2026-08-13'
     establishes:
     - schematics
+    - form_factor
     http_status: 200
     content_sha256: 32fb979dda95231cd393dee14d5a7c3c78e4bcf74164524ac216c880d4923be2
   - url: https://github.com/khadas/fenix

--- a/sources/scores/memryx-mx3.yaml
+++ b/sources/scores/memryx-mx3.yaml
@@ -19,11 +19,16 @@ openness:
       value: open_market
       detail: Amazon/Mouser ~$149
       raw: open_market (Amazon/Mouser ~$149)
+    form_factor:
+      value: module
+      detail: M.2 2280 module carrying four MX3 chips
+      raw: module (M.2 2280 module carrying four MX3 chips)
   confidence: high
   note: Proprietary dataflow silicon with public datasheets, retail availability, and several open source
     runtime/driver repos, though the compiler core is closed.
   raw: schematics:none;toolchain:partial (open runtime (MxAccl) + utils + driver mirror, closed NeuralCompiler);datasheets:public;blobs:required
-    (proprietary silicon);retail:open_market (Amazon/Mouser ~$149)
+    (proprietary silicon);retail:open_market (Amazon/Mouser ~$149);form_factor:module (M.2 2280 module carrying
+    four MX3 chips)
   last_verified: '2026-08-13'
   sources:
   - url: https://developer.memryx.com/specs/M.2_datasheet.html
@@ -34,6 +39,7 @@ openness:
     establishes:
     - schematics
     - datasheets
+    - form_factor
     http_status: 200
     content_sha256: 14d338f59a212d65ca4cae04933e6643e1cedba983b98f5ad9963f4bb88e9479
   - url: https://github.com/memryx/MxAccl

--- a/sources/scores/nvidia-jetson-agx-orin.yaml
+++ b/sources/scores/nvidia-jetson-agx-orin.yaml
@@ -21,6 +21,10 @@ openness:
       value: distributor
       detail: via distributors
       raw: distributor (via distributors)
+    form_factor:
+      value: module
+      detail: 699-pin Mirror Mezz module for a carrier board
+      raw: module (699-pin Mirror Mezz module for a carrier board)
   confidence: high
   note: Public datasheets and commercially purchasable, but SDK relies on proprietary NVIDIA blobs under
     license, placing it in the documented tier. The family page publishes module data sheets and points
@@ -29,7 +33,7 @@ openness:
     drivers under the NVIDIA Software License Agreement.
   raw: schematics:partial (module datasheet + carrier design guide public);toolchain:closed (JetPack/Jetson
     Linux proprietary (NVIDIA SLA));datasheets:public;blobs:required (proprietary drivers/bootloader);retail:distributor
-    (via distributors)
+    (via distributors);form_factor:module (699-pin Mirror Mezz module for a carrier board)
   last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin
@@ -41,6 +45,7 @@ openness:
     - schematics
     - datasheets
     - retail
+    - form_factor
     http_status: 200
     content_sha256: 99efa728010da0ac785f54233fbef4e621123d6f61ca67f2df5deee3d3df3fe2
   - url: https://developer.nvidia.com/embedded/jetson-linux

--- a/sources/scores/nvidia-jetson-orin-nano-super-developer-kit.yaml
+++ b/sources/scores/nvidia-jetson-orin-nano-super-developer-kit.yaml
@@ -21,6 +21,10 @@ openness:
       value: open_market
       detail: mass-market
       raw: open_market (mass-market)
+    form_factor:
+      value: board
+      detail: developer kit - the module on its own carrier board
+      raw: board (developer kit - the module on its own carrier board)
   confidence: high
   note: Public datasheets and globally purchasable, but the SDK requires proprietary NVIDIA drivers/blobs
     under license, so it sits in the documented tier despite the community OE4T BSP. The developer-kit page
@@ -29,7 +33,7 @@ openness:
     39.2.1 ships its kernel, UEFI bootloader and NVIDIA drivers under the NVIDIA Software License Agreement.
   raw: schematics:partial (carrier design guide public);toolchain:closed (JetPack/Jetson Linux free but
     NVIDIA-SLA proprietary);datasheets:public;blobs:required (proprietary GPU drivers/bootloader required);retail:open_market
-    (mass-market)
+    (mass-market);form_factor:board (developer kit - the module on its own carrier board)
   last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/nano-super-developer-kit/
@@ -40,6 +44,7 @@ openness:
     establishes:
     - datasheets
     - retail
+    - form_factor
     http_status: 200
     content_sha256: bfc0f0b3900815dcad4c93c9b773b1eaafd9be69c143f0e1002f9fd1f507d952
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin

--- a/sources/scores/nvidia-jetson-orin-nx.yaml
+++ b/sources/scores/nvidia-jetson-orin-nx.yaml
@@ -21,6 +21,10 @@ openness:
       value: distributor
       detail: via distributors
       raw: distributor (via distributors)
+    form_factor:
+      value: module
+      detail: 260-pin SO-DIMM module for a carrier board
+      raw: module (260-pin SO-DIMM module for a carrier board)
   confidence: high
   note: Public datasheets and purchasable through distributors, but the SDK depends on proprietary NVIDIA
     blobs under license. The family page publishes module data sheets and points designers at the Product
@@ -29,7 +33,7 @@ openness:
     Software License Agreement.
   raw: schematics:partial (module datasheet + carrier design guide public);toolchain:closed (JetPack/Jetson
     Linux proprietary (NVIDIA SLA));datasheets:public;blobs:required (proprietary drivers/bootloader);retail:distributor
-    (via distributors)
+    (via distributors);form_factor:module (260-pin SO-DIMM module for a carrier board)
   last_verified: '2026-08-13'
   sources:
   - url: https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin
@@ -41,6 +45,7 @@ openness:
     - schematics
     - datasheets
     - retail
+    - form_factor
     http_status: 200
     content_sha256: 99efa728010da0ac785f54233fbef4e621123d6f61ca67f2df5deee3d3df3fe2
   - url: https://developer.nvidia.com/embedded/jetson-linux

--- a/sources/scores/nxp-imx-8m-plus.yaml
+++ b/sources/scores/nxp-imx-8m-plus.yaml
@@ -23,6 +23,10 @@ openness:
       value: distributor
       detail: commercial via NXP and SoM partners
       raw: distributor (commercial via NXP and SoM partners)
+    form_factor:
+      value: chipset
+      detail: applications-processor family, not a board
+      raw: chipset (applications-processor family, not a board)
   confidence: high
   note: 'Public datasheets and a Linux BSP with broad commercial availability, but proprietary silicon with
     no open board files. The documentation is the strongest part of the picture: the datasheet identified
@@ -39,7 +43,8 @@ openness:
     headers change nothing, so this is the host and not the URL - and these components therefore rest on
     substitute sources.'
   raw: schematics:none (EVK reference designs only);toolchain:open (Linux/Yocto BSP);datasheets:public (IMX8MPCEC);blobs:required
-    (proprietary silicon + NPU firmware);retail:distributor (commercial via NXP and SoM partners)
+    (proprietary silicon + NPU firmware);retail:distributor (commercial via NXP and SoM partners);form_factor:chipset
+    (applications-processor family, not a board)
   last_verified: '2026-08-14'
   sources:
   - url: https://www.nxp.com/products/i.MX8MPLUS
@@ -55,7 +60,7 @@ openness:
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: 6cfe20059a1d3bec77bd89893c3db75bcf0fd99b7742f3730adb528f091911d1
-    establishes: [datasheets, schematics]
+    establishes: [datasheets, schematics, form_factor]
   - url: https://raw.githubusercontent.com/nxp-imx/meta-imx/master/README.md
     shows: '"Yocto Project BSP for NXP i.MX Linux Release LF6.18.20_2.0.0", with i.MX 8M Plus machines
       imx8mp-lpddr4-evk, imx8mp-ddr4-evk and imx8mp-lpddr4-frdm; and "The NXP i.MX End User License

--- a/sources/scores/orange-pi-5.yaml
+++ b/sources/scores/orange-pi-5.yaml
@@ -23,11 +23,16 @@ openness:
       value: open_market
       detail: global
       raw: open_market (global)
+    form_factor:
+      value: board
+      detail: SBC sold ready to run
+      raw: board (SBC sold ready to run)
   confidence: high
   note: Proprietary Rockchip silicon with an open GPL-2.0 BSP, public datasheet and schematics, and global
     retail availability, but bootable images depend on Rockchip firmware blobs.
   raw: schematics:published (published PDF);toolchain:open (open GPL-2.0 BSP/build system);datasheets:public
-    (public RK3588S);blobs:required (Rockchip firmware required);retail:open_market (global)
+    (public RK3588S);blobs:required (Rockchip firmware required);retail:open_market (global);form_factor:board
+    (SBC sold ready to run)
   last_verified: '2026-08-13'
   sources:
   - url: https://github.com/orangepi-xunlong/orangepi-build
@@ -54,6 +59,7 @@ openness:
     establishes:
     - datasheets
     - retail
+    - form_factor
     http_status: 200
     content_sha256: 9477dddc0147a7932d0959d44d7e687e5d09d047b76aa181786e08c88917fc94
   - url: https://github.com/rockchip-linux/rkbin

--- a/sources/scores/qualcomm-dragonwing-rb3-gen-2.yaml
+++ b/sources/scores/qualcomm-dragonwing-rb3-gen-2.yaml
@@ -23,6 +23,10 @@ openness:
       value: distributor
       detail: via Thundercomm/distributors
       raw: distributor (via Thundercomm/distributors)
+    form_factor:
+      value: board
+      detail: 96Boards development-kit board
+      raw: board (96Boards development-kit board)
   confidence: high
   note: Proprietary Qualcomm silicon with public documentation and a Linux SDK, sold through distributors,
     but the board itself is not fully open hardware. The public documentation is a product brief, document
@@ -36,7 +40,8 @@ openness:
     kits. www.qualcomm.com serves a client-rendered 9KB shell to an automated fetch and no header set changes
     that, which is why the brief is taken from docs.qualcomm.com instead.
   raw: schematics:partial (96Boards mezzanine standard);toolchain:open (open Qualcomm Linux + AI Hub);datasheets:brief
-    (public brief);blobs:required (proprietary silicon + firmware);retail:distributor (via Thundercomm/distributors)
+    (public brief);blobs:required (proprietary silicon + firmware);retail:distributor (via Thundercomm/distributors);form_factor:board
+    (96Boards development-kit board)
   last_verified: '2026-08-14'
   sources:
   - url: https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit
@@ -53,7 +58,7 @@ openness:
     accessed: '2026-08-14'
     http_status: 200
     content_sha256: b74769821c1cd5d01d3d7b947392c8af80aa68f2f69a49f95f5775a3b05c75f0
-    establishes: [datasheets, schematics, toolchain, blobs]
+    establishes: [datasheets, schematics, toolchain, blobs, form_factor]
   - url: https://api.github.com/repos/quic/ai-hub-models
     shows: 'Qualcomm AI Hub Models, license spdx_id BSD-3-Clause, 1183 stars, last pushed 2026-08-13 -
       the open half of the toolchain'

--- a/sources/scores/radxa-rock-5b.yaml
+++ b/sources/scores/radxa-rock-5b.yaml
@@ -19,11 +19,16 @@ openness:
       value: open_market
       detail: global
       raw: open_market (global)
+    form_factor:
+      value: board
+      detail: SBC sold ready to run
+      raw: board (SBC sold ready to run)
   confidence: high
   note: Schematics and mechanical files are publicly downloadable and the BSP is open, but the RK3588 needs
     proprietary Rockchip blobs and editable PCB source is not released.
   raw: schematics:published (PDF + SMD maps + DXF + 3D STP + CE/FCC public);toolchain:open (open BSP/kernel/U-Boot);blobs:required
-    (Rockchip rkbin/DDR/TF-A required);retail:open_market (global)
+    (Rockchip rkbin/DDR/TF-A required);retail:open_market (global);form_factor:board (SBC sold ready to
+    run)
   last_verified: '2026-08-13'
   sources:
   - url: https://docs.radxa.com/en/rock5/rock5b/download
@@ -33,6 +38,7 @@ openness:
     accessed: '2026-08-13'
     establishes:
     - schematics
+    - form_factor
     http_status: 200
     content_sha256: 5be2c030020841b46a9db971a60695cb5e30415494eabed3d8d53e166dbd4ec5
   - url: https://github.com/radxa-repo/bsp

--- a/sources/scores/raspberry-pi-5.yaml
+++ b/sources/scores/raspberry-pi-5.yaml
@@ -19,6 +19,10 @@ openness:
       value: open_market
       detail: mass-market
       raw: open_market (mass-market)
+    form_factor:
+      value: board
+      detail: SBC sold ready to run
+      raw: board (SBC sold ready to run)
   confidence: high
   note: 'Raspberry Pi publishes an open Linux kernel tree and public datasheets and the board is on sale
     worldwide, but it publishes no schematic for the Pi 5 at all. The Pi 4''s reduced schematic is still
@@ -37,8 +41,9 @@ openness:
     boot chain as minimal firmware, where all nineteen other boards in the category describe the same shape
     of fact as required firmware, beagley-ai included. Nothing scored turns on the difference, because no
     rung on the hardware ladder reads the firmware component at all.'
-  raw: schematics:partial (mechanical drawing + STEP files only, no schematic);toolchain:open (open
-    kernel tree + Raspberry Pi OS);datasheets:public;blobs:minimal;retail:open_market (mass-market)
+  raw: schematics:partial (mechanical drawing + STEP files only, no schematic);toolchain:open (open kernel
+    tree + Raspberry Pi OS);datasheets:public;blobs:minimal;retail:open_market (mass-market);form_factor:board
+    (SBC sold ready to run)
   last_verified: '2026-08-14'
   sources:
   - url: https://datasheets.raspberrypi.com/rpi5/raspberry-pi-5-mechanical-drawing.pdf
@@ -50,6 +55,7 @@ openness:
     content_sha256: 5dd680d6c1f5e7aa9c7b020695e315d04aac862df82ff01d4e9041cd0668d7f2
     establishes:
     - schematics
+    - form_factor
   - url: https://datasheets.raspberrypi.com/rpi4/raspberry-pi-4-reduced-schematics.pdf
     shows: The Pi 4 reduced schematics, live, which is the document the old `reduced published`
       value described; no Pi 5 equivalent exists

--- a/sources/scores/raspberry-pi-ai-hat-plus.yaml
+++ b/sources/scores/raspberry-pi-ai-hat-plus.yaml
@@ -26,6 +26,10 @@ openness:
       value: open_market
       detail: mass-market
       raw: open_market (mass-market)
+    form_factor:
+      value: board
+      detail: HAT+ add-on board; the host it completes is recorded under accessory-host
+      raw: board (HAT+ add-on board; the host it completes is recorded under accessory-host)
   confidence: medium
   note: 'An officially supported open Raspberry Pi software stack and a public product page, on sale worldwide,
     but the underlying Hailo model-compiler toolchain is registration-gated. The HAT is scored as an accessory:
@@ -48,7 +52,8 @@ openness:
     customer-gated compiler. Retail availability comes from The Pi Hut stocking both variants.'
   raw: schematics:partial (HAT+ mechanical spec public);accessory-host:documented(Raspberry Pi 5, which
     scores 3/documented);toolchain:partial (open Pi driver integration, Hailo compiler gated);datasheets:brief
-    (public brief);blobs:required (Hailo firmware required);retail:open_market (mass-market)
+    (public brief);blobs:required (Hailo firmware required);retail:open_market (mass-market);form_factor:board
+    (HAT+ add-on board; the host it completes is recorded under accessory-host)
   last_verified: '2026-08-14'
   sources:
   - url: https://datasheets.raspberrypi.com/ai-hat-plus/raspberry-pi-ai-hat-plus-product-brief.pdf
@@ -80,6 +85,7 @@ openness:
     content_sha256: 3a0932253767147038383162ac9f4b5aac3adb048c30bd1f9177a462a054ca1e
     establishes:
     - schematics
+    - form_factor
   - url: https://datasheets.raspberrypi.com/rpi5/raspberry-pi-5-mechanical-drawing.pdf
     shows: RP-008347-DS, the only board-level design document Raspberry Pi publishes for the Pi 5, and
       the evidence that puts the host at 3/documented rather than 4/open_toolchain. The reduced

--- a/sources/scores/rockchip-rk3588.yaml
+++ b/sources/scores/rockchip-rk3588.yaml
@@ -16,15 +16,27 @@ openness:
       value: required
       detail: proprietary GPU/NPU firmware
       raw: required (proprietary GPU/NPU firmware)
+    retail:
+      value: distributor
+      detail: commercial through Rockchip's module and board partners
+      raw: distributor (commercial through Rockchip's module and board partners)
+    form_factor:
+      value: chipset
+      detail: application-processor SoC, not a board
+      raw: chipset (application-processor SoC, not a board)
   confidence: high
   note: Documentation is unusually open (full TRM and datasheet public) and the RKNN toolkit is openly distributed,
     but the SDK ships as prebuilt binaries under a proprietary license with closed firmware. The brief datasheet
     downloads straight from rock-chips.com with no registration or NDA, the RKNN SDK licence in airockchip/rknn-toolkit2
     is the proprietary "RKNN SDK License" (no reverse engineering, use restricted to Rockchip products),
-    and rkbin distributes the DDR/BL31/OPTEE firmware as prebuilt binaries.
+    and rkbin distributes the DDR/BL31/OPTEE firmware as prebuilt binaries. The part is not sold from a
+    Rockchip storefront and no distributor page for the bare silicon was reachable, so retail rests on the
+    module partners who build on it. Firefly lists the Core-3588J, a system-on-module carrying this SoC,
+    at $289 with a working order path.
   raw: toolchain:partial (NPU SDK on GitHub but proprietary RKNN license + prebuilt blobs, rknpu kernel
     driver open);datasheets:public (full TRM + datasheet public, no NDA);blobs:required (proprietary GPU/NPU
-    firmware)
+    firmware);retail:distributor (commercial through Rockchip's module and board partners);form_factor:chipset
+    (application-processor SoC, not a board)
   last_verified: '2026-08-13'
   sources:
   - url: https://www.rock-chips.com/uploads/pdf/2022.8.26/192/RK3588%20Brief%20Datasheet.pdf
@@ -34,6 +46,7 @@ openness:
     accessed: '2026-08-13'
     establishes:
     - datasheets
+    - form_factor
     http_status: 200
     content_sha256: 81aff61337ab10bf0f7c9234450703816037af169bf6657d3d62b868bd61fd1a
   - url: https://github.com/airockchip/rknn-toolkit2/blob/master/LICENSE
@@ -58,6 +71,14 @@ openness:
     accessed: '2026-08-13'
     http_status: 200
     content_sha256: b5ca75ad042e019b490b1627bd74996fe02a72a320a1d292db2accd549e0dd71
+  - url: https://www.t-firefly.com/products/core-3588j-8k-ai-core-board-rockchip-rk3588-new-gen-8-core-64-bit-processor
+    shows: a module partner selling the part commercially - "Core-3588J 8K AI System on Module RK3588 SOC
+      4G RAM+32G ROM" listed at $289.00 with an Add to cart path
+    accessed: '2026-09-12'
+    establishes:
+    - retail
+    http_status: 200
+    content_sha256: f50a563d6cbe9b2293c3dff620643091020ebb98f1de996061dc76a1b79e1a4d
 adoption:
   level: 5
   reach: mass-market

--- a/sources/scores/sipeed-maixcam.yaml
+++ b/sources/scores/sipeed-maixcam.yaml
@@ -23,11 +23,16 @@ openness:
       value: open_market
       detail: global via AliExpress/Taobao
       raw: open_market (global via AliExpress/Taobao)
+    form_factor:
+      value: board
+      detail: camera board sold ready to run
+      raw: board (camera board sold ready to run)
   confidence: high
   note: Open Apache-2.0 SDKs, public schematics/datasheets, and global retail availability, though the SG2002
     silicon itself is proprietary.
   raw: schematics:published (available via wiki/GitHub);toolchain:open (fully open (MaixPy/MaixCDK, Apache-2.0));datasheets:public
-    (public on wiki);blobs:required (SG2002 silicon proprietary);retail:open_market (global via AliExpress/Taobao)
+    (public on wiki);blobs:required (SG2002 silicon proprietary);retail:open_market (global via AliExpress/Taobao);form_factor:board
+    (camera board sold ready to run)
   last_verified: '2026-08-13'
   sources:
   - url: https://wiki.sipeed.com/hardware/en/maixcam/maixcam.html
@@ -40,6 +45,7 @@ openness:
     - datasheets
     - blobs
     - retail
+    - form_factor
     http_status: 200
     content_sha256: 98cfa748b6715a0a8eae56bb6520f503a18b33e43820f373258dd97469db62da
   - url: https://github.com/sipeed/MaixPy

--- a/sources/scores/ti-am67a.yaml
+++ b/sources/scores/ti-am67a.yaml
@@ -23,6 +23,10 @@ openness:
       value: distributor
       detail: active via TI and partners
       raw: distributor (active via TI and partners)
+    form_factor:
+      value: chipset
+      detail: edge-AI vision SoC, not a board
+      raw: chipset (edge-AI vision SoC, not a board)
   confidence: high
   note: Public datasheet and open SDK/TIDL tools on GitHub, commercially active, but proprietary silicon
     and firmware keep it short of fully open hardware. TI publishes the "AM67x Processors datasheet (Rev.
@@ -31,7 +35,7 @@ openness:
     repository.
   raw: schematics:partial (reference designs (BeagleY-AI board files open));toolchain:open (open SDK + TIDL
     tools + Edge AI Studio);datasheets:public (Rev B);blobs:required (proprietary silicon + TIDL firmware);retail:distributor
-    (active via TI and partners)
+    (active via TI and partners);form_factor:chipset (edge-AI vision SoC, not a board)
   last_verified: '2026-08-13'
   sources:
   - url: https://www.ti.com/product/AM67A
@@ -44,6 +48,7 @@ openness:
     - datasheets
     - blobs
     - retail
+    - form_factor
     http_status: 200
     content_sha256: 147b265e34a7b894413ce9cfc9883a4594de7d689d575a46948de2265eafaf9a
   - url: https://github.com/TexasInstruments/edgeai-tidl-tools

--- a/tests/test_check_parity.py
+++ b/tests/test_check_parity.py
@@ -243,7 +243,15 @@ def test_local_scores_matches_check_rubrics_split():
     # use_bounded, CC-BY-NC-4.0 onto commercial_forbidden - and all four closed, returning the
     # count to 5. Not one recorded score moved: every product they reach had been hand-placed at
     # exactly the value its tier computes. The measurement is in pretrained.yaml beside the names.
-    assert len(deferred) == 5
+    #
+    # 5 -> 4 on 2026-09-12, when `form_factor` landed and `edge_hardware`'s only deferral closed
+    # (#219). rockchip-rk3588 was not blocked on a license or on a missing fact: it is an
+    # application-processor SoC, and every rung the hardware ladder had turned on `schematics`,
+    # which a bare chipset has no answer to. The ladder now asks a chipset whether its datasheets
+    # are public and whether anybody can buy one, and never asks it about design files at all,
+    # and the product reproduces the 3/documented it already recorded. The remaining four are all license-tier gaps, three of them waiting on
+    # the same `unstated` ruling.
+    assert len(deferred) == 4
     # 517/5 -> 522/5 on 2026-08-30, when the first five products were promoted out of the
     # agent_tools_protocols tail registry: 5 products in, and no net change to the deferral
     # count. Two licenses the tiers plainly covered and could not name were ruled on that day -
@@ -311,12 +319,20 @@ def test_a_missing_row_fails(monkeypatch, capsys):
 # `ui_api` until 2026-08-12, when the second resolution batch took both to zero deferrals -
 # at which point one raised IndexError and the other passed while asserting "0 abstain on
 # both sides", which is the silent-narrowing failure this repo has already been bitten by
-# three times. `edge_hardware` holds the two deferrals least likely to close soon: one waits
-# on the form_factor taxonomy proposal (#219) and one on a direction for the whole hardware
-# ladder. Re-point them rather than loosening them if that stops being true.
+# three times. They then ran against `edge_hardware` until 2026-09-12, when #219 landed
+# `form_factor` and closed its only deferral, taking that category to zero the same way.
+# Re-pointed rather than loosened, as the note here already said to do.
+#
+# `benchmark_eval_data` is the choice now, and it is the least likely of the four remaining
+# to close soon: both livecodebench and multipl-e are blocked on a LADDER gap rather than on
+# an unread fact - an unstated license with no tier, and a BSD-3-with-ML-restriction this
+# ladder has no tier for - and closing either is a rubric change across the categories that
+# share the tier. Two deferrals also means `sorted(deferred)[0]` still picks a victim
+# deterministically without the list being a single item. Re-point them rather than loosening
+# them if that stops being true.
 def test_scoring_a_deferred_product_fails(monkeypatch, capsys):
     """The safeguards bug: a ladder ending in `otherwise` scoring what the repo declined."""
-    computed, deferred = local_scores("edge_hardware")
+    computed, deferred = local_scores("benchmark_eval_data")
     assert deferred, "pick a category that still defers something"
     published = {
         key: row(key[0], key[1], value[0], value[1], rule=0) for key, value in computed.items()
@@ -324,16 +340,16 @@ def test_scoring_a_deferred_product_fails(monkeypatch, capsys):
     published.update({key: row(key[0], key[1], deferred=True) for key in deferred})
     victim = sorted(deferred)[0]
     published[victim] = row(victim[0], victim[1], 3, "open_weights", deferred=False, rule=6)
-    assert run(monkeypatch, published, "edge_hardware") == 1
+    assert run(monkeypatch, published, "benchmark_eval_data") == 1
     assert "repo defers it, the warehouse does not know" in capsys.readouterr().out
 
 
 def test_a_shared_abstention_is_not_a_divergence(monkeypatch, capsys):
     """Both sides declining is a curation work list, not a parity failure."""
-    _, deferred = local_scores("edge_hardware")
+    _, deferred = local_scores("benchmark_eval_data")
     assert deferred, "pick a category that still defers something"
     published = {key: row(key[0], key[1], deferred=True) for key in deferred}
-    assert run(monkeypatch, published, "edge_hardware") == 1  # the scored products are missing
+    assert run(monkeypatch, published, "benchmark_eval_data") == 1  # the scored products are missing
     out = capsys.readouterr().out
     assert f"{len(deferred)} abstain on both sides" in out
 

--- a/tests/test_hardware_form_factor.py
+++ b/tests/test_hardware_form_factor.py
@@ -1,0 +1,105 @@
+"""The hardware ladder's form-factor routing, replayed against the real rubric.
+
+`sources/rubrics/hardware.yaml` asks two different sets of questions of two different
+kinds of thing: a board or a module is scored on whether its design files were published,
+a chipset on whether its documentation is public and whether anybody can buy one. The
+routing between them is the whole of #219, and it is the part that cannot be read off a
+reproduction count - every product on today's roster answers its own questions, so the
+category reproduces 20/20 whether or not a chipset is fenced off from the board rungs.
+
+What these replays pin is the fence. They build fact sets no product records, walk the
+REAL formula with them, and assert where each one lands. Putting the chipset rung above
+the board rungs and leaving the board rungs unguarded reads as routing and is not: first
+match wins means a chipset that fails its own rung meets a board's next, so a part whose
+datasheets sit behind a design win would collect 3/documented on somebody else's
+reference-board files.
+
+Falling off the ladder is the intended outcome for a chipset that fails, not a gap. The
+formula declares no `otherwise`, so a product the rungs do not decide abstains and the
+category defers it with a reason - which is the ladder saying it does not know, rather
+than a board's answer wearing a chipset's name.
+"""
+
+from pathlib import Path
+
+from build.check_rubric import score_openness
+from build.rubrics import load_shared
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def hardware_ladder():
+    return load_shared(ROOT)["hardware"]
+
+
+def landing(**components):
+    """Where the real hardware ladder puts one synthetic product."""
+    clauses = ";".join(f"{key}:{value}" for key, value in components.items())
+    outcome = score_openness(hardware_ladder(), {"components": clauses})
+    return outcome.result
+
+
+def test_a_chipset_whose_datasheets_are_gated_is_not_scored_from_board_files():
+    """The replay that failed review. `nda` misses the chipset rung; the design rungs
+    below it must not pick the product up on a reference design that is not its own."""
+    assert landing(
+        form_factor="chipset",
+        datasheets="nda",
+        schematics="partial",
+        toolchain="open",
+        retail="distributor",
+    ) is None
+
+
+def test_a_chipset_nobody_can_buy_is_not_documented():
+    """`documented` is defined by the category as datasheets public AND buyable. A
+    design-win part meets half of that, and half is not the class."""
+    assert landing(
+        form_factor="chipset",
+        datasheets="public",
+        schematics="published",
+        toolchain="open",
+        retail="restricted",
+    ) is None
+
+
+def test_a_withdrawn_chipset_is_not_scored_either():
+    """`discontinued` is a different fact from `restricted` and `retail` keeps them apart,
+    but the rung only asks whether anybody can buy one, and nobody can."""
+    assert landing(form_factor="chipset", datasheets="public", retail="discontinued") is None
+
+
+def test_a_chipset_that_answers_both_questions_scores():
+    """Public datasheets and a part on sale. No `schematics` anywhere in the fact set,
+    which is the point: this is the rung that let `rockchip-rk3588` off its deferral."""
+    assert landing(form_factor="chipset", datasheets="public", retail="distributor") == (3, "documented")
+
+
+def test_the_chipset_rung_does_not_read_the_toolchain():
+    """Deliberate, and pinned so that adding a toolchain condition has to argue with a
+    test. This category's vocabulary places a closed SDK inside `documented`, and the
+    Jetson modules record `toolchain: closed` and score 3 - so requiring an open SDK of a
+    chipset would score bare silicon below the module built on it."""
+    closed = landing(form_factor="chipset", datasheets="public", retail="distributor", toolchain="closed")
+    opened = landing(form_factor="chipset", datasheets="public", retail="distributor", toolchain="open")
+    assert closed == opened == (3, "documented")
+
+
+def test_a_board_still_climbs_the_design_rungs():
+    assert landing(
+        form_factor="board", schematics="published", toolchain="open"
+    ) == (4, "open_toolchain")
+
+
+def test_a_module_still_climbs_the_design_rungs():
+    """`schematics: none` on an M.2 card means withheld, which is an answer. The same
+    word on a chipset means there was never a board, which is not."""
+    assert landing(form_factor="module", schematics="none") == (3, "documented")
+    assert landing(form_factor="chipset", schematics="none") is None
+
+
+def test_a_hardware_product_recording_no_form_factor_abstains():
+    """A new product added without the call is not quietly scored as a board. The ladder
+    reports that it does not decide, and the category has to defer it or the curator has
+    to make the call - which is what a required routing dimension is for."""
+    assert landing(schematics="published", toolchain="open") is None

--- a/tests/test_serialize_rubric.py
+++ b/tests/test_serialize_rubric.py
@@ -698,11 +698,21 @@ def test_real_sources_serialize_without_errors(real_rubric):
     #
     # `edge_hardware` is the first HARDWARE category and the only ladder with no
     # `license_tier`. It was 6: 4 rungs, each a single condition on `schematics` except the
-    # two that also test `toolchain`. It is 7 since 2026-08-12, when a single-condition
+    # two that also test `toolchain`. It was 7 from 2026-08-12, when a single-condition
     # `accessory_host` rung was added at the top of the formula on the ruling that an
     # accessory tracks the platform it completes. It decides a different KIND of product
-    # rather than a better one - `raspberry-pi-ai-hat-plus` is a HAT, and the four rungs
+    # rather than a better one - `raspberry-pi-ai-hat-plus` is a HAT, and the rungs
     # below it all assume the thing being scored is a board.
+    #
+    # 9 -> 17 on 2026-09-12 (#219), when `form_factor` landed. Eight of those rows are the
+    # new chipset rung, which serializes as three (`form_factor`, `datasheets`,
+    # `availability`), plus one `board_design` row on each of the five rungs that turn on
+    # `schematics`: a bare SoC has no board design files, so those rungs answer about an
+    # artifact it does not have, and each now says so in its own conditions rather than
+    # relying on sitting below the chipset rung. First match wins, so position guards
+    # nothing - a chipset falling past its own rung would meet a board's next.
+    # No score moved; `rockchip-rk3588` stopped being deferred and `ti-am67a` and
+    # `nxp-imx-8m-plus` reach their unchanged 3/documented by the chipset rung.
     # Software is 13 since 2026-08-12, and `safeguards` 23, because `permissive_non_osi`
     # got a rung back. Three rows, not one: it tests `license_tier`, `source` and
     # `core_gated`, and a three-condition rung serializes as three. Note the shape of the
@@ -718,7 +728,7 @@ def test_real_sources_serialize_without_errors(real_rubric):
             ("base_pretrained", "finetuned_chat", "safeguards", "benchmark_eval_data",
              "training_synthetic_datasets", "edge_hardware")} == {
         "base_pretrained": 12, "finetuned_chat": 10, "safeguards": 23,
-        "benchmark_eval_data": 24, "training_synthetic_datasets": 24, "edge_hardware": 9,
+        "benchmark_eval_data": 24, "training_synthetic_datasets": 24, "edge_hardware": 17,
     }
     # Software categories inherit ONE ladder, so they must all serialize the same rule
     # count. Identical counts are the point: a category showing a different number means
@@ -960,8 +970,8 @@ def test_real_sources_serialize_without_errors(real_rubric):
         # six rows it now publishes include the `framework` and `note` keys it already carried.
         # The category now defers nothing.
         "safeguards": 123,
-        # 17 scored hardware products across the five recorded dimensions, less the keys
-        # individual products do not record. No license row among them, by design -
+        # 20 scored hardware products across the seven keys they record, read as nine
+        # declared dimensions, less the keys individual products do not record. No license row among them, by design -
         # `edge_hardware` is the only category whose ladder declares no `license_tier`.
         #
         # 83 -> 90 when raspberry-pi-ai-hat-plus's deferral closed on 2026-08-12. It had been
@@ -972,9 +982,20 @@ def test_real_sources_serialize_without_errors(real_rubric):
         # 90 -> 95 the same day when arduino-uno-q moved 3/documented to the 5/open_hardware
         # the ladder computes, on openly licensed CC-BY-SA 4.0 design files - the same
         # `schematics: open` as beagley-ai. Five rows, from none while deferred.
-        # rockchip-rk3588 stays deferred pending the form_factor proposal (#219) and so still
-        # publishes nothing, which is what holds the rise to the one product.
-        "edge_hardware": 95,
+        #
+        # 95 -> 158 on 2026-09-12 when `form_factor` landed (#219). Four movements in one
+        # number, and they are worth separating. Nineteen already-scored products each gained
+        # one `form_factor` row (+19). rockchip-rk3588's deferral closed, so it went from
+        # publishing nothing to publishing all five of its recorded keys (+5), the fifth being
+        # the `retail` this change records for it - the chipset rung asks whether anybody can
+        # buy one, and until now nothing in the file answered. Then two derived dimensions
+        # publish a row each wherever the key they read is recorded: `board_design` on all 20,
+        # `availability` on the 19 that record `retail`. 95 + 19 + 5 + 20 + 19 = 158.
+        #
+        # A derived dimension emits its own row because the warehouse joins a rule's
+        # condition_key against this column, and the rungs test `board_design`, not
+        # `form_factor`. The recorded key is not lost: it goes out under its own name too.
+        "edge_hardware": 158,
         # compilers and storage joined on 2026-08-18, promoted from the tail registry with 26
         # and 27 products. Both inherit the shared software ladder and both record the same three
         # dimensions per product, so the row count runs close to 4 x products, short of it because


### PR DESCRIPTION
## Summary

The hardware ladder turned every rung on `schematics` — "are the board design files published?" — and asked it of things that are not boards. This adds the `form_factor` dimension ruled for on 8 September and lets the ladder choose its questions before it asks them.

- **`form_factor`** (`board` / `module` / `chipset`) on the ladder and on all 20 products: 11 boards, 6 modules, 3 chipsets.
- **The board rungs are guarded.** All five `schematics` rungs require `board_design: exists`, so a chipset cannot fall through to them. Without the guard, `{chipset, datasheets: nda, schematics: partial}` returned 3/documented — a chipset scored from reference-board files.
- **`board_design` and `availability` are derived dimensions**, declared with `reads:` and `value_aliases:` rather than new recorded keys, which is the mechanism `software.yaml` already uses. Splitting each design rung into board and module variants would have created four rungs that can never fire, the defect `check_recipe` exists to catch.
- **Score-neutral for the 19 products that scored before**, verified by replaying the whole category. The only line that moves is `rockchip-rk3588`, from `ABSTAIN / deferred` to `3/documented` — which is the issue's deliverable.

## What review changed

The chipset rung asks two things: are the datasheets public, and can anybody buy one. Review found the second established, **for every chipset on the roster, by a page selling something else** — a Firefly module for `rockchip-rk3588`, a Toradex SoM for `nxp-imx-8m-plus`. That is the wrong-artifact inference this PR removes from `schematics`, re-entering through availability.

**The fix is to the claim, not the evidence.** `buyable` now says the silicon can be obtained commercially in the form it is sold in, and that for a chipset the module and board partners *are* the retail channel rather than a proxy for one. Read that way a partner listing is direct evidence, and each record's note says which channel was read.

The alternative — narrowing availability to the bare part — was rejected on cost and on truth. No re-fetchable citation for a bare i.MX 8M Plus exists: `nxp.com` 404s through `build.fetch_source` and Mouser serves a bot wall. So `nxp-imx-8m-plus` would have gone from 3/documented to deferred, `rockchip-rk3588` would have stayed deferred, and the chipset rung would fire for one product. Requiring a cut-tape listing would mark almost every SoC in the category ungated-and-unbuyable, which is the less true answer. `ti-am67a` is the one chipset whose own vendor page carries it: AM67A ACTIVE with an order path on ti.com, verified through the repo's own fetcher.

Also corrects a note on `google-coral-dev-board` claiming no rung reads `retail`. The chipset rung does now; the claim stays score-neutral there because it is a board.

Closes #219.

## Test plan

- `uv run pytest -q` → 2045 passed, 1 skipped
- `uv run python -m build.validate` → 0 errors; `check_recipe` 0 failures; `check_rubric` and `check_components` clean
- `check_parity` needs `OSO_API_KEY`, a maintainer step here as in CI
- Score/class replay of the whole `edge_hardware` category, before and after, is a single changed line
- Codex reviewed three times: it caught the unguarded board rungs, then the availability inference, and passes on the current head
