### PR TITLE
Confirm a source on the quoted fragments inside shows, not on the sentence around them

### DIFF
--- a/build/reverify.py
+++ b/build/reverify.py
@@ -4,9 +4,11 @@ What it does: for each of the N oldest products (by the oldest of its three axis
 ties broken by slug), re-fetch every digested source that `establishes` a recorded
 dimension on the selected axes through build.fetch_source. A dimension re-confirms when
 every establishing source's fresh fetch is non-transient and either (a) the body is
-byte-identical to what was recorded, (b) the source's recorded `shows` excerpt still
-occurs in the fresh body, or (c) for a GitHub license API / repo endpoint or a Hugging
-Face model-info source, the fresh SPDX id normalizes to the same license already recorded.
+byte-identical to what was recorded, (b) the source's recorded `shows` still checks out
+against the fresh body — the whole sentence occurs, or every fragment quoted inside it
+does and at least one of those is long enough to discriminate — or (c) for a GitHub
+license API / repo endpoint or a Hugging Face model-info source, the fresh SPDX id
+normalizes to the same license already recorded.
 Whichever path confirms it, the source takes the new `accessed`, `http_status` and
 `content_sha256`, and once every dimension an axis records has confirmed, that axis's
 `last_verified` is stamped to today. Any drift, any transient result, or any dimension
