### PR TITLE
Enforce the machine re-dating axis limit

### DIFF
--- a/build/reverify.py
+++ b/build/reverify.py
@@ -423,6 +423,35 @@ def apply(root: Path, slug: str, result: ProductResult, today: date) -> None:
         path.write_text(text)
 
 
+#: The only axis a machine may re-date, ruled 2026-09 (#445). Adoption and capability cite
+#: numbers that move, so an unchanged body there confirms that a figure is STALE rather than
+#: that a fact has held — the opposite of what a confirmation claims.
+MACHINE_REDATABLE_AXES = ("openness",)
+
+
+def axes_refusal(axes: tuple[str, ...]) -> str | None:
+    """Why `--axes` may not be honoured, or None.
+
+    The #445 limit was documented and enforced nowhere: `--axes` took any string, so
+    `--axes capability` would have re-dated capability against the ruling, and `--axes opennes`
+    would have planned nothing at all and reported a clean run over zero dimensions. A limit
+    that lives only in prose and in how a workflow happens to invoke the tool is not a limit.
+    """
+    if not axes:
+        return "--axes is empty; pass at least one axis"
+    unknown = [a for a in axes if a not in _axes()]
+    if unknown:
+        return (f"--axes names {', '.join(sorted(unknown))}, which is not an axis. "
+                f"Known axes: {', '.join(_axes())}")
+    refused = [a for a in axes if a not in MACHINE_REDATABLE_AXES]
+    if refused:
+        return (f"--axes names {', '.join(sorted(refused))}. Machine re-dating is limited to "
+                f"{', '.join(MACHINE_REDATABLE_AXES)} by the #445 ruling: adoption and capability "
+                f"cite numbers that move, so an unchanged body confirms a stale figure rather "
+                f"than a held fact. Re-verify those through the agent leg (refresh-category).")
+    return None
+
+
 def main(argv: list[str] | None = None, root: Path | None = None) -> int:
     root = root or ROOT
     p = argparse.ArgumentParser(description=__doc__)
@@ -437,6 +466,10 @@ def main(argv: list[str] | None = None, root: Path | None = None) -> int:
     args = p.parse_args(argv)
     today = parse_date(args.today) if args.today else date.today()
     axes = tuple(a.strip() for a in args.axes.split(",") if a.strip())
+    refusal = axes_refusal(axes)
+    if refusal:
+        print(f"[FAIL] {refusal}", file=sys.stderr)
+        return 2
     body_dir = args.body_dir or Path(tempfile.mkdtemp(prefix="os-ai-map-reverify-"))
 
     report = {"today": today.isoformat(), "axes": axes, "products": []}

--- a/build/reverify.py
+++ b/build/reverify.py
@@ -353,6 +353,9 @@ def _spdx_confirms(url: str, fetched: dict, recorded_license: str) -> bool:
 def reverify_product(root: Path, slug: str, today: date, axes: tuple[str, ...] = ("openness",),
                      fetch=_fetch, pace: float = 0.0, sleep=time.sleep,
                      body_dir: Path | None = None) -> ProductResult:
+    refusal = axes_refusal(tuple(axes))
+    if refusal:
+        raise ValueError(refusal)
     score = _score(root, slug)
     result = ProductResult(slug=slug)
     cache: dict[str, dict] = {}