@@ -26,6 +28,12 @@ by default (--axes openness). Ruled again 2026-09-03 (#445 follow-up): shows-mat
 SPDX comparison are also acceptable confirmations, since byte identity is the wrong test
 for evidence pages that legitimately re-render on every load. See
 docs/reference/evidence-and-freshness.md.
+
+Shows-match tests the quoted fragments as well as the whole sentence, because `shows` is
+written as a curator's sentence *about* the page with the verbatim material quoted inside
+it, and such a sentence never occurs on the page it describes. Measured 2026-09-12 over
+the 25 oldest products: 72 sources drifted, 0 were skipped, 0 carried a placeholder
+`shows`, and whole-sentence match confirmed 4 of them. See `_fragments_confirm`.
 """
 from __future__ import annotations
 
@@ -214,15 +222,90 @@ def _read_body(fetched: dict) -> str | None:
     return html.unescape(raw.decode("utf-8", errors="replace"))
 
 
+# The corpus quotes with both straight and curly double quotes, sometimes in one
+# sentence, so the delimiters are folded together before the pair scan.
+_SMART_DOUBLE_QUOTES = "\u201c\u201d\u201e\u201f\u2033"
+
+# A quoted fragment shorter than this does not count toward a confirmation. Chosen off
+# the corpus rather than by taste: of the 1,714 fragments quoted inside a `shows` today,
+# the 563 below 24 characters are almost entirely JSON key names and license ids —
+# `license`, `name`, `spdx_id`, `MIT`, `Apache-2.0`, `open_issues_count` — and one- or
+# two-word English like `gated`, `open source`, `Enterprise`. Those occur on any page of
+# the kind being cited, so finding one discriminates nothing. 426 of the 563 are one or
+# two words, and at 24 characters only 5 of the 1,151 surviving fragments are that short
+# (they are file paths, `surfsense_backend/app/proprietary/LICENSE` and the like). At a
+# floor of 20 characters, 93 two-word fragments still qualify; at 24, two do. A two-word
+# quote found somewhere on a page proves nothing, and 24 is where the corpus stops
+# offering them.
+MIN_FRAGMENT_CHARS = 24
+
+
+def _shows_fragments(shows: str) -> list[str]:
+    """The verbatim material quoted inside a curator's `shows` sentence.
+
+    A plain double-quote pair scan: split the whitespace-normalized sentence on `"` and
+    the odd-indexed segments are the insides of the pairs. An unbalanced trailing quote
+    opens a pair that never closes, and that dangling segment is dropped rather than
+    guessed at. Nested quotes are not parsed as nesting — the scan just pairs off
+    quotes in order, which is what a curator writing `"license":{"spdxId":"MIT"}` inside
+    a sentence actually means.
+
+    Fragments are matched with `in` and are never compiled, so a regex metacharacter, a
+    bracket or a bare URL inside one is only ever text.
+    """
+    text = _normalize_text(str(shows))
+    for ch in _SMART_DOUBLE_QUOTES:
+        text = text.replace(ch, '"')
+    parts = text.split('"')
+    pairs = (len(parts) - 1) // 2
+    return [f for f in (p.strip() for p in parts[1::2][:pairs]) if f]
+
+
+def _fragments_confirm(shows: str, body: str) -> bool:
+    """Every fragment quoted inside `shows` still occurs in `body`, and at least one of
+    them is long enough to mean something. `body` is already normalized.
+
+    Both halves carry weight, and dropping either one breaks it in a different
+    direction. **Every** is what stops a partial match being read as a confirmation: a
+    `shows` that quotes nine things and finds two of them on the page has not been
+    confirmed; seven of the things it says the page carries are not on the page. **At least one long fragment** is
+    what stops the opposite failure, where a `shows` whose only quoted material is
+    `"license"` and `"MIT"` would confirm against any GitHub API response ever served.
+    A short fragment still has to be there; it just cannot be the thing that earns the
+    date. A `shows` that quotes nothing at all has no long fragment and so never reaches
+    this path — saying less must not make a source easier to confirm.
+    """
+    fragments = _shows_fragments(shows)
+    if not any(len(f) >= MIN_FRAGMENT_CHARS for f in fragments):
+        return False
+    return all(f in body for f in fragments)
+
+
 def _shows_confirms(src: dict, fetched: dict) -> bool:
-    """The source's recorded `shows` excerpt still occurs in the fresh body."""
+    """The source's recorded `shows` still checks out against the fresh body.
+
+    Two ways, under one normalization (whitespace collapsed, the body read through
+    `html.unescape`). The whole sentence may occur verbatim, which is the original test
+    and is unchanged. Otherwise the fragments quoted inside it must all occur.
+
+    The second path exists because `shows` is almost never an excerpt. It is a curator's
+    sentence *about* the page with the verbatim material quoted inside it — "repo page
+    carries the label "Public archive" and the banner "This repository was archived..."" —
+    and a sentence like that does not appear on the page it describes, so testing the
+    whole of it tests the curator's prose rather than the evidence. Measured 2026-09-12
+    over the 25 oldest products through `build.fetch_source`: 72 sources drifted, none
+    skipped, none carrying a placeholder `shows`, and the whole-sentence path confirmed 4.
+    """
     shows = src.get("shows")
     if not shows or _is_placeholder_shows(shows):
         return False
     body = _read_body(fetched)
     if body is None:
         return False
-    return _normalize_text(str(shows)) in _normalize_text(body)
+    body = _normalize_text(body)
+    if _normalize_text(str(shows)) in body:
+        return True
+    return _fragments_confirm(str(shows), body)
 
 
 def _spdx_confirms(url: str, fetched: dict, recorded_license: str) -> bool:

--- a/build/reverify.py
+++ b/build/reverify.py
@@ -268,12 +268,12 @@ def _fragments_confirm(shows: str, body: str) -> bool:
     Both halves carry weight, and dropping either one breaks it in a different
     direction. **Every** is what stops a partial match being read as a confirmation: a
     `shows` that quotes nine things and finds two of them on the page has not been
-    confirmed; seven of the things it says the page carries are not on the page. **At least one long fragment** is
-    what stops the opposite failure, where a `shows` whose only quoted material is
-    `"license"` and `"MIT"` would confirm against any GitHub API response ever served.
-    A short fragment still has to be there; it just cannot be the thing that earns the
-    date. A `shows` that quotes nothing at all has no long fragment and so never reaches
-    this path — saying less must not make a source easier to confirm.
+    confirmed; seven of the things it says the page carries are not on the page.
+    **At least one long fragment** stops the opposite failure, where a `shows` whose
+    only quoted material is `"license"` and `"MIT"` would confirm against any GitHub API
+    response ever served. A short fragment still has to be there; it just cannot be the
+    thing that earns the date. A `shows` that quotes nothing at all has no long fragment,
+    so it never reaches this path: saying less must not make a source easier to confirm.
     """
     fragments = _shows_fragments(shows)
     if not any(len(f) >= MIN_FRAGMENT_CHARS for f in fragments):

--- a/build/reverify.py
+++ b/build/reverify.py
@@ -240,15 +240,23 @@ _SMART_DOUBLE_QUOTES = "\u201c\u201d\u201e\u201f\u2033"
 MIN_FRAGMENT_CHARS = 24
 
 
-def _shows_fragments(shows: str) -> list[str]:
-    """The verbatim material quoted inside a curator's `shows` sentence.
+def _shows_fragments(shows: str) -> list[str] | None:
+    """The verbatim material quoted inside a curator's `shows` sentence, or None when the
+    quote delimiters do not pair off.
 
     A plain double-quote pair scan: split the whitespace-normalized sentence on `"` and
-    the odd-indexed segments are the insides of the pairs. An unbalanced trailing quote
-    opens a pair that never closes, and that dangling segment is dropped rather than
-    guessed at. Nested quotes are not parsed as nesting — the scan just pairs off
-    quotes in order, which is what a curator writing `"license":{"spdxId":"MIT"}` inside
-    a sentence actually means.
+    the odd-indexed segments are the insides of the pairs. Nested quotes are not parsed as
+    nesting — the scan just pairs off quotes in order, which is what a curator writing
+    `"license":{"spdxId":"MIT"}` inside a sentence actually means.
+
+    An odd number of delimiters is refused outright rather than repaired. The last quote
+    opens a claim that never closes, so the material the curator says the page carries
+    cannot be read out of the sentence at all — and dropping that dangling segment would
+    confirm the source on a strict subset of what it claims, which is the same rubber
+    stamp as a partial match reached through a typo. `... the banner reads "Archived` would
+    otherwise be re-dated by a page with no archive banner anywhere on it. The sentence is
+    ambiguous, a confirmation is not allowed to be, so the fragment path declines and the
+    source drifts to the agent leg where a person can read it.
 
     Fragments are matched with `in` and are never compiled, so a regex metacharacter, a
     bracket or a bare URL inside one is only ever text.
@@ -257,8 +265,9 @@ def _shows_fragments(shows: str) -> list[str]:
     for ch in _SMART_DOUBLE_QUOTES:
         text = text.replace(ch, '"')
     parts = text.split('"')
-    pairs = (len(parts) - 1) // 2
-    return [f for f in (p.strip() for p in parts[1::2][:pairs]) if f]
+    if len(parts) % 2 == 0:  # an odd number of `"` — some quoted claim has no end
+        return None
+    return [f for f in (p.strip() for p in parts[1::2]) if f]
 
 
 def _fragments_confirm(shows: str, body: str) -> bool:
@@ -274,8 +283,12 @@ def _fragments_confirm(shows: str, body: str) -> bool:
     response ever served. A short fragment still has to be there; it just cannot be the
     thing that earns the date. A `shows` that quotes nothing at all has no long fragment,
     so it never reaches this path: saying less must not make a source easier to confirm.
+    A sentence whose quotes do not pair off yields no fragments at all and is refused for
+    the same reason — see `_shows_fragments`.
     """
     fragments = _shows_fragments(shows)
+    if fragments is None:
+        return False
     if not any(len(f) >= MIN_FRAGMENT_CHARS for f in fragments):
         return False
     return all(f in body for f in fragments)

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -477,8 +477,10 @@ ids — `license`, `spdx_id`, `MIT` — which occur on every page of the kind be
 prove nothing; a short fragment must still be present, it simply cannot be what earns the
 date. A `shows` that quotes nothing keeps the whole-sentence test and nothing else, so saying
 less never makes a source easier to confirm. Measured on 2026-09-12 across the 25 oldest
-products, 72 sources drifted and whole-sentence match confirmed 4 of them. A new verification date records a successful re-evaluation on that
-date, not a claim that the fact was established or the source changed then. Ruling on #445
+products, 72 sources drifted and whole-sentence match confirmed 4 of them.
+
+A new verification date records a successful re-evaluation on that date, not a claim that the
+fact was established or the source changed then. Ruling on #445
 (2026-09): a byte-identical re-fetch confirms an openness dimension; adoption and
 capability are excluded from machine re-dating because their sources carry numbers that
 move. Their re-verification stays with the agent leg in `refresh-category`. Ruled again

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -446,7 +446,7 @@ of the gate's rule — it calls `build.check_verification.recorded_dimensions` d
 non-evidence key like `free_text` is never treated as requiring one.
 
 A source confirms one of three ways: the body is byte-identical (same `content_sha256`); the
-source's recorded `shows` excerpt still occurs in the fresh body, after both sides are
+source's recorded `shows` still checks out against the fresh body, after both sides are
 whitespace-normalized and the body is tried through `html.unescape` (a placeholder `shows` —
 see `check_verification.placeholder_shows` — never confirms this way); or, for a source
 answering the `license` dimension from a GitHub license/repo API or a Hugging Face
@@ -457,7 +457,27 @@ confirms it, the source is rewritten with the fetch's actual `http_status` and i
 `content_sha256` — a shows match records that the page still says what the source was cited
 for; the new digest is recorded so the next re-check compares against what was actually
 read. It never derives a date, never records a transient fetch, and never touches an axis
-whose evidence changed. A new verification date records a successful re-evaluation on that
+whose evidence changed.
+
+**What "the `shows` still checks out" means, and why it is not the whole sentence.** A
+`shows` is only occasionally an excerpt. Far more often it is a curator's sentence *about*
+the page with the verbatim material quoted inside it — *repo page carries the label "Public
+archive" and the banner "This repository was archived by the owner on Jul 4, 2026"* — and a
+sentence of that shape never occurs on the page it describes. Testing the whole of it tests
+the curator's prose. So the whole sentence is tried first and still confirms where it fires,
+and failing that the **quoted fragments** are tried: every fragment quoted inside the `shows`
+must occur in the fresh body, and at least one of them must be at least
+`reverify.MIN_FRAGMENT_CHARS` (24) characters long.
+
+Both conditions are load-bearing. *Every* fragment, because a `shows` that quotes nine things
+and finds two of them has been contradicted rather than confirmed, and "at least one matched"
+is the rubber stamp this whole apparatus exists to prevent. *At least one long fragment*,
+because the short quoted material in this corpus is overwhelmingly JSON key names and license
+ids — `license`, `spdx_id`, `MIT` — which occur on every page of the kind being cited and so
+prove nothing; a short fragment must still be present, it simply cannot be what earns the
+date. A `shows` that quotes nothing keeps the whole-sentence test and nothing else, so saying
+less never makes a source easier to confirm. Measured on 2026-09-12 across the 25 oldest
+products, 72 sources drifted and whole-sentence match confirmed 4 of them. A new verification date records a successful re-evaluation on that
 date, not a claim that the fact was established or the source changed then. Ruling on #445
 (2026-09): a byte-identical re-fetch confirms an openness dimension; adoption and
 capability are excluded from machine re-dating because their sources carry numbers that

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -479,6 +479,12 @@ date. A `shows` that quotes nothing keeps the whole-sentence test and nothing el
 less never makes a source easier to confirm. Measured on 2026-09-12 across the 25 oldest
 products, 72 sources drifted and whole-sentence match confirmed 4 of them.
 
+A sentence whose quote marks do not pair off gets no fragment test at all. The unclosed quote
+opens a claim whose text cannot be recovered — *the banner reads "Archived* — and confirming on
+the fragments that did close would re-date the source on a strict subset of what it claims,
+against a page that need not carry the missing claim anywhere. It keeps the whole-sentence test
+and otherwise drifts to the agent leg, where a person can read both the sentence and the page.
+
 A new verification date records a successful re-evaluation on that date, not a claim that the
 fact was established or the source changed then. Ruling on #445
 (2026-09): a byte-identical re-fetch confirms an openness dimension; adoption and

--- a/tests/test_reverify.py
+++ b/tests/test_reverify.py
@@ -331,3 +331,188 @@ def test_apply_refuses_a_confirmation_whose_citation_changed_underneath_it(tmp_p
     # loop was already edited in memory, so the whole file has to be byte-identical —
     # not merely unstamped.
     assert path.read_text() == before
+
+
+# --- The quoted fragments inside a `shows`, not the whole curator's sentence -----------
+#
+# `shows` is written as a sentence ABOUT the page with the verbatim material quoted inside
+# it, so the whole-sentence test tests the curator's prose. Measured 2026-09-12 over the 25
+# oldest products: 72 sources drifted, 0 skipped, 0 placeholder, whole-sentence confirmed 4.
+
+
+_ATROPOS_SHOWS = (
+    'Repo page carries the label "Public archive" and the banner "This repository was '
+    'archived by the owner on Jul 4, 2026. It is now read-only." The rendered README says '
+    '"Atropos is an environment microservice framework for async RL with LLMs." and its '
+    'Navigating the Repo table lists "Core library containing base classes and utilities" '
+    'and "Collection of ready-to-use RL environments"; installation is '
+    '"pip install atroposlib".'
+)
+
+
+def _shows_case(tmp_path, shows, body_text, name="page.html"):
+    # A fresh corpus root per call, so one test can run two cases over one tmp_path.
+    root_dir = tmp_path / f"case-{name}"
+    root_dir.mkdir()
+    body_path = _body(root_dir, name, body_text)
+    root = _score_with_sources(root_dir, [_src("https://a/LICENSE", "a" * 64, ["license"],
+                                                shows=shows)], dims=("license",))
+    fake = lambda url, **kw: {"url": url, "http_status": 200, "content_sha256": "b" * 64,  # noqa: E731
+                              "body_path": str(body_path)}
+    return reverify.reverify_product(root, "p", date(2026, 9, 12), axes=("openness",), fetch=fake)
+
+
+def test_every_quoted_fragment_present_confirms_a_sentence_that_never_occurs(tmp_path):
+    """The shape this change exists for: the curator's sentence is nowhere on the page, and
+    every piece of verbatim material quoted inside it is."""
+    body = (
+        "<h1>NousResearch/atropos</h1><span>Public archive</span>"
+        "<div>This repository was archived by the owner on Jul 4, 2026. It is now read-only.</div>"
+        "<p>Atropos is an environment microservice framework for async RL with LLMs.</p>"
+        "<td>Core library containing base classes and utilities</td>"
+        "<td>Collection of ready-to-use RL environments</td>"
+        "<code>pip install atroposlib</code>"
+    )
+    result = _shows_case(tmp_path, _ATROPOS_SHOWS, body)
+    assert result.stamped == ["openness"]
+    assert result.reconfirmed_by_shows == [("openness", "https://a/LICENSE")]
+    assert result.drifted == []
+
+
+def test_a_partial_fragment_match_still_drifts(tmp_path):
+    """The atropos shape that must NOT confirm. Two of the quoted fragments are on the page
+    and the rest are gone; "at least one matched" is exactly the rubber stamp this leg
+    exists to refuse."""
+    body = (
+        "<h1>NousResearch/atropos</h1><span>Public archive</span>"
+        "<p>Atropos is an environment microservice framework for async RL with LLMs.</p>"
+        "<p>The README has been rewritten and the tables are gone.</p>"
+    )
+    result = _shows_case(tmp_path, _ATROPOS_SHOWS, body)
+    assert result.stamped == []
+    assert result.drifted == [("openness", "https://a/LICENSE")]
+
+
+def test_a_shows_that_quotes_nothing_is_unchanged(tmp_path):
+    """No quoted fragment means no fragment path, so the whole-sentence test is the only
+    one available. Saying less must not make a source easier to confirm."""
+    absent = _shows_case(
+        tmp_path, "the repo page still describes an archived public MIT project",
+        "<p>An archived public MIT project, described in quite different words.</p>")
+    assert absent.stamped == []
+    assert absent.drifted == [("openness", "https://a/LICENSE")]
+
+    present = _shows_case(
+        tmp_path, "the repo page still describes an archived public MIT project",
+        "<p>Preamble. the repo page still describes an archived public MIT project.</p>",
+        name="present.html")
+    assert present.stamped == ["openness"]
+    assert present.reconfirmed_by_shows == [("openness", "https://a/LICENSE")]
+
+
+def test_a_placeholder_shows_never_confirms_on_fragments_either(tmp_path):
+    marker = next(iter(PLACEHOLDER_SHOWS))
+    shows = f'{marker}: the page carries "Licensed under the Apache License, Version 2.0".'
+    body = f"<p>{marker}</p><p>Licensed under the Apache License, Version 2.0</p>"
+    result = _shows_case(tmp_path, shows, body)
+    assert result.stamped == []
+    assert result.drifted == [("openness", "https://a/LICENSE")]
+
+
+def test_fragments_below_the_length_floor_do_not_earn_a_date(tmp_path):
+    """A `shows` whose only quoted material is a JSON key and a license id would otherwise
+    confirm against any GitHub API response ever served."""
+    shows = 'Repository JSON reads "license": "MIT" and "private": false.'
+    body = '{"license": "MIT", "private": false, "name": "something else entirely"}'
+    assert all(len(f) < reverify.MIN_FRAGMENT_CHARS
+               for f in reverify._shows_fragments(shows)), "the fixture must stay short"
+    result = _shows_case(tmp_path, shows, body)
+    assert result.stamped == []
+    assert result.drifted == [("openness", "https://a/LICENSE")]
+
+
+def test_the_atropos_api_citation_does_not_confirm_on_json_key_names(tmp_path):
+    """The measured counter-example, and the reason `atropos` still drifts on 2026-09-12.
+
+    Every fragment quoted inside this `shows` does occur in the fresh response — they are
+    the keys and values of a GitHub repository payload, and they occur in every such
+    payload ever served. None of them reaches the length floor, so there is nothing here
+    that could earn a date, and the axis is left alone."""
+    shows = ('Repository JSON: "private": false, "visibility": "public", "archived": true, '
+             '"disabled": false, "spdx_id": "MIT", "pushed_at": "2026-07-04T17:39:01Z", '
+             '"open_issues_count": 0, default_branch main, created 2025-04-29.')
+    body = ('{"private": false, "visibility": "public", "archived": true, "disabled": false, '
+            '"spdx_id": "MIT", "pushed_at": "2026-07-04T17:39:01Z", "open_issues_count": 0}')
+    fragments = reverify._shows_fragments(shows)
+    assert len(fragments) == 10 and all(f in " ".join(body.split()) for f in fragments), (
+        "every fragment is on the page; the floor is the only thing refusing this")
+    assert max(len(f) for f in fragments) < reverify.MIN_FRAGMENT_CHARS
+    result = _shows_case(tmp_path, shows, body)
+    assert result.stamped == []
+    assert result.drifted == [("openness", "https://a/LICENSE")]
+
+
+def test_a_short_fragment_still_has_to_be_present(tmp_path):
+    """Too short to earn the date is not the same as ignored. The long fragment is on the
+    page; the short one it is quoted beside is not."""
+    shows = ('The model card says "Released under the Apache 2.0 License." '
+             'and the header reads "MIT".')
+    body = "<p>Released under the Apache 2.0 License.</p>"
+    result = _shows_case(tmp_path, shows, body)
+    assert result.stamped == []
+    assert result.drifted == [("openness", "https://a/LICENSE")]
+
+
+def test_curly_quotes_delimit_a_fragment(tmp_path):
+    shows = "The pricing page says “Comes bundled with your subscription” today."
+    body = "<li>Comes bundled with your subscription</li>"
+    assert reverify._shows_fragments(shows) == ["Comes bundled with your subscription"]
+    result = _shows_case(tmp_path, shows, body)
+    assert result.stamped == ["openness"]
+    assert result.reconfirmed_by_shows == [("openness", "https://a/LICENSE")]
+
+
+def test_a_regex_metacharacter_in_a_fragment_is_matched_literally(tmp_path):
+    """`.*` and the brackets are text. Compiled as a pattern the fragment would match
+    almost anything; as a substring it matches only itself."""
+    shows = ('The pyproject line reads '
+             '"license = {text = \'MIT\'}  # (.*|[a-z]+) is not a pattern here" verbatim.')
+    assert reverify._shows_fragments(shows) == [
+        "license = {text = 'MIT'} # (.*|[a-z]+) is not a pattern here"]
+    hit = _shows_case(
+        tmp_path, shows,
+        "<pre>license = {text = 'MIT'}  # (.*|[a-z]+) is not a pattern here</pre>")
+    assert hit.stamped == ["openness"]
+    miss = _shows_case(tmp_path, shows,
+                       "<pre>anything at all, which a compiled pattern would match</pre>",
+                       name="miss.html")
+    assert miss.stamped == []
+    assert miss.drifted == [("openness", "https://a/LICENSE")]
+
+
+def test_an_unbalanced_trailing_quote_opens_no_fragment(tmp_path):
+    shows = ('The README still opens "A composable training library for large models" '
+             'and the banner reads "Archived')
+    assert reverify._shows_fragments(shows) == [
+        "A composable training library for large models"]
+    result = _shows_case(
+        tmp_path, shows, "<p>A composable training library for large models</p>")
+    assert result.stamped == ["openness"]
+
+
+def test_a_url_inside_a_fragment_is_just_text(tmp_path):
+    shows = ('The notice points at "https://example.org/license?v=2&t=1 (see terms)" '
+             'for the full text.')
+    assert reverify._shows_fragments(shows) == [
+        "https://example.org/license?v=2&t=1 (see terms)"]
+    result = _shows_case(
+        tmp_path, shows,
+        "<a>https://example.org/license?v=2&amp;t=1 (see terms)</a>")
+    assert result.stamped == ["openness"], "the body is unescaped before matching"
+
+
+def test_fragments_are_matched_after_the_same_whitespace_collapse(tmp_path):
+    shows = 'The page carries "Deploy leading open source tools and AI models with confidence".'
+    body = ("<p>Deploy leading open source\n   tools and AI models\twith confidence</p>")
+    result = _shows_case(tmp_path, shows, body)
+    assert result.stamped == ["openness"]

--- a/tests/test_reverify.py
+++ b/tests/test_reverify.py
@@ -490,14 +490,28 @@ def test_a_regex_metacharacter_in_a_fragment_is_matched_literally(tmp_path):
     assert miss.drifted == [("openness", "https://a/LICENSE")]
 
 
-def test_an_unbalanced_trailing_quote_opens_no_fragment(tmp_path):
+def test_an_unbalanced_quote_refuses_the_fragment_path(tmp_path):
+    """The dangling claim is the one that matters, and it cannot be read out of the
+    sentence. Pairing off what is left and confirming on that would re-date this source
+    against a page carrying no archive banner at all — a partial match reached through a
+    typo. So the fragment path declines and the source goes to the agent leg."""
     shows = ('The README still opens "A composable training library for large models" '
              'and the banner reads "Archived')
-    assert reverify._shows_fragments(shows) == [
-        "A composable training library for large models"]
+    assert reverify._shows_fragments(shows) is None
     result = _shows_case(
         tmp_path, shows, "<p>A composable training library for large models</p>")
+    assert result.stamped == []
+    assert result.drifted == [("openness", "https://a/LICENSE")]
+
+
+def test_an_unbalanced_quote_still_confirms_on_the_whole_sentence(tmp_path):
+    """Refusing the fragment path is not refusing the source. If the curator's sentence
+    does occur verbatim, the original test fires exactly as it did before."""
+    shows = ('The README still opens "A composable training library for large models" '
+             'and the banner reads "Archived')
+    result = _shows_case(tmp_path, shows, f"<p>Preamble. {shows}</p>")
     assert result.stamped == ["openness"]
+    assert result.reconfirmed_by_shows == [("openness", "https://a/LICENSE")]
 
 
 def test_a_url_inside_a_fragment_is_just_text(tmp_path):


### PR DESCRIPTION
# shows-match-fragments — pass

**Goal.** The deterministic re-verification leg re-dates about one product in twenty-five. Measured on

## Success criteria
- [ ] `build/reverify.py`'s shows-match confirms when **every** quoted fragment inside the recorded `shows` occurs in the fresh body, under the same normalization the whole-sentence path uses (whitespace-collapsed, `html.unescape` tried); the existing whole-sentence match keeps working where it already fires
- [ ] a `shows` with **no** quoted fragment is unchanged in behaviour — it can still only confirm by whole-sentence match, so nothing becomes easier to confirm by having said less
- [ ] a placeholder `shows` still never confirms, by either path
- [ ] **partial fragment matches never confirm.** The measured counter-example is `atropos`, whose `shows` carries nine fragments of which two occur; it must still drift. A rule that accepted "at least one" would confirm it, and that is the rubber stamp this apparatus exists to stop
- [ ] a fragment shorter than a stated minimum length does not count toward confirmation, and the threshold is defended in the PR — a two-word quote occurring somewhere on a page proves nothing
- [ ] the before/after effect is **measured, not asserted**: run `uv run python -m build.reverify --limit 25 --pace 1.5 --dry-run --report <path>` on `main` and on the branch over the same slugs, and quote both reason counts (`reconfirmed_by_shows`, `drifted`, `transient`, `skipped`) in the PR body
- [ ] no file under `sources/` changes. `--dry-run` writes nothing; the deliverable is the matcher
- [ ] `uv run python -m build.validate` reports 0 errors and `uv run pytest -q` passes

## Outcome
`pass` after 2 round(s). Branch `loop/shows-match-fragments-2026-09-12-a1`.

## Final verdict
```json
{
 "verdict": "pass",
 "blocking": [],
 "non_blocking": [],
 "settled_now": [
  "The round 1 blocker is fixed: unbalanced quotes refuse fragment confirmation while preserving whole-sentence matching. Six isolated matcher checks passed.",
  "The reported before/after measurements and validation results satisfy the requested checks; the full diff contains no sources/ changes."
 ],
 "escalation": null
}
```

## Settled ground this run added (9)
- The three confirmation paths and their terms. This changes how one of them matches, not what
- A placeholder `shows` never confirms.
- Machine re-dating stays limited to openness.
- No score file changes in this PR.
- Short fragments must all occur, with at least one fragment meeting the 24-character floor.
- Presence is sufficient; fragment ordering need not be imposed.
- The live atropos fragment counts can differ from the earlier probe; partial-match refusal remains independently testable.
- The round 1 blocker is fixed: unbalanced quotes refuse fragment confirmation while preserving whole-sentence matching. Six isolated matcher checks passed.
- The reported before/after measurements and validation results satisfy the requested checks; the full diff contains no sources/ changes.

Later runs of this job inherit `/workspace/GitHub/personal/agent-loops/jobs/settled/shows-match-fragments.json`; prune it there.

_Opened by build-review-loop; builder notes in the first comment._