@@ -406,6 +409,17 @@ def reverify_product(root: Path, slug: str, today: date, axes: tuple[str, ...] =
 
 
 def apply(root: Path, slug: str, result: ProductResult, today: date) -> None:
+    """Write the confirmations and the new dates.
+
+    The policy check is repeated HERE, not only where axes are chosen, because this is the
+    function that writes `last_verified`. A caller that assembled a `ProductResult` by some
+    other route — a hand-built result, a future planner — would otherwise reach the write with
+    no check between it and the field. Binding the guard to the write is the same doctrine the
+    merge interlock uses: check the thing you are about to do, where you do it.
+    """
+    stamped_refusal = axes_refusal(tuple(result.stamped))
+    if result.stamped and stamped_refusal:
+        raise ValueError(stamped_refusal)
     path = root / "sources" / "scores" / f"{slug}.yaml"
     text = path.read_text()
     for axis in result.stamped:
@@ -424,8 +438,9 @@ def apply(root: Path, slug: str, result: ProductResult, today: date) -> None:
 
 
 #: The only axis a machine may re-date, ruled 2026-09 (#445). Adoption and capability cite
-#: numbers that move, so an unchanged body there confirms that a figure is STALE rather than
-#: that a fact has held — the opposite of what a confirmation claims.
+#: numbers that move. An unchanged body there does not establish that the figure is still
+#: current — it only shows the page has not been rewritten — so re-dating on it would claim a
+#: confirmation nobody made.
 MACHINE_REDATABLE_AXES = ("openness",)
 
 
@@ -441,14 +456,16 @@ def axes_refusal(axes: tuple[str, ...]) -> str | None:
         return "--axes is empty; pass at least one axis"
     unknown = [a for a in axes if a not in _axes()]
     if unknown:
-        return (f"--axes names {', '.join(sorted(unknown))}, which is not an axis. "
-                f"Known axes: {', '.join(_axes())}")
+        return (f"--axes names {', '.join(sorted(unknown))}, which is not an axis. Known axes: "
+                f"{', '.join(_axes())}, of which only {', '.join(MACHINE_REDATABLE_AXES)} may be "
+                f"machine re-dated (#445).")
     refused = [a for a in axes if a not in MACHINE_REDATABLE_AXES]
     if refused:
         return (f"--axes names {', '.join(sorted(refused))}. Machine re-dating is limited to "
                 f"{', '.join(MACHINE_REDATABLE_AXES)} by the #445 ruling: adoption and capability "
-                f"cite numbers that move, so an unchanged body confirms a stale figure rather "
-                f"than a held fact. Re-verify those through the agent leg (refresh-category).")
+                f"cite numbers that move, and an unchanged body does not establish that such a "
+                f"figure is still current. Re-verify those through the agent leg "
+                f"(refresh-category).")
     return None
 
 

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -723,9 +723,11 @@ that is a defensible basis for re-dating that axis's own `last_verified`, and it
 `build/reverify.py` does exactly this. The permission is narrower than the principle, on purpose.
 The #445 ruling limits machine re-dating to **openness**, because adoption and capability cite
 numbers that move — there, unchanged bytes would confirm a figure that has gone stale rather than
-a fact that has stayed put. `--axes` enforces that limit: it refuses any axis but openness, and refuses a name
-that is not an axis at all, which previously planned nothing and reported a clean run over zero
-dimensions. It is
+a fact that has stayed put. The tool enforces that limit rather than describing it. `--axes` refuses any axis but
+openness, and refuses a name that is not an axis at all — which previously planned nothing and
+reported a clean run over zero dimensions. The check binds to the write as well as to the flag:
+`reverify_product` refuses a policy-breaking axis, and `apply`, the function that actually
+writes the field, refuses a result stamped for one however it was assembled. It is
 never a basis for dating a comparison. Not when the peer's sources reproduce, not
 when both products' sources reproduce, because the thing that falsifies a spacing is a third
 product that neither one cites. An attestation written on the strength of unchanged bytes is the

--- a/docs/reference/evidence-and-freshness.md
+++ b/docs/reference/evidence-and-freshness.md
@@ -723,8 +723,9 @@ that is a defensible basis for re-dating that axis's own `last_verified`, and it
 `build/reverify.py` does exactly this. The permission is narrower than the principle, on purpose.
 The #445 ruling limits machine re-dating to **openness**, because adoption and capability cite
 numbers that move — there, unchanged bytes would confirm a figure that has gone stale rather than
-a fact that has stayed put. `--axes` accepts any axis name and does not enforce that limit, so it
-currently lives in the ruling and in the workflow's invocation rather than in the tool. It is
+a fact that has stayed put. `--axes` enforces that limit: it refuses any axis but openness, and refuses a name
+that is not an axis at all, which previously planned nothing and reported a clean run over zero
+dimensions. It is
 never a basis for dating a comparison. Not when the peer's sources reproduce, not
 when both products' sources reproduce, because the thing that falsifies a spacing is a third
 product that neither one cites. An attestation written on the strength of unchanged bytes is the

--- a/tests/test_reverify.py
+++ b/tests/test_reverify.py
@@ -530,3 +530,36 @@ def test_fragments_are_matched_after_the_same_whitespace_collapse(tmp_path):
     body = ("<p>Deploy leading open source\n   tools and AI models\twith confidence</p>")
     result = _shows_case(tmp_path, shows, body)
     assert result.stamped == ["openness"]
+
+# ---------------------------------------------------------------------------
+# --axes: the #445 limit, enforced rather than documented
+# ---------------------------------------------------------------------------
+
+
+def test_a_non_openness_axis_is_refused():
+    """#445 limits machine re-dating to openness, and until now that limit lived only in prose
+    and in how the workflow happened to invoke the tool. `--axes capability` would have re-dated
+    capability against the ruling."""
+    msg = reverify.axes_refusal(("capability",))
+    assert msg and "limited to openness" in msg and "#445" in msg
+    assert reverify.axes_refusal(("openness", "adoption"))
+
+
+def test_an_axis_that_is_not_an_axis_is_refused():
+    """A typo used to plan nothing and report a clean run over zero dimensions, which reads as
+    success. It is now a refusal that names the known axes."""
+    msg = reverify.axes_refusal(("opennes",))
+    assert msg and "not an axis" in msg and "openness" in msg
+
+
+def test_an_empty_axes_list_is_refused():
+    assert reverify.axes_refusal(())
+
+
+def test_openness_alone_is_allowed():
+    assert reverify.axes_refusal(("openness",)) is None
+
+
+def test_main_exits_two_on_a_refused_axis(capsys):
+    assert reverify.main(["--axes", "capability", "--dry-run", "--limit", "1"]) == 2
+    assert "limited to openness" in capsys.readouterr().err

--- a/tests/test_reverify.py
+++ b/tests/test_reverify.py
@@ -563,3 +563,39 @@ def test_openness_alone_is_allowed():
 def test_main_exits_two_on_a_refused_axis(capsys):
     assert reverify.main(["--axes", "capability", "--dry-run", "--limit", "1"]) == 2
     assert "limited to openness" in capsys.readouterr().err
+
+def test_reverify_product_refuses_a_policy_breaking_axis(tmp_path):
+    """The CLI guard protects main() only. A library caller reaching reverify_product directly
+    would otherwise obtain a stamped capability result and hand it to apply()."""
+    import pytest
+
+    with pytest.raises(ValueError, match="limited to openness"):
+        reverify.reverify_product(tmp_path, "anything", date(2026, 9, 12), axes=("capability",))
+
+
+def test_apply_refuses_to_write_a_date_for_a_policy_breaking_axis(tmp_path):
+    """`apply` is the function that writes `last_verified`, so the check binds to the write.
+    A result assembled by any other route still cannot reach the field."""
+    import pytest
+
+    result = reverify.ProductResult(slug="p")
+    result.stamped = ["capability"]
+    with pytest.raises(ValueError, match="limited to openness"):
+        reverify.apply(tmp_path, "p", result, date(2026, 9, 12))
+
+
+def test_apply_writes_nothing_and_raises_nothing_for_an_empty_result(tmp_path):
+    """An empty stamped list is the ordinary no-confirmation outcome, not a policy breach."""
+    path = tmp_path / "sources" / "scores"
+    path.mkdir(parents=True)
+    (path / "p.yaml").write_text("product: p\n")
+    reverify.apply(tmp_path, "p", reverify.ProductResult(slug="p"), date(2026, 9, 12))
+    assert (path / "p.yaml").read_text() == "product: p\n"
+
+
+def test_the_unknown_axis_message_says_which_axis_may_be_re_dated():
+    """Listing the known axes without saying only openness is permitted invites a second
+    rejected attempt."""
+    msg = reverify.axes_refusal(("opennes",))
+    assert "only openness" in msg
+


### PR DESCRIPTION
## Summary

The #445 ruling limits machine re-dating to **openness**: adoption and capability cite numbers that move, so an unchanged body there confirms a figure has gone *stale* rather than that a fact has held. That limit lived in the ruling and in how the workflow happened to invoke the tool — `--axes` took any string, so `--axes capability` would have re-dated capability against the ruling.

- `--axes` now refuses any axis but openness and exits 2 with the reason.
- It also refuses a name that is not an axis. `--axes opennes` previously planned nothing, re-dated nothing, and printed a clean run over zero dimensions — a typo that reads as success.
- `docs/reference/evidence-and-freshness.md` said the limit was unenforced. It is now, so it says that instead.

Found while reconciling that doc in #557: the review there noted the code excluded capability only by default, and the doc named the gap rather than closing it. This closes it.

## Test plan

- `uv run pytest -q` → 2063 passed, 1 skipped
- `uv run python -m build.validate` → 0 errors
- Exit codes checked by hand: `--axes capability` → 2, `--axes opennes` → 2, `--axes ''` → 2, `--axes openness` → runs normally
- Five new tests covering each refusal and the allowed path